### PR TITLE
changes to address #646 - Adjust highlight comment icon

### DIFF
--- a/Zotero/Controllers/CommentIconDrawingController.swift
+++ b/Zotero/Controllers/CommentIconDrawingController.swift
@@ -24,7 +24,7 @@ struct CommentIconDrawingController {
         let newBoundingBox = CGRect(origin: origin, size: size)
 
         context.clip(to: newBoundingBox, mask: colorizedCgImage)
-        color.setFill()
+        color.withAlphaComponent(0.5).setFill()
         context.fill(newBoundingBox)
 
         context.resetClip()

--- a/Zotero/Models/AnnotationsConfig.swift
+++ b/Zotero/Models/AnnotationsConfig.swift
@@ -21,7 +21,7 @@ struct AnnotationsConfig {
     // Line width of image annotation in PDF document.
     static let imageAnnotationLineWidth: CGFloat = 2
     // Size of note annotation in PDF document.
-    static let noteAnnotationSize: CGSize = CGSize(width: 22, height: 22)
+    static let noteAnnotationSize: CGSize = CGSize(width: 16, height: 16)
     static let positionSizeLimit = 65000
     static let supported: PSPDFKit.Annotation.Kind = [.note, .highlight, .square, .ink]
 

--- a/Zotero/Scenes/Detail/PDF/Models/NoteAnnotation.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/NoteAnnotation.swift
@@ -24,7 +24,7 @@ final class NoteAnnotation: PSPDFKit.NoteAnnotation {
         guard let colorizedCgImage = colorizedImage.cgImage, let outlineCgImage = outlineImage.cgImage, let color = self.color else { return }
 
         context.clip(to: boundingBox, mask: colorizedCgImage)
-        color.setFill()
+        color.withAlphaComponent(0.5).setFill()
         context.fill(boundingBox)
 
         context.resetClip()


### PR DESCRIPTION
Hi, I'm a research scientist who recently started using Zotero to collaborate with a friend on several reference collections. 
I'm also an iOS developer, and have been looking for open source projects to contribute to and came across Zotero. I've spent some time exploring the repository and forum discussions to see if I could address any open, unassigned issues.
<br>

I looked into issue #646 and wanted to propose a few small changes to improve to the size and opacity of the note annotations shown on PDFs, re the discussion on this post: https://forums.zotero.org/discussion/comment/424317.   

**I made the following changes:**
- reduced note icon size from 22 to 16 (initially tried 12, but the icons looked too small when I tested it) 
- added 50% opacity to fill color used for comment icons
- added 50% opacity to fill color used for note icon that is added highlight

<br>

**Sample screenshots of note and highlight annotations with my these changes**
<img src="https://user-images.githubusercontent.com/10591026/234472052-0f475b29-c3e9-49e0-804c-b5a94c4c7cde.jpeg" width="350" />   <img src="https://user-images.githubusercontent.com/10591026/234471373-e6712487-7531-4c3c-be93-2febcace9ef0.PNG" width="200" />     <img src="https://user-images.githubusercontent.com/10591026/234471422-1fa07aa3-cdab-4479-bec7-c7f5cdbd5721.PNG" width="200" />
<br>

**Sample screenshots of the same PDF before these changes (in the current App Store app)**
<img src="https://user-images.githubusercontent.com/10591026/234472080-f2a9bb7d-46e0-4dc8-b1c4-7fe4c3627dd4.jpeg"  width="350" />  <img src="https://user-images.githubusercontent.com/10591026/234471268-d7cae030-3ab1-4066-93d8-010f13e89bb1.PNG" width="200" />     <img src="https://user-images.githubusercontent.com/10591026/234471275-c8ca8dd9-deca-406c-ac5c-65a7a07128ac.PNG" width="200" />

