### PR TITLE
Fixed #645 tag picker appearing behind standalone note editor

### DIFF
--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -774,7 +774,8 @@ extension DetailCoordinator: DetailNoteEditorCoordinatorDelegate {
         let viewModel = ViewModel(initialState: state, handler: handler)
         let controller = TagPickerViewController(viewModel: viewModel, saveAction: picked)
 
-        self.navigationController.pushViewController(controller, animated: true)
+        let navigationController = (self.navigationController.presentedViewController as? UINavigationController) ?? self.navigationController
+        navigationController.pushViewController(controller, animated: true)
     }
 }
 


### PR DESCRIPTION
Created a quick fix, using proper navigation controller. Proper fix where standalone note is refactored into separate coordinator is included in tagfiltering branch