### PR TITLE
Enable building for Apple Silicon simulator

### DIFF
--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -5470,7 +5470,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 8LAYR367YV;
 				ENABLE_BITCODE = NO;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -5508,7 +5507,6 @@
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 8LAYR367YV;
 				ENABLE_BITCODE = NO;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -5653,7 +5651,6 @@
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 8LAYR367YV;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -5687,7 +5684,6 @@
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 8LAYR367YV;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -5721,7 +5717,6 @@
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 8LAYR367YV;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -5823,7 +5818,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 8LAYR367YV;
 				ENABLE_BITCODE = NO;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -5978,8 +5972,6 @@
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 8LAYR367YV;
 				ENABLE_BITCODE = NO;
-				EXCLUDED_ARCHS = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -6066,7 +6058,6 @@
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 8LAYR367YV;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",


### PR DESCRIPTION
Previously, the project excluded arm64 processors when building for iOS Simulators. This change removes that exclusion so the project will build for the iOS Simulator on both Intel and Apple Silicon processors.

Apple recommends that projects [exclude architectures sparingly](https://developer.apple.com/documentation/technotes/tn3117-resolving-build-errors-for-apple-silicon#Exclude-architectures-sparingly). The approach to exclude arm64 processors from simulator builds was in some cases expedient when Apple Silicon processors were new, a project's third party dependencies were shipping precompiled frameworks rather than source code, and those frameworks had not been updated to include support for the arm64 simulator. Where a project's developers were not using Apple Silicon machines, there was no (immediate) disadvantage in excluding this architecture.

In the case of Zotero for iOS, both the project itself and all dependencies today compile correctly for the iOS Simulator on Apple Silicon, when this excluded architectures setting is removed.

(Without this change, building the project for the iOS Simulator on an Apple Silicon machine will fail with a slightly misdirecting error along the lines of `Could not find module 'CocoaLumberjackSwift' for target 'x86_64-apple-ios-simulator'; found: arm64-apple-ios-simulator...`.)