### PR TITLE
Share image annotation

### DIFF
--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -528,6 +528,8 @@
 "accessibility.pdf.image_annotation" = "Image annotation";
 "accessibility.pdf.ink_annotation" = "Ink annotation";
 "accessibility.pdf.edit_annotation" = "Edit annotation";
+"accessibility.pdf.share_annotation" = "Share annotation";
+"accessibility.pdf.share_annotation_image" = "Share annotation image";
 "accessibility.pdf.eraser_annotation" = "Eraser";
 "accessibility.pdf.highlighted_text" = "Highlighted text";
 "accessibility.pdf.author" = "Author";

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -240,8 +240,9 @@
 "pdf.deleted_message" = "This document has been deleted. Do you want to restore it?";
 "pdf.line_width_point" = "%0.1f pt";
 "pdf.highlight" = "Highlight";
-"pdf.annotation_share.image.medium" = "Share medium image";
-"pdf.annotation_share.image.large" = "Share large image";
+"pdf.annotation_share.image.share" = "Share image";
+"pdf.annotation_share.image.medium" = "Medium";
+"pdf.annotation_share.image.large" = "Large";
 "pdf.annotation_toolbar.eraser" = "Eraser";
 "pdf.annotation_toolbar.highlight" = "Highlight";
 "pdf.annotation_toolbar.note" = "Note";

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -240,6 +240,8 @@
 "pdf.deleted_message" = "This document has been deleted. Do you want to restore it?";
 "pdf.line_width_point" = "%0.1f pt";
 "pdf.highlight" = "Highlight";
+"pdf.annotation_share.image.medium" = "Share medium image";
+"pdf.annotation_share.image.large" = "Share large image";
 "pdf.annotation_toolbar.eraser" = "Eraser";
 "pdf.annotation_toolbar.highlight" = "Highlight";
 "pdf.annotation_toolbar.note" = "Note";

--- a/Zotero/Controllers/AnnotationPreviewController.swift
+++ b/Zotero/Controllers/AnnotationPreviewController.swift
@@ -25,7 +25,6 @@ final class AnnotationPreviewController: NSObject {
         let scale: CGFloat
     }
     
-    
     /// Type of annotation preview
     /// - temporary: Rendered image is returned by `Single<UIImage>` immediately, no caching is performed.
     /// - cachedAndReported: Rendered image is cached and reported through global observable `PublishSubject<AnnotationPreviewUpdate>`.
@@ -241,6 +240,7 @@ extension AnnotationPreviewController {
             case .temporary(let subscriberKey):
                 // Temporary request always needs to return an error if image was not available
                 self.perform(event: .failure(error), subscriberKey: subscriberKey)
+                
             default:
                 break
             }

--- a/Zotero/Controllers/Architecture/Coordinator.swift
+++ b/Zotero/Controllers/Architecture/Coordinator.swift
@@ -20,7 +20,7 @@ protocol Coordinator: AnyObject {
 
     func start(animated: Bool)
     func childDidFinish(_ child: Coordinator)
-    func share(item: Any, sourceView: SourceView, presenter: UIViewController?)
+    func share(item: Any, sourceView: SourceView, presenter: UIViewController?, completionWithItemsHandler: UIActivityViewController.CompletionWithItemsHandler?)
 }
 
 extension Coordinator {
@@ -36,9 +36,10 @@ extension Coordinator {
         }
     }
 
