### PR TITLE
Fix setup for paths needing escaping

### DIFF
--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -4190,7 +4190,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "$SCRIPT_INPUT_FILE_0 config lint\n$SCRIPT_INPUT_FILE_0 config run\n\n";
+			shellScript = "\"$SCRIPT_INPUT_FILE_0\" config lint\n\"$SCRIPT_INPUT_FILE_0\" config run\n\n";
 		};
 		B34A85AC243CB1E4003D5638 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -4209,7 +4209,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "python3 $SCRIPT_INPUT_FILE_0\n";
+			shellScript = "python3 \"$SCRIPT_INPUT_FILE_0\"\n";
 		};
 		B3593F142668D37900FA4BB2 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -4228,7 +4228,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "python3 $SCRIPT_INPUT_FILE_0\n";
+			shellScript = "python3 \"$SCRIPT_INPUT_FILE_0\"\n";
 		};
 		B3CF8840266E0FE6009CFC20 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -4247,7 +4247,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "python3 $SCRIPT_INPUT_FILE_0\n";
+			shellScript = "python3 \"$SCRIPT_INPUT_FILE_0\"\n";
 		};
 		B3E196FB25308DA500DBBE5C /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/scripts/fetch_bundled_jsons.sh
+++ b/scripts/fetch_bundled_jsons.sh
@@ -4,8 +4,8 @@ realpath() {
     [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
 }
 
-SCRIPT_PATH=`realpath $0`
-SCRIPT_DIR=`dirname $SCRIPT_PATH`
+SCRIPT_PATH=`realpath "$0"`
+SCRIPT_DIR=`dirname "$SCRIPT_PATH"`
 SCHEMA_FILE="$SCRIPT_DIR/../Bundled/schema.json"
 
-curl --compressed https://api.zotero.org/schema --output $SCHEMA_FILE
+curl --compressed https://api.zotero.org/schema --output "$SCHEMA_FILE"

--- a/scripts/licenses.sh
+++ b/scripts/licenses.sh
@@ -4,8 +4,8 @@ realpath() {
     [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
 }
 
-SCRIPT_PATH=`realpath $0`
-SCRIPT_DIR=`dirname $SCRIPT_PATH`
+SCRIPT_PATH=`realpath "$0"`
+SCRIPT_DIR=`dirname "$SCRIPT_PATH"`
 LICENSES_DIR="$SCRIPT_DIR/../pdf-keys"
 LICENSES_FILE="$LICENSES_DIR/licenses.plist"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,8 +4,8 @@ realpath() {
     [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
 }
 
-SCRIPT_PATH=`realpath $0`
-SCRIPT_DIR=`dirname $SCRIPT_PATH`
+SCRIPT_PATH=`realpath "$0"`
+SCRIPT_DIR=`dirname "$SCRIPT_PATH"`
 
 "$SCRIPT_DIR/licenses.sh"
 "$SCRIPT_DIR/fetch_bundled_jsons.sh"


### PR DESCRIPTION
Hey guys, amazing work here 💪 

When the absolute path for the project directory contains unescaped characters, specifically whitespaces, the current setup always fails because of the way path "fragments" are rendered as different arguments. 
This is a small fix for such edge cases.