### PR TITLE
reload whenever interface style changes

### DIFF
--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
@@ -141,6 +141,10 @@ final class AnnotationsViewController: UIViewController {
             self.emptyLabel.isHidden = !self.tableView.isHidden
         }
 
+        if state.shouldStoreAnnotationPreviewsIfNeeded {
+            self.viewModel.process(action: .updateAnnotationPreviews)
+        }
+
         self.reloadIfNeeded(for: state) {
             if let keys = state.loadedPreviewImageAnnotationKeys {
                 self.updatePreviewsIfVisible(for: keys)
@@ -182,7 +186,7 @@ final class AnnotationsViewController: UIViewController {
             return
         }
 
-        if state.changes.contains(.annotations) || state.changes.contains(.interfaceStyle) {
+        if state.changes.contains(.annotations) {
             var snapshot = NSDiffableDataSourceSnapshot<Int, PDFReaderState.AnnotationKey>()
             snapshot.appendSections([0])
             snapshot.appendItems(state.sortedKeys)
@@ -197,6 +201,13 @@ final class AnnotationsViewController: UIViewController {
             }
             self.dataSource.apply(snapshot, animatingDifferences: isVisible, completion: completion)
 
+            return
+        }
+
+        if state.changes.contains(.interfaceStyle) {
+            var snapshot = self.dataSource.snapshot()
+            snapshot.reloadSections([0])
+            self.dataSource.apply(snapshot, animatingDifferences: false, completion: completion)
             return
         }
 

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -296,10 +296,6 @@ class PDFReaderViewController: UIViewController {
             self.updateInterface(to: state.settings)
         }
 
-        if state.shouldStoreAnnotationPreviewsIfNeeded {
-            self.viewModel.process(action: .updateAnnotationPreviews)
-        }
-
         if state.changes.contains(.export) {
             self.update(state: state.exportState)
         }


### PR DESCRIPTION
1. After testing this I noticed a reload wasn't happening because interface style changes do not have `updatedNotificationKeys`. I moved that change to its own scope and now I reload the whole section because an interface style change requires that. 
2. I moved the storeAnnotationPreviews to the annotation view controller. 