### PR TITLE
Don’t percent encode valid slash character in DOIs

### DIFF
--- a/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailViewController.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailViewController.swift
@@ -147,7 +147,7 @@ final class ItemDetailViewController: UIViewController {
             }
 
         case .openDoi(let doi):
-            guard let encoded = FieldKeys.Item.clean(doi: doi).addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) else { return }
+            guard let encoded = FieldKeys.Item.clean(doi: doi).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else { return }
             self.coordinatorDelegate?.show(doi: encoded)
         }
     }


### PR DESCRIPTION
At present when opening a doi.org link created from a DOI, the project is addingPercentEncoding to the DOI using the [.urlHostAllowed](https://developer.apple.com/documentation/foundation/nscharacterset/1416426-urlhostallowed) character set when it should be using the [.urlPathAllowed](https://developer.apple.com/documentation/foundation/nscharacterset/1416804-urlpathallowed) character set.

The effect is that a DOI string correctly stored as `10.1080/24735132.2022.2151776` is currently being encoded to `10.1080%2F24735132.2022.2151776` and thus passed to the webview as [https://doi.org/10.1080%2F24735132.2022.2151776](https://doi.org/10.1080%2F24735132.2022.2151776).

Because Webkit like all browsers is forgiving of percent encoding of path separators in URLs, this does not affect the functionality provided when tapping on a DOI and opening the resulting page. However, these incorrectly percent encoded URLs could appear in logs, and could plausibly be associated now or in the future with other issues e.g., if such a URL was passed directly to a PDF rendering tool (see #520 as a possible instance).