### PR TITLE
Simplify MD5 hash generation and avoid warnings

### DIFF
--- a/Zotero/Extensions/MD5+Url.swift
+++ b/Zotero/Extensions/MD5+Url.swift
@@ -6,41 +6,19 @@
 //  Copyright © 2019 Corporation for Digital Scholarship. All rights reserved.
 //
 
-import CommonCrypto
+import CryptoKit
 import Foundation
 
 import CocoaLumberjackSwift
 
 func md5(from url: URL) -> String? {
-    let bufferSize = 1024 * 1024
 
     do {
-        // Open file for reading:
-        let file = try FileHandle(forReadingFrom: url)
-        defer {
-            file.closeFile()
-        }
-
-        // Create and initialize MD5 context:
-        var context = CC_MD5_CTX()
-        CC_MD5_Init(&context)
-
-        // Read up to `bufferSize` bytes, until EOF is reached, and update MD5 context:
-        while autoreleasepool(invoking: {
-            let data = file.readData(ofLength: bufferSize)
-            if data.count > 0 {
-                data.withUnsafeBytes {
-                    _ = CC_MD5_Update(&context, $0.baseAddress, numericCast(data.count))
-                }
-                return true // Continue
-            } else {
-                return false // End of file
-            }
-        }) { }
+        // Read data from file URL
+        let fileData = try Data(contentsOf: url)
 
         // Compute the MD5 digest:
-        var digest: [UInt8] = Array(repeating: 0, count: Int(CC_MD5_DIGEST_LENGTH))
-        _ = CC_MD5_Final(&digest, &context)
+        let digest = Insecure.MD5.hash(data: fileData)
 
         return Data(digest).map({ String(format: "%02hhx", $0) }).joined()
     } catch {


### PR DESCRIPTION
Using CryptoKit (part of all Apple platforms) allows us to avoid multiple warnings about how MD5 is deprecated in a cryptographic context and avoids the very un-Swifty C operations related to CommonCrypto. Getting Data from the URL is also simplified.