-    func share(item: Any, sourceView: SourceView, presenter: UIViewController? = nil) {
+    func share(item: Any, sourceView: SourceView, presenter: UIViewController? = nil, completionWithItemsHandler: UIActivityViewController.CompletionWithItemsHandler? = nil) {
         let controller = UIActivityViewController(activityItems: [item], applicationActivities: nil)
         controller.modalPresentationStyle = .pageSheet
+        controller.completionWithItemsHandler = completionWithItemsHandler
 
         switch sourceView {
         case .item(let item):

--- a/Zotero/Controllers/Architecture/Coordinator.swift
+++ b/Zotero/Controllers/Architecture/Coordinator.swift
@@ -20,7 +20,7 @@ protocol Coordinator: AnyObject {
 
     func start(animated: Bool)
     func childDidFinish(_ child: Coordinator)
-    func share(item: Any, sourceView: SourceView)
+    func share(item: Any, sourceView: SourceView, presenter: UIViewController?)
 }
 
 extension Coordinator {
@@ -36,7 +36,7 @@ extension Coordinator {
         }
     }
 
-    func share(item: Any, sourceView: SourceView) {
+    func share(item: Any, sourceView: SourceView, presenter: UIViewController? = nil) {
         let controller = UIActivityViewController(activityItems: [item], applicationActivities: nil)
         controller.modalPresentationStyle = .pageSheet
 
@@ -51,6 +51,6 @@ extension Coordinator {
             }
         }
 
-        self.navigationController.present(controller, animated: true, completion: nil)
+        (presenter ?? navigationController).present(controller, animated: true, completion: nil)
     }
 }

--- a/Zotero/Extensions/CoreGraphics+Extensions.swift
+++ b/Zotero/Extensions/CoreGraphics+Extensions.swift
@@ -58,3 +58,10 @@ extension CGPoint {
         return CGPoint(x: self.x.rounded(to: places), y: self.y.rounded(to: places))
     }
 }
+
+extension CGSize: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(width)
+        hasher.combine(height)
+    }
+}

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -857,10 +857,12 @@ internal enum L10n {
     }
     internal enum AnnotationShare {
       internal enum Image {
-        /// Share large image
+        /// Large
         internal static let large = L10n.tr("Localizable", "pdf.annotation_share.image.large")
-        /// Share medium image
+        /// Medium
         internal static let medium = L10n.tr("Localizable", "pdf.annotation_share.image.medium")
+        /// Share image
+        internal static let share = L10n.tr("Localizable", "pdf.annotation_share.image.share")
       }
     }
     internal enum AnnotationToolbar {

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -215,6 +215,10 @@ internal enum L10n {
       internal static let selected = L10n.tr("Localizable", "accessibility.pdf.selected")
       /// Settings
       internal static let settings = L10n.tr("Localizable", "accessibility.pdf.settings")
+      /// Share annotation
+      internal static let shareAnnotation = L10n.tr("Localizable", "accessibility.pdf.share_annotation")
+      /// Share annotation image
+      internal static let shareAnnotationImage = L10n.tr("Localizable", "accessibility.pdf.share_annotation_image")
       /// Show more
       internal static let showMoreTools = L10n.tr("Localizable", "accessibility.pdf.show_more_tools")
       /// Close sidebar

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -855,6 +855,14 @@ internal enum L10n {
       /// Update subsequent pages
       internal static let updateSubsequentPages = L10n.tr("Localizable", "pdf.annotation_popover.update_subsequent_pages")
     }
+    internal enum AnnotationShare {
+      internal enum Image {
+        /// Share large image
+        internal static let large = L10n.tr("Localizable", "pdf.annotation_share.image.large")
+        /// Share medium image
+        internal static let medium = L10n.tr("Localizable", "pdf.annotation_share.image.medium")
+      }
+    }
     internal enum AnnotationToolbar {
       /// Eraser
       internal static let eraser = L10n.tr("Localizable", "pdf.annotation_toolbar.eraser")

--- a/Zotero/Scenes/Detail/Annotation Popover/AnnotationPopoverCoordinator.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/AnnotationPopoverCoordinator.swift
@@ -15,7 +15,7 @@ protocol AnnotationPopover: AnyObject {
 }
 
 protocol AnnotationPopoverAnnotationCoordinatorDelegate: AnyObject {
-    func shareAnnotation(sender: UIButton, scale: CGFloat)
+    func shareAnnotationMenu(sender: UIButton) -> UIMenu?
     func showEdit(annotation: Annotation, userId: Int, library: Library, saveAction: @escaping AnnotationEditSaveAction, deleteAction: @escaping AnnotationEditDeleteAction)
     func showTagPicker(libraryId: LibraryIdentifier, selected: Set<String>, picked: @escaping ([Tag]) -> Void)
     func didFinish()
@@ -58,16 +58,14 @@ final class AnnotationPopoverCoordinator: NSObject, Coordinator {
 }
 
 extension AnnotationPopoverCoordinator: AnnotationPopoverAnnotationCoordinatorDelegate {
-    func shareAnnotation(sender: UIButton, scale: CGFloat = 1.0) {
+    func shareAnnotationMenu(sender: UIButton) -> UIMenu? {
         guard let pdfCoordinator = parentCoordinator as? PDFCoordinator,
               let annotation = viewModel.state.selectedAnnotation
-        else { return }
-        pdfCoordinator.shareAnnotation(
+        else { return nil }
+        return pdfCoordinator.shareAnnotationMenu(
             state: viewModel.state,
             annotation: annotation,
-            scale: scale,
-            sender: sender,
-            presenter: navigationController
+            sender: sender
         )
     }
     

--- a/Zotero/Scenes/Detail/Annotation Popover/AnnotationPopoverCoordinator.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/AnnotationPopoverCoordinator.swift
@@ -15,7 +15,7 @@ protocol AnnotationPopover: AnyObject {
 }
 
 protocol AnnotationPopoverAnnotationCoordinatorDelegate: AnyObject {
-    func shareAnnotation(sender: UIButton)
+    func shareAnnotation(sender: UIButton, scale: CGFloat)
     func showEdit(annotation: Annotation, userId: Int, library: Library, saveAction: @escaping AnnotationEditSaveAction, deleteAction: @escaping AnnotationEditDeleteAction)
     func showTagPicker(libraryId: LibraryIdentifier, selected: Set<String>, picked: @escaping ([Tag]) -> Void)
     func didFinish()
@@ -58,11 +58,12 @@ final class AnnotationPopoverCoordinator: NSObject, Coordinator {
 }
 
 extension AnnotationPopoverCoordinator: AnnotationPopoverAnnotationCoordinatorDelegate {
-    func shareAnnotation(sender: UIButton) {
+    func shareAnnotation(sender: UIButton, scale: CGFloat = 1.0) {
         guard let pdfCoordinator = parentCoordinator as? PDFCoordinator else { return }
         pdfCoordinator.shareAnnotation(
             viewModel: viewModel,
             annotationKey: nil,
+            scale: scale,
             sender: sender,
             presenter: navigationController
         )

--- a/Zotero/Scenes/Detail/Annotation Popover/AnnotationPopoverCoordinator.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/AnnotationPopoverCoordinator.swift
@@ -15,6 +15,7 @@ protocol AnnotationPopover: AnyObject {
 }
 
 protocol AnnotationPopoverAnnotationCoordinatorDelegate: AnyObject {
+    func shareAnnotation(sender: UIButton)
     func showEdit(annotation: Annotation, userId: Int, library: Library, saveAction: @escaping AnnotationEditSaveAction, deleteAction: @escaping AnnotationEditDeleteAction)
     func showTagPicker(libraryId: LibraryIdentifier, selected: Set<String>, picked: @escaping ([Tag]) -> Void)
     func didFinish()
@@ -57,6 +58,16 @@ final class AnnotationPopoverCoordinator: NSObject, Coordinator {
 }
 
 extension AnnotationPopoverCoordinator: AnnotationPopoverAnnotationCoordinatorDelegate {
+    func shareAnnotation(sender: UIButton) {
+        guard let pdfCoordinator = parentCoordinator as? PDFCoordinator else { return }
+        pdfCoordinator.shareAnnotation(
+            viewModel: viewModel,
+            annotationKey: nil,
+            sender: sender,
+            presenter: navigationController
+        )
+    }
+    
     func showEdit(annotation: Annotation, userId: Int, library: Library, saveAction: @escaping AnnotationEditSaveAction, deleteAction: @escaping AnnotationEditDeleteAction) {
         let state = AnnotationEditState(annotation: annotation, userId: userId, library: library)
         let handler = AnnotationEditActionHandler()

--- a/Zotero/Scenes/Detail/Annotation Popover/AnnotationPopoverCoordinator.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/AnnotationPopoverCoordinator.swift
@@ -59,10 +59,12 @@ final class AnnotationPopoverCoordinator: NSObject, Coordinator {
 
 extension AnnotationPopoverCoordinator: AnnotationPopoverAnnotationCoordinatorDelegate {
     func shareAnnotation(sender: UIButton, scale: CGFloat = 1.0) {
-        guard let pdfCoordinator = parentCoordinator as? PDFCoordinator else { return }
+        guard let pdfCoordinator = parentCoordinator as? PDFCoordinator,
+              let annotation = viewModel.state.selectedAnnotation
+        else { return }
         pdfCoordinator.shareAnnotation(
-            viewModel: viewModel,
-            annotationKey: nil,
+            state: viewModel.state,
+            annotation: annotation,
             scale: scale,
             sender: sender,
             presenter: navigationController

--- a/Zotero/Scenes/Detail/Annotation Popover/AnnotationPopoverCoordinator.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/AnnotationPopoverCoordinator.swift
@@ -15,7 +15,7 @@ protocol AnnotationPopover: AnyObject {
 }
 
 protocol AnnotationPopoverAnnotationCoordinatorDelegate: AnyObject {
-    func shareAnnotationMenu(sender: UIButton) -> UIMenu?
+    func createShareAnnotationMenu(sender: UIButton) -> UIMenu?
     func showEdit(annotation: Annotation, userId: Int, library: Library, saveAction: @escaping AnnotationEditSaveAction, deleteAction: @escaping AnnotationEditDeleteAction)
     func showTagPicker(libraryId: LibraryIdentifier, selected: Set<String>, picked: @escaping ([Tag]) -> Void)
     func didFinish()
@@ -58,11 +58,11 @@ final class AnnotationPopoverCoordinator: NSObject, Coordinator {
 }
 
 extension AnnotationPopoverCoordinator: AnnotationPopoverAnnotationCoordinatorDelegate {
-    func shareAnnotationMenu(sender: UIButton) -> UIMenu? {
+    func createShareAnnotationMenu(sender: UIButton) -> UIMenu? {
         guard let pdfCoordinator = parentCoordinator as? PDFCoordinator,
               let annotation = viewModel.state.selectedAnnotation
         else { return nil }
-        return pdfCoordinator.shareAnnotationMenu(
+        return pdfCoordinator.createShareAnnotationMenu(
             state: viewModel.state,
             annotation: annotation,
             sender: sender

--- a/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
@@ -94,7 +94,7 @@ final class AnnotationViewController: UIViewController {
         // Update header
         let editability = annotation.editability(currentUserId: state.userId, library: state.library)
         var annotationIsShareable = false
-        if let button = header.shareButton, let menu = shareAnnotationMenu(sender: button) {
+        if let button = header.shareButton, let menu = createShareAnnotationMenu(sender: button) {
             annotationIsShareable = true
             button.showsMenuAsPrimaryAction = true
             button.menu = menu
@@ -138,8 +138,8 @@ final class AnnotationViewController: UIViewController {
         self.viewModel.process(action: .removeAnnotation(key))
     }
     
-    private func shareAnnotationMenu(sender: UIButton) -> UIMenu? {
-        coordinatorDelegate?.shareAnnotationMenu(sender: sender)
+    private func createShareAnnotationMenu(sender: UIButton) -> UIMenu? {
+        coordinatorDelegate?.createShareAnnotationMenu(sender: sender)
     }
 
     private func showSettings() {
@@ -188,7 +188,7 @@ final class AnnotationViewController: UIViewController {
         let header = AnnotationViewHeader(layout: layout)
         let editability = annotation.editability(currentUserId: self.viewModel.state.userId, library: self.viewModel.state.library)
         var annotationIsShareable = false
-        if let button = header.shareButton, let menu = shareAnnotationMenu(sender: button) {
+        if let button = header.shareButton, let menu = createShareAnnotationMenu(sender: button) {
             annotationIsShareable = true
             button.showsMenuAsPrimaryAction = true
             button.menu = menu

--- a/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
@@ -93,10 +93,16 @@ final class AnnotationViewController: UIViewController {
 
         // Update header
         let editability = annotation.editability(currentUserId: state.userId, library: state.library)
+        var annotationIsShareable = false
+        if let button = header.shareButton, let menu = shareAnnotationMenu(sender: button) {
+            annotationIsShareable = true
+            button.showsMenuAsPrimaryAction = true
+            button.menu = menu
+        }
         self.header.setup(
             with: annotation,
             libraryId: state.library.identifier,
-            showShareButton: (annotation.type == .image),
+            showShareButton: annotationIsShareable,
             isEditable: (editability == .editable),
             showsLock: (editability != .editable),
             showDoneButton: false,
@@ -132,8 +138,8 @@ final class AnnotationViewController: UIViewController {
         self.viewModel.process(action: .removeAnnotation(key))
     }
     
-    private func shareAnnotation(sender: UIButton, scale: CGFloat = 1.0) {
-        coordinatorDelegate?.shareAnnotation(sender: sender, scale: scale)
+    private func shareAnnotationMenu(sender: UIButton) -> UIMenu? {
+        coordinatorDelegate?.shareAnnotationMenu(sender: sender)
     }
 
     private func showSettings() {
@@ -181,7 +187,12 @@ final class AnnotationViewController: UIViewController {
         // Setup header
         let header = AnnotationViewHeader(layout: layout)
         let editability = annotation.editability(currentUserId: self.viewModel.state.userId, library: self.viewModel.state.library)
-        let annotationIsShareable = (annotation.type == .image)
+        var annotationIsShareable = false
+        if let button = header.shareButton, let menu = shareAnnotationMenu(sender: button) {
+            annotationIsShareable = true
+            button.showsMenuAsPrimaryAction = true
+            button.menu = menu
+        }
         header.setup(
             with: annotation,
             libraryId: self.viewModel.state.library.identifier,
@@ -193,17 +204,6 @@ final class AnnotationViewController: UIViewController {
             displayName: self.viewModel.state.displayName,
             username: self.viewModel.state.username
         )
-        if annotationIsShareable, let button = header.shareButton {
-            // TODO: ask delegate for menu instead?
-            let shareMediumImageAction = UIAction(title: L10n.Pdf.AnnotationShare.Image.medium) { (_: UIAction) in
-                self.shareAnnotation(sender: button, scale: 300.0 / 72.0)
-            }
-            let shareLargeImageAction = UIAction(title: L10n.Pdf.AnnotationShare.Image.large) { (_: UIAction) in
-                self.shareAnnotation(sender: button, scale: 600.0 / 72.0)
-            }
-            button.showsMenuAsPrimaryAction = true
-            button.menu = UIMenu(children: [shareMediumImageAction, shareLargeImageAction])
-        }
         header.menuTap
               .subscribe(with: self, onNext: { `self`, _ in
                   self.showSettings()

--- a/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
@@ -132,11 +132,11 @@ final class AnnotationViewController: UIViewController {
         self.viewModel.process(action: .removeAnnotation(key))
     }
     
-    private func shareAnnotation(sender: UIButton) {
+    private func shareAnnotation(sender: UIButton, scale: CGFloat = 1.0) {
         guard let annotation = self.viewModel.state.selectedAnnotation,
               annotation.type == .image
         else { return }
-        coordinatorDelegate?.shareAnnotation(sender: sender)
+        coordinatorDelegate?.shareAnnotation(sender: sender, scale: scale)
     }
 
     private func showSettings() {
@@ -196,14 +196,16 @@ final class AnnotationViewController: UIViewController {
             displayName: self.viewModel.state.displayName,
             username: self.viewModel.state.username
         )
-        if annotationIsShareable {
-            header.shareTap.subscribe(
-                with: self,
-                onNext: { (`self`: AnnotationViewController, button: UIButton) in
-                    self.shareAnnotation(sender: button)
-                }
-            )
-            .disposed(by: self.disposeBag)
+        if annotationIsShareable, let button = header.shareButton {
+            // TODO: ask delegate for menu instead?
+            let shareMediumImageAction = UIAction(title: L10n.Pdf.AnnotationShare.Image.medium) { (_: UIAction) in
+                self.shareAnnotation(sender: button, scale: 1.0)
+            }
+            let shareLargeImageAction = UIAction(title: L10n.Pdf.AnnotationShare.Image.large) { (_: UIAction) in
+                self.shareAnnotation(sender: button, scale: 300.0 / 72.0)
+            }
+            button.showsMenuAsPrimaryAction = true
+            button.menu = UIMenu(children: [shareMediumImageAction, shareLargeImageAction])
         }
         header.menuTap
               .subscribe(with: self, onNext: { `self`, _ in

--- a/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
@@ -184,7 +184,7 @@ final class AnnotationViewController: UIViewController {
         // Setup header
         let header = AnnotationViewHeader(layout: layout)
         let editability = annotation.editability(currentUserId: self.viewModel.state.userId, library: self.viewModel.state.library)
-        let annotationIsShareable: Bool = (annotation.type == .image)
+        let annotationIsShareable = (annotation.type == .image)
         header.setup(
             with: annotation,
             libraryId: self.viewModel.state.library.identifier,

--- a/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
@@ -133,9 +133,6 @@ final class AnnotationViewController: UIViewController {
     }
     
     private func shareAnnotation(sender: UIButton, scale: CGFloat = 1.0) {
-        guard let annotation = self.viewModel.state.selectedAnnotation,
-              annotation.type == .image
-        else { return }
         coordinatorDelegate?.shareAnnotation(sender: sender, scale: scale)
     }
 

--- a/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
@@ -93,16 +93,12 @@ final class AnnotationViewController: UIViewController {
 
         // Update header
         let editability = annotation.editability(currentUserId: state.userId, library: state.library)
-        var annotationIsShareable = false
-        if let button = header.shareButton, let menu = createShareAnnotationMenu(sender: button) {
-            annotationIsShareable = true
-            button.showsMenuAsPrimaryAction = true
-            button.menu = menu
-        }
         self.header.setup(
             with: annotation,
             libraryId: state.library.identifier,
-            showShareButton: annotationIsShareable,
+            shareMenuProvider: { [weak self] button in
+                self?.createShareAnnotationMenu(sender: button)
+            },
             isEditable: (editability == .editable),
             showsLock: (editability != .editable),
             showDoneButton: false,
@@ -187,16 +183,12 @@ final class AnnotationViewController: UIViewController {
         // Setup header
         let header = AnnotationViewHeader(layout: layout)
         let editability = annotation.editability(currentUserId: self.viewModel.state.userId, library: self.viewModel.state.library)
-        var annotationIsShareable = false
-        if let button = header.shareButton, let menu = createShareAnnotationMenu(sender: button) {
-            annotationIsShareable = true
-            button.showsMenuAsPrimaryAction = true
-            button.menu = menu
-        }
         header.setup(
             with: annotation,
             libraryId: self.viewModel.state.library.identifier,
-            showShareButton: annotationIsShareable,
+            shareMenuProvider: { [weak self] button in
+                self?.createShareAnnotationMenu(sender: button)
+            },
             isEditable: (editability == .editable),
             showsLock: (editability != .editable),
             showDoneButton: false,

--- a/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
@@ -196,10 +196,10 @@ final class AnnotationViewController: UIViewController {
         if annotationIsShareable, let button = header.shareButton {
             // TODO: ask delegate for menu instead?
             let shareMediumImageAction = UIAction(title: L10n.Pdf.AnnotationShare.Image.medium) { (_: UIAction) in
-                self.shareAnnotation(sender: button, scale: 1.0)
+                self.shareAnnotation(sender: button, scale: 300.0 / 72.0)
             }
             let shareLargeImageAction = UIAction(title: L10n.Pdf.AnnotationShare.Image.large) { (_: UIAction) in
-                self.shareAnnotation(sender: button, scale: 300.0 / 72.0)
+                self.shareAnnotation(sender: button, scale: 600.0 / 72.0)
             }
             button.showsMenuAsPrimaryAction = true
             button.menu = UIMenu(children: [shareMediumImageAction, shareLargeImageAction])

--- a/Zotero/Scenes/Detail/CitationBibliographyExport/ViewModels/CitationBibliographyExportActionHandler.swift
+++ b/Zotero/Scenes/Detail/CitationBibliographyExport/ViewModels/CitationBibliographyExportActionHandler.swift
@@ -92,7 +92,7 @@ struct CitationBibliographyExportActionHandler: ViewModelActionHandler {
                     self.copy(html: data.0, plaintext: data.1, in: viewModel)
                     self.citationController.finishCitation()
                 }, onFailure: { viewModel, error in
-                    DDLogError("CitationBibliographyExportActionHbi andler: can't create citation of bibliography - \(error)")
+                    DDLogError("CitationBibliographyExportActionHandler: can't create citation of bibliography - \(error)")
                     self.handle(error: error, in: viewModel)
                     self.citationController.finishCitation()
                 })

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -324,11 +324,10 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
             parentKey: viewModel.state.key,
             libraryId: viewModel.state.library.id
         )
+        .observe(on: MainScheduler.instance)
         .subscribe { [weak self] (image: UIImage) in
             guard let self else { return }
-            inMainThread {
-                self.share(item: image, sourceView: .view(sender, nil), presenter: presenter)
-            }
+            self.share(item: image, sourceView: .view(sender, nil), presenter: presenter)
         } onFailure: { (error: Error) in
             // TODO: log error
             // TODO: show error

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -31,8 +31,8 @@ protocol PdfReaderCoordinatorDelegate: AnyObject {
 
 protocol PdfAnnotationsCoordinatorDelegate: AnyObject {
     func shareAnnotation(
-        viewModel: ViewModel<PDFReaderActionHandler>,
-        annotationKey: PDFReaderState.AnnotationKey?,
+        state: PDFReaderState,
+        annotation: Annotation,
         scale: CGFloat,
         sender: UIButton,
         presenter: UIViewController?
@@ -299,17 +299,13 @@ extension PDFCoordinator: PdfReaderCoordinatorDelegate {
 
 extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
     func shareAnnotation(
-        viewModel: ViewModel<PDFReaderActionHandler>,
-        annotationKey: PDFReaderState.AnnotationKey? = nil,
+        state: PDFReaderState,
+        annotation: Annotation,
         scale: CGFloat = 1.0,
         sender: UIButton,
         presenter: UIViewController? = nil
     ) {
-        let state = viewModel.state
-        let document = state.document
-        guard let annotationKey = annotationKey ?? state.selectedAnnotationKey,
-              let annotation = state.annotation(for: annotationKey),
-              annotation.type == .image,
+        guard annotation.type == .image,
               let pdfReaderViewController = navigationController.viewControllers.last as? PDFReaderViewController
         else { return }
         let annotationPreviewController = controllers.annotationPreviewController
@@ -319,14 +315,14 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
         size.width *= scale
         size.height *= scale
         annotationPreviewController.render(
-            document: document,
+            document: state.document,
             page: pageIndex,
             rect: rect,
             imageSize: size,
             imageScale: 1.0,
             key: annotation.key,
-            parentKey: viewModel.state.key,
-            libraryId: viewModel.state.library.id
+            parentKey: state.key,
+            libraryId: state.library.id
         )
         .observe(on: MainScheduler.instance)
         .subscribe { [weak self] (image: UIImage) in

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -371,22 +371,20 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
         annotation: Annotation,
         sender: UIButton
     ) -> UIMenu? {
+        guard annotation.type == .image,
+              let boundingBoxConverter = self.navigationController.viewControllers.last as? AnnotationBoundingBoxConverter
+        else { return nil }
         var children: [UIMenuElement] = []
-        if annotation.type == .image,
-           let boundingBoxConverter = self.navigationController.viewControllers.last as? AnnotationBoundingBoxConverter
-        {
-            var shareImageMenuChildren: [UIMenuElement] = []
-            for (scale, title) in [
-                (300.0 / 72.0, L10n.Pdf.AnnotationShare.Image.medium),
-                (600.0 / 72.0, L10n.Pdf.AnnotationShare.Image.large)
-            ] {
-                let menuElement = deferredShareImageMenuElement(state: state, annotation: annotation, sender: sender, boundingBoxConverter: boundingBoxConverter, scale: scale, title: title)
-                shareImageMenuChildren.append(menuElement)
-            }
-            let shareImageMenu = UIMenu(title: L10n.Pdf.AnnotationShare.Image.share, options: [.displayInline], children: shareImageMenuChildren)
-            children.append(shareImageMenu)
+        var shareImageMenuChildren: [UIMenuElement] = []
+        for (scale, title) in [
+            (300.0 / 72.0, L10n.Pdf.AnnotationShare.Image.medium),
+            (600.0 / 72.0, L10n.Pdf.AnnotationShare.Image.large)
+        ] {
+            let menuElement = deferredShareImageMenuElement(state: state, annotation: annotation, sender: sender, boundingBoxConverter: boundingBoxConverter, scale: scale, title: title)
+            shareImageMenuChildren.append(menuElement)
         }
-        guard !children.isEmpty else { return nil }
+        let shareImageMenu = UIMenu(title: L10n.Pdf.AnnotationShare.Image.share, options: [.displayInline], children: shareImageMenuChildren)
+        children.append(shareImageMenu)
         return UIMenu(children: children)
     }
     

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -33,6 +33,7 @@ protocol PdfAnnotationsCoordinatorDelegate: AnyObject {
     func shareAnnotation(
         viewModel: ViewModel<PDFReaderActionHandler>,
         annotationKey: PDFReaderState.AnnotationKey?,
+        scale: CGFloat,
         sender: UIButton,
         presenter: UIViewController?
     )
@@ -300,6 +301,7 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
     func shareAnnotation(
         viewModel: ViewModel<PDFReaderActionHandler>,
         annotationKey: PDFReaderState.AnnotationKey? = nil,
+        scale: CGFloat = 1.0,
         sender: UIButton,
         presenter: UIViewController? = nil
     ) {
@@ -313,14 +315,15 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
         let annotationPreviewController = controllers.annotationPreviewController
         let pageIndex: PageIndex = UInt(annotation.page)
         let rect = annotation.boundingBox(boundingBoxConverter: pdfReaderViewController)
-        // TODO: check if size should be scaled by a factor, either fixed, or dynamic e.g. screen scale
-        let size = rect.size
+        var size = rect.size
+        size.width *= scale
+        size.height *= scale
         annotationPreviewController.render(
             document: document,
             page: pageIndex,
             rect: rect,
             imageSize: size,
-            imageScale: 0.0,
+            imageScale: 1.0,
             key: annotation.key,
             parentKey: viewModel.state.key,
             libraryId: viewModel.state.library.id

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -355,6 +355,8 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
                         (self as Coordinator).share(item: image, sourceView: .view(sender, nil))
                     }
                 }
+                action.accessibilityLabel = L10n.Accessibility.Pdf.shareAnnotationImage + " " + title
+                action.isAccessibilityElement = true
                 elementProvider([action])
             } onFailure: { (error: Error) in
                 DDLogError("PDFCoordinator: can't render annotation image - \(error)")

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -30,7 +30,7 @@ protocol PdfReaderCoordinatorDelegate: AnyObject {
 }
 
 protocol PdfAnnotationsCoordinatorDelegate: AnyObject {
-    func shareAnnotationMenu(
+    func createShareAnnotationMenu(
         state: PDFReaderState,
         annotation: Annotation,
         sender: UIButton
@@ -366,7 +366,7 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
         }
     }
         
-    func shareAnnotationMenu(
+    func createShareAnnotationMenu(
         state: PDFReaderState,
         annotation: Annotation,
         sender: UIButton

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -310,7 +310,7 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
         scale: CGFloat,
         title: String
     ) -> UIDeferredMenuElement {
-        UIDeferredMenuElement { [weak self] (elementProvider: @escaping ([UIMenuElement]) -> Void) in
+        UIDeferredMenuElement { [weak self] elementProvider in
             guard let self else {
                 elementProvider([])
                 return
@@ -332,7 +332,7 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
                 libraryId: state.library.id
             )
             .observe(on: MainScheduler.instance)
-            .subscribe { [weak self] (image: UIImage) in
+            .subscribe { [weak self] image in
                 var menuTitle = title
                 // By default UIActivityViewController shares a JPEG image with 0.8 compression quality,
                 // so we compute the image size as such. Actual image produced can be overriden if we need to.

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -30,17 +30,8 @@ protocol PdfReaderCoordinatorDelegate: AnyObject {
 }
 
 protocol PdfAnnotationsCoordinatorDelegate: AnyObject {
-    func createShareAnnotationMenu(
-        state: PDFReaderState,
-        annotation: Annotation,
-        sender: UIButton
-    ) -> UIMenu?
-    func shareAnnotationImage(
-        state: PDFReaderState,
-        annotation: Annotation,
-        scale: CGFloat,
-        sender: UIButton
-    )
+    func createShareAnnotationMenu(state: PDFReaderState, annotation: Annotation, sender: UIButton) -> UIMenu?
+    func shareAnnotationImage(state: PDFReaderState, annotation: Annotation, scale: CGFloat, sender: UIButton )
     func showTagPicker(libraryId: LibraryIdentifier, selected: Set<String>, userInterfaceStyle: UIUserInterfaceStyle?, picked: @escaping ([Tag]) -> Void)
     func showCellOptions(for annotation: Annotation, userId: Int, library: Library, sender: UIButton, userInterfaceStyle: UIUserInterfaceStyle, saveAction: @escaping AnnotationEditSaveAction, deleteAction: @escaping AnnotationEditDeleteAction)
     func showFilterPopup(from barButton: UIBarButtonItem, filter: AnnotationsFilter?, availableColors: [String], availableTags: [Tag], userInterfaceStyle: UIUserInterfaceStyle, completed: @escaping (AnnotationsFilter?) -> Void)
@@ -370,11 +361,7 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
         }
     }
         
-    func createShareAnnotationMenu(
-        state: PDFReaderState,
-        annotation: Annotation,
-        sender: UIButton
-    ) -> UIMenu? {
+    func createShareAnnotationMenu(state: PDFReaderState, annotation: Annotation, sender: UIButton) -> UIMenu? {
         guard annotation.type == .image,
               let boundingBoxConverter = self.navigationController.viewControllers.last as? AnnotationBoundingBoxConverter
         else { return nil }
@@ -392,12 +379,7 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
         return UIMenu(children: children)
     }
     
-    func shareAnnotationImage(
-        state: PDFReaderState,
-        annotation: Annotation,
-        scale: CGFloat = 1.0,
-        sender: UIButton
-    ) {
+    func shareAnnotationImage(state: PDFReaderState, annotation: Annotation, scale: CGFloat = 1.0, sender: UIButton) {
         guard annotation.type == .image,
               let pdfReaderViewController = navigationController.viewControllers.last as? PDFReaderViewController
         else { return }

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -311,14 +311,16 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
               let pdfReaderViewController = navigationController.viewControllers.last as? PDFReaderViewController
         else { return }
         let annotationPreviewController = controllers.annotationPreviewController
+        let pageIndex: PageIndex = UInt(annotation.page)
         let rect = annotation.boundingBox(boundingBoxConverter: pdfReaderViewController)
         // TODO: check if size should be scaled by a factor, either fixed, or dynamic e.g. screen scale
         let size = rect.size
         annotationPreviewController.render(
             document: document,
-            page: UInt(annotation.page),
+            page: pageIndex,
             rect: rect,
             imageSize: size,
+            imageScale: 0.0,
             key: annotation.key,
             parentKey: viewModel.state.key,
             libraryId: viewModel.state.library.id

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -349,10 +349,14 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
                 let action = UIAction(title: menuTitle) { [weak self] (_: UIAction) in
                     guard let self else { return }
                     DDLogInfo("PDFCoordinator: share pdf annotation image - \(title)")
+                    let completion = { (activityType: UIActivity.ActivityType?, completed: Bool, _: [Any]?, error: Error?) in
+                        DDLogInfo("PDFCoordinator: share pdf annotation image - activity type: \(String(describing: activityType)) completed: \(completed) error: \(String(describing: error))")
+                    }
+                    
                     if let coordinator = self.childCoordinators.last, coordinator is AnnotationPopoverCoordinator {
-                        coordinator.share(item: image, sourceView: .view(sender, nil))
+                        coordinator.share(item: image, sourceView: .view(sender, nil), completionWithItemsHandler: completion)
                     } else {
-                        (self as Coordinator).share(item: image, sourceView: .view(sender, nil))
+                        (self as Coordinator).share(item: image, sourceView: .view(sender, nil), completionWithItemsHandler: completion)
                     }
                 }
                 action.accessibilityLabel = L10n.Accessibility.Pdf.shareAnnotationImage + " " + title

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
@@ -107,7 +107,7 @@ final class AnnotationView: UIView {
 
         var annotationIsShareable = false
         if let button = header.shareButton,
-           let menu = pdfAnnotationsCoordinatorDelegate.shareAnnotationMenu(state: state, annotation: annotation, sender: button)
+           let menu = pdfAnnotationsCoordinatorDelegate.createShareAnnotationMenu(state: state, annotation: annotation, sender: button)
         {
             annotationIsShareable = true
             button.showsMenuAsPrimaryAction = true

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
@@ -105,18 +105,12 @@ final class AnnotationView: UIView {
         let color = UIColor(hex: annotation.color)
         let canEdit = editability == .editable && selected
 
-        var annotationIsShareable = false
-        if let button = header.shareButton,
-           let menu = pdfAnnotationsCoordinatorDelegate.createShareAnnotationMenu(state: state, annotation: annotation, sender: button)
-        {
-            annotationIsShareable = true
-            button.showsMenuAsPrimaryAction = true
-            button.menu = menu
-        }
         self.header.setup(
             with: annotation,
             libraryId: library.identifier,
-            showShareButton: annotationIsShareable,
+            shareMenuProvider: { button in
+                pdfAnnotationsCoordinatorDelegate.createShareAnnotationMenu(state: state, annotation: annotation, sender: button)
+            },
             isEditable: (editability != .notEditable && selected),
             showsLock: editability != .editable,
             showDoneButton: self.layout.showDoneButton,

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
@@ -248,7 +248,7 @@ final class AnnotationView: UIView {
     private func setupObserving() {
         var disposables: [Disposable] = buildDisposables()
         if let doneTap = self.header.doneTap {
-            disposables.append(doneTap.flatMap({ Observable.just(Action.done) }).bind(to: self.actionPublisher))            
+            disposables.append(doneTap.flatMap({ Observable.just(Action.done) }).bind(to: self.actionPublisher))
         }
         disposeBag = CompositeDisposable(disposables: disposables)
     }

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
@@ -22,6 +22,7 @@ final class AnnotationView: UIView {
         case setComment(NSAttributedString)
         case setCommentActive(Bool)
         case done
+        case share(UIButton)
     }
 
     enum AccessibilityType {
@@ -103,8 +104,17 @@ final class AnnotationView: UIView {
         let color = UIColor(hex: annotation.color)
         let canEdit = editability == .editable && selected
 
-        self.header.setup(with: annotation, libraryId: library.identifier, isEditable: (editability != .notEditable && selected), showsLock: editability != .editable,
-                          showDoneButton: self.layout.showDoneButton, accessibilityType: .cell, displayName: displayName, username: username)
+        self.header.setup(
+            with: annotation,
+            libraryId: library.identifier,
+            showShareButton: (annotation.type == .image),
+            isEditable: (editability != .notEditable && selected),
+            showsLock: editability != .editable,
+            showDoneButton: self.layout.showDoneButton,
+            accessibilityType: .cell,
+            displayName: displayName,
+            username: username
+        )
         self.setupContent(for: annotation, preview: preview, color: color, canEdit: canEdit, selected: selected, availableWidth: availableWidth, accessibilityType: .cell, boundingBoxConverter: boundingBoxConverter)
         self.setup(comment: comment, canEdit: canEdit)
         self.setupTags(for: annotation, canEdit: canEdit, accessibilityEnabled: selected)
@@ -230,6 +240,11 @@ final class AnnotationView: UIView {
         self.tags.tap.flatMap({ _ in Observable.just(Action.tags) }).bind(to: self.actionPublisher)
         self.tagsButton.rx.tap.flatMap({ Observable.just(Action.tags) }).bind(to: self.actionPublisher)
         self.header.menuTap.flatMap({ Observable.just(Action.options($0)) }).bind(to: self.actionPublisher)
+        header.shareTap.subscribe(
+            onNext: { [weak self] (sender: UIButton) in
+                self?.actionPublisher.on(.next(.share(sender)))
+            }
+        )
     }
     
     private func setupObserving() {

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
@@ -228,10 +228,10 @@ final class AnnotationView: UIView {
         guard let sender = header.shareButton else { return }
         // TODO: ask delegate for menu instead?
         let shareMediumImageAction = UIAction(title: L10n.Pdf.AnnotationShare.Image.medium) { [weak self] (_: UIAction) in
-            self?.actionPublisher.on(.next(.shareImage(sender: sender, scale: 1.0)))
+            self?.actionPublisher.on(.next(.shareImage(sender: sender, scale: 300.0 / 72.0)))
         }
         let shareLargeImageAction = UIAction(title: L10n.Pdf.AnnotationShare.Image.large) { [weak self](_: UIAction) in
-            self?.actionPublisher.on(.next(.shareImage(sender: sender, scale: 300.0 / 72.0)))
+            self?.actionPublisher.on(.next(.shareImage(sender: sender, scale: 600.0 / 72.0)))
         }
         sender.showsMenuAsPrimaryAction = true
         sender.menu = UIMenu(children: [shareMediumImageAction, shareLargeImageAction])

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHeader.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHeader.swift
@@ -140,8 +140,8 @@ final class AnnotationViewHeader: UIView {
 
         self.menuButton.accessibilityLabel = L10n.Accessibility.Pdf.editAnnotation
         self.menuButton.isAccessibilityElement = true
-        
-        // TODO: setup accessibility for share button
+        self.shareButton.accessibilityLabel = L10n.Accessibility.Pdf.shareAnnotation
+        self.shareButton.isAccessibilityElement = true
     }
 
     private func setupView(with layout: AnnotationViewLayout) {

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHeader.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHeader.swift
@@ -15,6 +15,7 @@ final class AnnotationViewHeader: UIView {
     private weak var typeImageView: UIImageView!
     private weak var pageLabel: UILabel!
     private weak var authorLabel: UILabel!
+    private weak var shareButton: UIButton!
     private weak var menuButton: UIButton!
     private weak var doneButton: UIButton?
     private weak var lockIcon: UIImageView?
@@ -23,6 +24,10 @@ final class AnnotationViewHeader: UIView {
     private var authorTrailingToContainer: NSLayoutConstraint!
     private var authorTrailingToButton: NSLayoutConstraint!
 
+    var shareTap: Observable<UIButton> {
+        return self.shareButton.rx.tap.flatMap({ Observable.just(self.shareButton) })
+    }
+    
     var menuTap: Observable<UIButton> {
         return self.menuButton.rx.tap.flatMap({ Observable.just(self.menuButton) })
     }
@@ -70,11 +75,22 @@ final class AnnotationViewHeader: UIView {
         return annotationName + ", " + L10n.page + " " + pageLabel
     }
 
-    private func setup(type: AnnotationType, color: UIColor, pageLabel: String, author: String, showsMenuButton: Bool, showsDoneButton: Bool, showsLock: Bool, accessibilityType: AnnotationView.AccessibilityType) {
+    private func setup(
+        type: AnnotationType,
+        color: UIColor,
+        pageLabel: String,
+        author: String,
+        showsShareButton: Bool,
+        showsMenuButton: Bool,
+        showsDoneButton: Bool,
+        showsLock: Bool,
+        accessibilityType: AnnotationView.AccessibilityType
+    ) {
         self.typeImageView.image = self.image(for: type)?.withRenderingMode(.alwaysTemplate)
         self.typeImageView.tintColor = color
         self.pageLabel.text = L10n.page + " " + pageLabel
         self.authorLabel.text = author
+        self.shareButton.isHidden = !showsShareButton
         self.menuButton.isHidden = !showsMenuButton
         self.lockIcon?.isHidden = !showsLock
 
@@ -85,10 +101,30 @@ final class AnnotationViewHeader: UIView {
         self.setupAccessibility(type: type, pageLabel: pageLabel, author: author, accessibilityType: accessibilityType)
     }
 
-    func setup(with annotation: Annotation, libraryId: LibraryIdentifier, isEditable: Bool, showsLock: Bool, showDoneButton: Bool, accessibilityType: AnnotationView.AccessibilityType, displayName: String, username: String) {
+    func setup(
+        with annotation: Annotation,
+        libraryId: LibraryIdentifier,
+        showShareButton: Bool,
+        isEditable: Bool,
+        showsLock: Bool,
+        showDoneButton: Bool,
+        accessibilityType: AnnotationView.AccessibilityType,
+        displayName: String,
+        username: String
+    ) {
         let color = UIColor(hex: annotation.color)
         let author = libraryId == .custom(.myLibrary) ? "" : annotation.author(displayName: displayName, username: username)
-        self.setup(type: annotation.type, color: color, pageLabel: annotation.pageLabel, author: author, showsMenuButton: isEditable, showsDoneButton: showDoneButton, showsLock: showsLock, accessibilityType: accessibilityType)
+        self.setup(
+            type: annotation.type,
+            color: color,
+            pageLabel: annotation.pageLabel,
+            author: author,
+            showsShareButton: showShareButton,
+            showsMenuButton: isEditable,
+            showsDoneButton: showDoneButton,
+            showsLock: showsLock,
+            accessibilityType: accessibilityType
+        )
     }
 
     private func setupAccessibility(type: AnnotationType, pageLabel: String, author: String, accessibilityType: AnnotationView.AccessibilityType) {
@@ -128,14 +164,21 @@ final class AnnotationViewHeader: UIView {
         authorLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
         authorLabel.translatesAutoresizingMaskIntoConstraints = false
 
+        let shareButton = UIButton()
+        shareButton.setImage(UIImage(systemName: "square.and.arrow.up"), for: .normal)
+        shareButton.tintColor = Asset.Colors.zoteroBlueWithDarkMode.color
+        shareButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: layout.horizontalInset, bottom: 0, right: (layout.horizontalInset / 2))
+        shareButton.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        shareButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        
         let menuButton = UIButton()
         menuButton.setImage(UIImage(systemName: "ellipsis"), for: .normal)
         menuButton.tintColor = Asset.Colors.zoteroBlueWithDarkMode.color
-        menuButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: layout.horizontalInset, bottom: 0, right: (layout.horizontalInset / 2))
+        menuButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: (layout.horizontalInset / 2), bottom: 0, right: (layout.horizontalInset / 2))
         menuButton.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         menuButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
 
-        var rightButtons: [UIView] = [menuButton]
+        var rightButtons: [UIView] = [shareButton, menuButton]
 
         if layout.showDoneButton {
             let doneButton = UIButton()
@@ -165,6 +208,7 @@ final class AnnotationViewHeader: UIView {
         self.typeImageView = typeImageView
         self.pageLabel = pageLabel
         self.authorLabel = authorLabel
+        self.shareButton = shareButton
         self.menuButton = menuButton
         self.lockIcon = lock
         self.rightBarButtonsStackView = rightBarButtons

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHeader.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHeader.swift
@@ -15,7 +15,7 @@ final class AnnotationViewHeader: UIView {
     private weak var typeImageView: UIImageView!
     private weak var pageLabel: UILabel!
     private weak var authorLabel: UILabel!
-    public weak var shareButton: UIButton!
+    private weak var shareButton: UIButton!
     private weak var menuButton: UIButton!
     private weak var doneButton: UIButton?
     private weak var lockIcon: UIImageView?
@@ -80,7 +80,7 @@ final class AnnotationViewHeader: UIView {
         color: UIColor,
         pageLabel: String,
         author: String,
-        showsShareButton: Bool,
+        shareMenu: UIMenu?,
         showsMenuButton: Bool,
         showsDoneButton: Bool,
         showsLock: Bool,
@@ -90,7 +90,16 @@ final class AnnotationViewHeader: UIView {
         self.typeImageView.tintColor = color
         self.pageLabel.text = L10n.page + " " + pageLabel
         self.authorLabel.text = author
-        self.shareButton.isHidden = !showsShareButton
+        
+        if let shareMenu {
+            shareButton.isHidden = false
+            shareButton.showsMenuAsPrimaryAction = true
+            shareButton.menu = shareMenu
+        } else {
+            shareButton.isHidden = true
+            shareButton.showsMenuAsPrimaryAction = false
+            shareButton.menu = nil
+        }
         self.menuButton.isHidden = !showsMenuButton
         self.lockIcon?.isHidden = !showsLock
 
@@ -104,7 +113,7 @@ final class AnnotationViewHeader: UIView {
     func setup(
         with annotation: Annotation,
         libraryId: LibraryIdentifier,
-        showShareButton: Bool,
+        shareMenuProvider: @escaping ((UIButton) -> UIMenu?),
         isEditable: Bool,
         showsLock: Bool,
         showDoneButton: Bool,
@@ -119,7 +128,7 @@ final class AnnotationViewHeader: UIView {
             color: color,
             pageLabel: annotation.pageLabel,
             author: author,
-            showsShareButton: showShareButton,
+            shareMenu: shareMenuProvider(shareButton),
             showsMenuButton: isEditable,
             showsDoneButton: showDoneButton,
             showsLock: showsLock,

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHeader.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHeader.swift
@@ -15,7 +15,7 @@ final class AnnotationViewHeader: UIView {
     private weak var typeImageView: UIImageView!
     private weak var pageLabel: UILabel!
     private weak var authorLabel: UILabel!
-    private weak var shareButton: UIButton!
+    public weak var shareButton: UIButton!
     private weak var menuButton: UIButton!
     private weak var doneButton: UIButton?
     private weak var lockIcon: UIImageView?
@@ -140,6 +140,8 @@ final class AnnotationViewHeader: UIView {
 
         self.menuButton.accessibilityLabel = L10n.Accessibility.Pdf.editAnnotation
         self.menuButton.isAccessibilityElement = true
+        
+        // TODO: setup accessibility for share button
     }
 
     private func setupView(with layout: AnnotationViewLayout) {

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationCell.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationCell.swift
@@ -18,7 +18,7 @@ final class AnnotationCell: UITableViewCell {
     var actionPublisher: PublishSubject<AnnotationView.Action> {
         return self.annotationView.actionPublisher
     }
-    var disposeBag: DisposeBag {
+    var disposeBag: CompositeDisposable {
         return self.annotationView.disposeBag
     }
 
@@ -37,6 +37,7 @@ final class AnnotationCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         self.key = ""
+        disposeBag.dispose()
     }
 
     // MARK: - Actions

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationCell.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationCell.swift
@@ -84,7 +84,7 @@ final class AnnotationCell: UITableViewCell {
     }
 
     func setup(with annotation: Annotation, comment: AnnotationView.Comment?, preview: UIImage?, selected: Bool, availableWidth: CGFloat, library: Library, isEditing: Bool, currentUserId: Int,
-               displayName: String, username: String, boundingBoxConverter: AnnotationBoundingBoxConverter) {
+               displayName: String, username: String, boundingBoxConverter: AnnotationBoundingBoxConverter, pdfAnnotationsCoordinatorDelegate: PdfAnnotationsCoordinatorDelegate, state: PDFReaderState) {
         if !selected {
             self.annotationView.resignFirstResponder()
         }
@@ -93,7 +93,8 @@ final class AnnotationCell: UITableViewCell {
         self.selectionView.layer.borderWidth = selected ? PDFReaderLayout.cellSelectionLineWidth : 0
         let availableWidth = availableWidth - (PDFReaderLayout.annotationLayout.horizontalInset * 2)
         self.annotationView.setup(with: annotation, comment: comment, preview: preview, selected: selected, availableWidth: availableWidth, library: library, currentUserId: currentUserId,
-                                  displayName: displayName, username: username, boundingBoxConverter: boundingBoxConverter)
+                                  displayName: displayName, username: username, boundingBoxConverter: boundingBoxConverter,
+                                  pdfAnnotationsCoordinatorDelegate: pdfAnnotationsCoordinatorDelegate, state: state)
 
         self.setupAccessibility(for: annotation, selected: selected, currentUserId: currentUserId, displayName: displayName, username: username)
     }

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
@@ -130,10 +130,11 @@ final class AnnotationsViewController: UIViewController {
 
         case .done: break // Done button doesn't appear here
             
-        case .share(let sender):
+        case .shareImage(let sender, let scale):
             coordinatorDelegate?.shareAnnotation(
                 viewModel: viewModel,
                 annotationKey: annotation.readerKey,
+                scale: scale,
                 sender: sender,
                 presenter: nil
             )

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
@@ -129,15 +129,6 @@ final class AnnotationsViewController: UIViewController {
             self.viewModel.process(action: .setCommentActive(isActive))
 
         case .done: break // Done button doesn't appear here
-            
-        case .shareImage(let sender, let scale):
-            coordinatorDelegate?.shareAnnotation(
-                state: state,
-                annotation: annotation,
-                scale: scale,
-                sender: sender,
-                presenter: nil
-            )
         }
     }
 
@@ -297,10 +288,10 @@ final class AnnotationsViewController: UIViewController {
             comment = .init(attributedString: self.loadAttributedComment(for: annotation), isActive: state.selectedAnnotationCommentActive)
         }
 
-        if let boundingBoxConverter = self.boundingBoxConverter {
+        if let boundingBoxConverter = self.boundingBoxConverter, let pdfAnnotationsCoordinatorDelegate = coordinatorDelegate {
             cell.setup(with: annotation, comment: comment, preview: preview, selected: selected, availableWidth: PDFReaderLayout.sidebarWidth, library: state.library,
                        isEditing: state.sidebarEditingEnabled, currentUserId: self.viewModel.state.userId, displayName: self.viewModel.state.displayName, username: self.viewModel.state.username,
-                       boundingBoxConverter: boundingBoxConverter)
+                       boundingBoxConverter: boundingBoxConverter, pdfAnnotationsCoordinatorDelegate: pdfAnnotationsCoordinatorDelegate, state: state)
         }
         let actionSubscription = cell.actionPublisher.subscribe(onNext: { [weak self] action in
             self?.perform(action: action, annotation: annotation)

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
@@ -132,8 +132,8 @@ final class AnnotationsViewController: UIViewController {
             
         case .shareImage(let sender, let scale):
             coordinatorDelegate?.shareAnnotation(
-                viewModel: viewModel,
-                annotationKey: annotation.readerKey,
+                state: state,
+                annotation: annotation,
                 scale: scale,
                 sender: sender,
                 presenter: nil

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
@@ -293,10 +293,10 @@ final class AnnotationsViewController: UIViewController {
                        isEditing: state.sidebarEditingEnabled, currentUserId: self.viewModel.state.userId, displayName: self.viewModel.state.displayName, username: self.viewModel.state.username,
                        boundingBoxConverter: boundingBoxConverter)
         }
-        cell.actionPublisher.subscribe(onNext: { [weak self] action in
+        let actionSubscription = cell.actionPublisher.subscribe(onNext: { [weak self] action in
             self?.perform(action: action, annotation: annotation)
         })
-        .disposed(by: cell.disposeBag)
+        cell.disposeBag.insert(actionSubscription)
     }
 
     private func loadAttributedComment(for annotation: Annotation) -> NSAttributedString? {

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
@@ -129,6 +129,14 @@ final class AnnotationsViewController: UIViewController {
             self.viewModel.process(action: .setCommentActive(isActive))
 
         case .done: break // Done button doesn't appear here
+            
+        case .share(let sender):
+            coordinatorDelegate?.shareAnnotation(
+                viewModel: viewModel,
+                annotationKey: annotation.readerKey,
+                sender: sender,
+                presenter: nil
+            )
         }
     }
 


### PR DESCRIPTION
closes #677 

* Adds share button in `AnnotationViewHeader` of image annotations, both in annotations in sidebar or selected annotation in document. When button is tapped it presents a `UIMenu` with 2 options, `Medium` & `Large`, corresponding to 300 & 600 PPI. Said options present a `UIActivityViewController`  for sharing the image (anchored to the share button). 
* Extends `AnnotationPreviewController` to allow rendering an image with an arbitrary size.
* Also adds some minor code improvements.

While this button will only be present for image annotations, we could easily extend the functionality for other types, e.g. to share a text snippet. The menu is built for the whole annotation, so it is easy to extend.

There are also some minor issues pending, noted as `TODO` items in the changes.