### PR TITLE
Link all Git submodules via https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/citation-style-language/locales.git
 [submodule "ZShare/Assets/translation/translate"]
 	path = ZShare/Assets/translation/translate
-	url = git@github.com:zotero/translate.git
+	url = https://github.com/zotero/translate.git
 [submodule "translators"]
 	path = translators
-	url = git@github.com:zotero/translators.git
+	url = https://github.com/zotero/translators.git


### PR DESCRIPTION
This project has four dependencies linked as Git Submodules. Previously, two of these submodules were linked via https and two were linked via ssh. This pull request makes the minor modification of linking all submodules via https.

With the previous configuration, an initial clone and setup of the Zotero iOS repo would fail if the local computer did not have an SSH key associated with the user's GitHub account, even though the project and all submodules are open source and publicly published, and can therefore be cloned by an anonymous user. With the current setup, a user who encounters this needs to either manually modify the .gitmodules file to use https links, or install an SSH key in their Github account that is present on their local machine. By changing the project to link all submodules via https, a clone will succeed for all users regardless of the SSH key status of the local machine.

The revised configuration will work even when a user clones the primary repo using SSH. While there are many advantages to using SSH keys to access GitHub, GitHub today defaults to offering https urls for clones, and there is no advantage to the project in using SSH for two of the four submodules.