### PR TITLE
Fix file sync issue when background upload finishes but doesn't update state in main app

### DIFF
--- a/ZShare/View Controllers/ShareViewController.swift
+++ b/ZShare/View Controllers/ShareViewController.swift
@@ -722,8 +722,7 @@ final class ShareViewController: UIViewController {
         let backgroundUploadObserver = BackgroundUploadObserver(context: backgroundUploadContext, processor: backgroundProcessor, backgroundTaskController: backgroundTaskController)
         let attachmentDownloader = AttachmentDownloader(userId: userId, apiClient: apiClient, fileStorage: fileStorage, dbStorage: dbStorage, webDavController: webDavController)
         let syncController = SyncController(userId: userId, apiClient: apiClient, dbStorage: dbStorage, fileStorage: fileStorage, schemaController: schemaController, dateParser: dateParser,
-                                            backgroundUploaderContext: backgroundUploadContext, webDavController: webDavController, attachmentDownloader: attachmentDownloader, syncDelayIntervals: DelayIntervals.sync,
-                                            conflictDelays: DelayIntervals.conflict)
+                                            backgroundUploaderContext: backgroundUploadContext, webDavController: webDavController, attachmentDownloader: attachmentDownloader, syncDelayIntervals: DelayIntervals.sync, maxRetryCount: DelayIntervals.retry.count)
 
         return ExtensionViewModel(webView: self.webView, apiClient: apiClient, attachmentDownloader: attachmentDownloader, backgroundUploader: backgroundUploader, backgroundUploadObserver: backgroundUploadObserver, dbStorage: dbStorage,
                                   schemaController: schemaController, webDavController: webDavController, dateParser: dateParser, fileStorage: fileStorage, syncController: syncController,

--- a/ZShare/View Controllers/ShareViewController.swift
+++ b/ZShare/View Controllers/ShareViewController.swift
@@ -720,11 +720,12 @@ final class ShareViewController: UIViewController {
         let backgroundProcessor = BackgroundUploadProcessor(apiClient: apiClient, dbStorage: dbStorage, fileStorage: fileStorage, webDavController: webDavController)
         let backgroundTaskController = BackgroundTaskController()
         let backgroundUploadObserver = BackgroundUploadObserver(context: backgroundUploadContext, processor: backgroundProcessor, backgroundTaskController: backgroundTaskController)
+        let attachmentDownloader = AttachmentDownloader(userId: userId, apiClient: apiClient, fileStorage: fileStorage, dbStorage: dbStorage, webDavController: webDavController)
         let syncController = SyncController(userId: userId, apiClient: apiClient, dbStorage: dbStorage, fileStorage: fileStorage, schemaController: schemaController, dateParser: dateParser,
-                                            backgroundUploaderContext: backgroundUploadContext, webDavController: webDavController, syncDelayIntervals: DelayIntervals.sync,
+                                            backgroundUploaderContext: backgroundUploadContext, webDavController: webDavController, attachmentDownloader: attachmentDownloader, syncDelayIntervals: DelayIntervals.sync,
                                             conflictDelays: DelayIntervals.conflict)
 
-        return ExtensionViewModel(webView: self.webView, apiClient: apiClient, backgroundUploader: backgroundUploader, backgroundUploadObserver: backgroundUploadObserver, dbStorage: dbStorage,
+        return ExtensionViewModel(webView: self.webView, apiClient: apiClient, attachmentDownloader: attachmentDownloader, backgroundUploader: backgroundUploader, backgroundUploadObserver: backgroundUploadObserver, dbStorage: dbStorage,
                                   schemaController: schemaController, webDavController: webDavController, dateParser: dateParser, fileStorage: fileStorage, syncController: syncController,
                                   translatorsController: translatorsController)
     }

--- a/ZShare/ViewModels/ExtensionViewModel.swift
+++ b/ZShare/ViewModels/ExtensionViewModel.swift
@@ -266,6 +266,7 @@ final class ExtensionViewModel {
 
     private let syncController: SyncController
     private let apiClient: ApiClient
+    private let attachmentDownloader: AttachmentDownloader
     private let dbStorage: DbStorage
     private let fileStorage: FileStorage
     private let schemaController: SchemaController
@@ -286,7 +287,7 @@ final class ExtensionViewModel {
         let mtime: Int
     }
 
-    init(webView: WKWebView, apiClient: ApiClient, backgroundUploader: BackgroundUploader, backgroundUploadObserver: BackgroundUploadObserver, dbStorage: DbStorage, schemaController: SchemaController,
+    init(webView: WKWebView, apiClient: ApiClient, attachmentDownloader: AttachmentDownloader, backgroundUploader: BackgroundUploader, backgroundUploadObserver: BackgroundUploadObserver, dbStorage: DbStorage, schemaController: SchemaController,
          webDavController: WebDavController, dateParser: DateParser, fileStorage: FileStorage, syncController: SyncController, translatorsController: TranslatorsAndStylesController) {
         let queue = DispatchQueue(label: "org.zotero.ZShare.BackgroundQueue", qos: .userInteractive)
 
@@ -305,6 +306,7 @@ final class ExtensionViewModel {
         self.webView = webView
         self.syncController = syncController
         self.apiClient = apiClient
+        self.attachmentDownloader = attachmentDownloader
         self.backgroundUploader = backgroundUploader
         self.backgroundUploadObserver = backgroundUploadObserver
         self.dbStorage = dbStorage

--- a/ZShare/ViewModels/ExtensionViewModel.swift
+++ b/ZShare/ViewModels/ExtensionViewModel.swift
@@ -329,7 +329,7 @@ final class ExtensionViewModel {
     func start(with extensionItem: NSExtensionItem) {
         // Start sync in background, so that collections are available for user to pick
         DDLogInfo("ExtensionViewModel: start sync")
-        self.syncController.start(type: .collectionsOnly, libraries: .all)
+        self.syncController.start(type: .collectionsOnly, libraries: .all, retryAttempt: 0)
         DDLogInfo("ExtensionViewModel: load extension item")
         self.loadAttachment(from: extensionItem)
             .subscribe(onSuccess: { [weak self] attachment in
@@ -1434,8 +1434,6 @@ final class ExtensionViewModel {
                            .observe(on: MainScheduler.instance)
                            .subscribe(onNext: { [weak self] data in
                                self?.finishSync(successful: (data == nil))
-                           }, onError: { [weak self] _ in
-                               self?.finishSync(successful: false)
                            })
                            .disposed(by: self.disposeBag)
     }

--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -984,6 +984,7 @@
 		B3DDDAAC24CAD6810014DF99 /* InsetLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3DDDAAB24CAD6810014DF99 /* InsetLabel.swift */; };
 		B3DEAAA728AD01CA00F72D90 /* URLSession+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3DEAAA628AD01CA00F72D90 /* URLSession+Extensions.swift */; };
 		B3DEAAA828AD106F00F72D90 /* URLSession+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3DEAAA628AD01CA00F72D90 /* URLSession+Extensions.swift */; };
+		B3DF44122A408339005AF766 /* test_item_attachment.json in Resources */ = {isa = PBXBuildFile; fileRef = B3DF44112A408339005AF766 /* test_item_attachment.json */; };
 		B3DF9AD22747AAD2007933CB /* ApiRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3DF9AD12747AAD2007933CB /* ApiRequest.swift */; };
 		B3DF9AD32747AAD9007933CB /* ApiRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3DF9AD12747AAD2007933CB /* ApiRequest.swift */; };
 		B3DF9AD52747AB4F007933CB /* ApiEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3DF9AD42747AB4F007933CB /* ApiEndpoint.swift */; };
@@ -1880,6 +1881,7 @@
 		B3DDC0CA2667824D00B2DFD1 /* RegularExpression+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RegularExpression+Extensions.swift"; sourceTree = "<group>"; };
 		B3DDDAAB24CAD6810014DF99 /* InsetLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetLabel.swift; sourceTree = "<group>"; };
 		B3DEAAA628AD01CA00F72D90 /* URLSession+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Extensions.swift"; sourceTree = "<group>"; };
+		B3DF44112A408339005AF766 /* test_item_attachment.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = test_item_attachment.json; sourceTree = "<group>"; };
 		B3DF9AD12747AAD2007933CB /* ApiRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiRequest.swift; sourceTree = "<group>"; };
 		B3DF9AD42747AB4F007933CB /* ApiEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiEndpoint.swift; sourceTree = "<group>"; };
 		B3DF9AD72747AB63007933CB /* ApiLogParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiLogParameters.swift; sourceTree = "<group>"; };
@@ -2766,6 +2768,7 @@
 				B3AAABD62502A40900031065 /* searchresponse_knownfields.json */,
 				B3AAABD52502A40600031065 /* searchresponse_unknownfields.json */,
 				B32A3C85248008A2009E2C5D /* test_collection.json */,
+				B3DF44112A408339005AF766 /* test_item_attachment.json */,
 				B32A3C87248008A2009E2C5D /* test_item.json */,
 				B32A3C84248008A2009E2C5D /* test_keys.json */,
 				B32A3C86248008A2009E2C5D /* test_search.json */,
@@ -4232,6 +4235,7 @@
 				B3B1EDFD2502498100D8BC1E /* collectionresponse_knownfields.json in Resources */,
 				B3B1EDF42502456000D8BC1E /* itemresponse_unknownfields.json in Resources */,
 				B32A3C8F248008A2009E2C5D /* translators_delete.xml in Resources */,
+				B3DF44122A408339005AF766 /* test_item_attachment.json in Resources */,
 				B32A3C8E248008A2009E2C5D /* test_item.json in Resources */,
 				B3B1EDFA2502493700D8BC1E /* Bundled in Resources */,
 				B3AAABD72502A40900031065 /* searchresponse_unknownfields.json in Resources */,

--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -452,6 +452,8 @@
 		B331F9B5265400D70099F6A6 /* ReadStylesDbRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B331F9B4265400D70099F6A6 /* ReadStylesDbRequest.swift */; };
 		B3325F6F27B41D69007C7137 /* CollectionTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3325F6E27B41D69007C7137 /* CollectionTree.swift */; };
 		B3343079282A563B00FB41BC /* NSUserActivity+Activities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3343078282A563B00FB41BC /* NSUserActivity+Activities.swift */; };
+		B336FE812A2F6D9E00B52F4A /* UploadFixSyncAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B336FE802A2F6D9E00B52F4A /* UploadFixSyncAction.swift */; };
+		B336FE822A2F6E8800B52F4A /* UploadFixSyncAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B336FE802A2F6D9E00B52F4A /* UploadFixSyncAction.swift */; };
 		B337283229F15AD4001F02CB /* FixSchemaIssueDbRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B337283129F15AD4001F02CB /* FixSchemaIssueDbRequest.swift */; };
 		B33791D723BF7B2A00919210 /* CreateItemWithAttachmentDbRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33791D623BF7B2900919210 /* CreateItemWithAttachmentDbRequest.swift */; };
 		B337A5A8244F1DEB00AFD13D /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = B337A5AA244F1DEB00AFD13D /* Localizable.strings */; };
@@ -1460,6 +1462,7 @@
 		B331F9B4265400D70099F6A6 /* ReadStylesDbRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadStylesDbRequest.swift; sourceTree = "<group>"; };
 		B3325F6E27B41D69007C7137 /* CollectionTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionTree.swift; sourceTree = "<group>"; };
 		B3343078282A563B00FB41BC /* NSUserActivity+Activities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSUserActivity+Activities.swift"; sourceTree = "<group>"; };
+		B336FE802A2F6D9E00B52F4A /* UploadFixSyncAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadFixSyncAction.swift; sourceTree = "<group>"; };
 		B337283129F15AD4001F02CB /* FixSchemaIssueDbRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixSchemaIssueDbRequest.swift; sourceTree = "<group>"; };
 		B33791D623BF7B2900919210 /* CreateItemWithAttachmentDbRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateItemWithAttachmentDbRequest.swift; sourceTree = "<group>"; };
 		B337A5A9244F1DEB00AFD13D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -2346,6 +2349,7 @@
 				B30564AC23FC051E003304F2 /* SyncSettingsSyncAction.swift */,
 				B30564A723FC051E003304F2 /* SyncVersionsSyncAction.swift */,
 				B30564A123FC051E003304F2 /* UploadAttachmentSyncAction.swift */,
+				B336FE802A2F6D9E00B52F4A /* UploadFixSyncAction.swift */,
 			);
 			path = SyncActions;
 			sourceTree = "<group>";
@@ -4434,6 +4438,7 @@
 				B331F9B5265400D70099F6A6 /* ReadStylesDbRequest.swift in Sources */,
 				B39D33712400150B00EF2ACB /* CreateAttachmentsDbRequest.swift in Sources */,
 				B3A081E125D2D8050088EC24 /* CollectionEditHostingViewController.swift in Sources */,
+				B336FE812A2F6D9E00B52F4A /* UploadFixSyncAction.swift in Sources */,
 				B3486B8B26CFAFEA0036A267 /* SingleCitationAction.swift in Sources */,
 				B3593F3C241A61C700760E20 /* ItemsSortType.swift in Sources */,
 				B372CEE92486748500B423AE /* MarkGroupForResyncSyncAction.swift in Sources */,
@@ -5157,6 +5162,7 @@
 				B3748D2026566F4800ED05F8 /* ContainerViewController.swift in Sources */,
 				B305676B23FC0A0B003304F2 /* Tag.swift in Sources */,
 				B305676C23FC0A0B003304F2 /* UpdatableObject.swift in Sources */,
+				B336FE822A2F6E8800B52F4A /* UploadFixSyncAction.swift in Sources */,
 				B3D84BEB27917D07005DDD7C /* CreatorTypes.swift in Sources */,
 				B305673D23FC09AF003304F2 /* LibraryResponse.swift in Sources */,
 				B325DBB324375DB100EFF0F5 /* ConflictResolution.swift in Sources */,

--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -956,6 +956,8 @@
 		B3D58D6725EE280300D8FA31 /* DebugResponseParserDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D58D6125EE26A600D8FA31 /* DebugResponseParserDelegate.swift */; };
 		B3D58D6B25EE437700D8FA31 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D58D6A25EE437700D8FA31 /* CircularProgressView.swift */; };
 		B3D58D7025EE43E700D8FA31 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D58D6A25EE437700D8FA31 /* CircularProgressView.swift */; };
+		B3D59F132A38A69100F6BB7D /* RevertLibraryFilesSyncAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D59F122A38A69100F6BB7D /* RevertLibraryFilesSyncAction.swift */; };
+		B3D59F142A38A6C100F6BB7D /* RevertLibraryFilesSyncAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D59F122A38A69100F6BB7D /* RevertLibraryFilesSyncAction.swift */; };
 		B3D84BEA27917BE1005DDD7C /* CreatorTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D84BE927917BE1005DDD7C /* CreatorTypes.swift */; };
 		B3D84BEB27917D07005DDD7C /* CreatorTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D84BE927917BE1005DDD7C /* CreatorTypes.swift */; };
 		B3D84BED27917E3D005DDD7C /* UpdateCreatorSummaryFormatDbRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D84BEC27917E3D005DDD7C /* UpdateCreatorSummaryFormatDbRequest.swift */; };
@@ -1856,6 +1858,7 @@
 		B3D58D5525ED856F00D8FA31 /* DebugLogUploadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogUploadRequest.swift; sourceTree = "<group>"; };
 		B3D58D6125EE26A600D8FA31 /* DebugResponseParserDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugResponseParserDelegate.swift; sourceTree = "<group>"; };
 		B3D58D6A25EE437700D8FA31 /* CircularProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
+		B3D59F122A38A69100F6BB7D /* RevertLibraryFilesSyncAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevertLibraryFilesSyncAction.swift; sourceTree = "<group>"; };
 		B3D84BE927917BE1005DDD7C /* CreatorTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatorTypes.swift; sourceTree = "<group>"; };
 		B3D84BEC27917E3D005DDD7C /* UpdateCreatorSummaryFormatDbRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCreatorSummaryFormatDbRequest.swift; sourceTree = "<group>"; };
 		B3DCDEE02408F5200039ED0D /* MainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
@@ -2341,6 +2344,7 @@
 				B372CEE82486748500B423AE /* MarkGroupForResyncSyncAction.swift */,
 				B3A081C325D2ADCD0088EC24 /* PerformDeletionsSyncAction.swift */,
 				B340868825D574D6000F4446 /* RestoreDeletionsSyncAction.swift */,
+				B3D59F122A38A69100F6BB7D /* RevertLibraryFilesSyncAction.swift */,
 				B30564B123FC051E003304F2 /* RevertLibraryUpdatesSyncAction.swift */,
 				B30564AE23FC051E003304F2 /* StoreVersionSyncAction.swift */,
 				B30564AD23FC051E003304F2 /* SubmitDeletionSyncAction.swift */,
@@ -4545,6 +4549,7 @@
 				B3C6D552261C9F2E0068B9FE /* PlaceholderTextViewDelegate.swift in Sources */,
 				B357A290285B74DF00E73CA1 /* ScannerActionHandler.swift in Sources */,
 				B3E8FE76271434F200F51458 /* GeneralSettingsView.swift in Sources */,
+				B3D59F132A38A69100F6BB7D /* RevertLibraryFilesSyncAction.swift in Sources */,
 				B30566C323FC051F003304F2 /* SyncObject.swift in Sources */,
 				B325DBAF24375D8D00EFF0F5 /* Conflict.swift in Sources */,
 				B3D84BEA27917BE1005DDD7C /* CreatorTypes.swift in Sources */,
@@ -5439,6 +5444,7 @@
 				B305672D23FC091A003304F2 /* MarkGroupAsLocalOnlySyncAction.swift in Sources */,
 				B3B8800A25FB590900904235 /* DeviceInfoProvider.swift in Sources */,
 				B30566FC23FC0862003304F2 /* MarkCollectionAndItemsAsDeletedDbRequest.swift in Sources */,
+				B3D59F142A38A6C100F6BB7D /* RevertLibraryFilesSyncAction.swift in Sources */,
 				B377F2A02493725E00022943 /* UrlDetector.swift in Sources */,
 				B305670A23FC08B5003304F2 /* ReadCollectionsDbRequest.swift in Sources */,
 				B305672A23FC0914003304F2 /* LoadUploadDataSyncAction.swift in Sources */,

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -51,6 +51,8 @@
 "scan_text" = "Scan Text";
 "move_to_trash" = "Move to Trash";
 "size" = "Size";
+"remove" = "Remove";
+"keep" = "Keep";
 
 "beta_wipe_title" = "Resync Required";
 "beta_wipe_message" = "Due to a beta update, your data must be redownloaded from zotero.org.";
@@ -382,6 +384,13 @@
 "errors.collections.empty_name" = "Please enter a collection name";
 "errors.collections.save_failed" = "Unable to save collection";
 "errors.collections.bibliography_failed" = "Could not load items for bibliography.";
+"errors.sync.group_removed" = "Group '%@' is no longer accessible. What would you like to do?";
+"errors.sync.metadata_write_denied" = "You can't write to group '%@' anymore. What would you like to do?";
+"errors.sync.keep_changes" = "Keep changes";
+"errors.sync.revert_to_original" = "Revert to original";
+"errors.sync.file_write_denied" = "You no longer have file-editing access for the group ‘%@’, and files you’ve changed locally cannot be uploaded. If you continue, all group files will be reset to their state on %@.\n\nIf you would like a chance to copy modified files elsewhere or to request file-editing access from a group administrator, you can skip syncing of the group now.";
+"errors.sync.reset_group_files" = "Reset Group Files and Sync";
+"errors.sync.skip_group" = "Skip Group";
 "errors.sync_toolbar.finished_with_errors" = "Finished sync (%@)";
 "errors.sync_toolbar.one_error" = "1 issue";
 "errors.sync_toolbar.multiple_errors" = "%d issues";

--- a/Zotero/Controllers/AnnotationConverter.swift
+++ b/Zotero/Controllers/AnnotationConverter.swift
@@ -44,7 +44,7 @@ struct AnnotationConverter {
         let textOffset = boundingBoxConverter?.textOffset(rect: rect, page: annotation.pageIndex) ?? 0
         let minY = boundingBoxConverter?.sortIndexMinY(rect: rect, page: annotation.pageIndex).flatMap({ Int(round($0)) }) ?? 0
         if minY < 0 {
-            DDLogWarn("AnnotationConverter: annotation \(annotation.key) has negative y position \(minY)")
+            DDLogWarn("AnnotationConverter: annotation \(String(describing: annotation.key)) has negative y position \(minY)")
         }
         return self.sortIndex(pageIndex: annotation.pageIndex, textOffset: textOffset, minY: minY)
     }

--- a/Zotero/Controllers/Background Uploader/BackgroundUploadObserver.swift
+++ b/Zotero/Controllers/Background Uploader/BackgroundUploadObserver.swift
@@ -40,7 +40,7 @@ final class BackgroundUploadObserver: NSObject {
         self.sessions = [:]
         self.finishedTasks = [:]
         self.completionHandlers = [:]
-        self.context = BackgroundUploaderContext()
+        self.context = context
         self.disposeBag = DisposeBag()
         self.shareExtensionSessionIdDisposeBag = DisposeBag()
         self.backgroundProcessingDisposeBag = DisposeBag()

--- a/Zotero/Controllers/Controllers.swift
+++ b/Zotero/Controllers/Controllers.swift
@@ -320,10 +320,10 @@ final class UserControllers {
         let backgroundUploadContext = BackgroundUploaderContext()
         let backgroundUploadProcessor = BackgroundUploadProcessor(apiClient: controllers.apiClient, dbStorage: dbStorage, fileStorage: controllers.fileStorage, webDavController: webDavController)
         let backgroundUploadObserver = BackgroundUploadObserver(context: backgroundUploadContext, processor: backgroundUploadProcessor, backgroundTaskController: controllers.backgroundTaskController)
-        let syncController = SyncController(userId: userId, apiClient: controllers.apiClient, dbStorage: dbStorage, fileStorage: controllers.fileStorage, schemaController: controllers.schemaController,
-                                            dateParser: controllers.dateParser, backgroundUploaderContext: backgroundUploadContext, webDavController: webDavController, syncDelayIntervals: DelayIntervals.sync,
-                                            conflictDelays: DelayIntervals.conflict)
         let fileDownloader = AttachmentDownloader(userId: userId, apiClient: controllers.apiClient, fileStorage: controllers.fileStorage, dbStorage: dbStorage, webDavController: webDavController)
+        let syncController = SyncController(userId: userId, apiClient: controllers.apiClient, dbStorage: dbStorage, fileStorage: controllers.fileStorage, schemaController: controllers.schemaController,
+                                            dateParser: controllers.dateParser, backgroundUploaderContext: backgroundUploadContext, webDavController: webDavController, attachmentDownloader: fileDownloader, syncDelayIntervals: DelayIntervals.sync,
+                                            conflictDelays: DelayIntervals.conflict)
         let webSocketController = WebSocketController(dbStorage: dbStorage, lowPowerModeController: controllers.lowPowerModeController)
         let fileCleanupController = AttachmentFileCleanupController(fileStorage: controllers.fileStorage, dbStorage: dbStorage)
 

--- a/Zotero/Controllers/Database/Requests/MarkAttachmentUploadedDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/MarkAttachmentUploadedDbRequest.swift
@@ -14,26 +14,14 @@ struct MarkAttachmentUploadedDbRequest: DbRequest {
     let libraryId: LibraryIdentifier
     let key: String
     let version: Int?
-    let md5: String?
 
     var needsWrite: Bool { return true }
-
-    init(libraryId: LibraryIdentifier, key: String, version: Int?, md5: String? = nil) {
-        self.libraryId = libraryId
-        self.key = key
-        self.version = version
-        self.md5 = md5
-    }
 
     func process(in database: Realm) throws {
         guard let attachment = database.objects(RItem.self).filter(.key(self.key, in: self.libraryId)).first else { return }
         attachment.attachmentNeedsSync = false
         attachment.changeType = .syncResponse
-        if let md5 = self.md5 {
-            let md5Field = attachment.fields.filter(.key(FieldKeys.Item.Attachment.md5)).first
-            md5Field?.value = md5
-            attachment.backendMd5 = md5
-        } else if let md5 = attachment.fields.filter(.key(FieldKeys.Item.Attachment.md5)).first?.value {
+        if let md5 = attachment.fields.filter(.key(FieldKeys.Item.Attachment.md5)).first?.value {
             attachment.backendMd5 = md5
         }
         if let version = self.version {

--- a/Zotero/Controllers/Database/Requests/MarkForResyncDbAction.swift
+++ b/Zotero/Controllers/Database/Requests/MarkForResyncDbAction.swift
@@ -25,7 +25,7 @@ struct MarkForResyncDbAction<Obj: SyncableObject&Updatable>: DbRequest {
         let syncDate = Date()
         var toCreate: [String] = self.keys
         let objects = database.objects(Obj.self).filter(.keys(self.keys, in: self.libraryId))
-        
+
         for object in objects {
             if object.syncState == .synced {
                 object.syncState = .outdated

--- a/Zotero/Controllers/Database/Requests/ReadAttachmentUploadsDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/ReadAttachmentUploadsDbRequest.swift
@@ -76,3 +76,15 @@ struct ReadAttachmentUploadsDbRequest: DbResponseRequest {
         return Array(uploads)
     }
 }
+
+struct ReadAllAttachmentUploadsDbRequest: DbResponseRequest {
+    typealias Response = Results<RItem>
+
+    let libraryId: LibraryIdentifier
+
+    var needsWrite: Bool { return false }
+
+    func process(in database: Realm) throws -> Results<RItem> {
+        return database.objects(RItem.self).filter(.library(with: libraryId)).filter(.item(type: ItemTypes.attachment)).filter(.attachmentNeedsUpload)
+    }
+}

--- a/Zotero/Controllers/Database/Requests/StoreItemsDbResponseRequest.swift
+++ b/Zotero/Controllers/Database/Requests/StoreItemsDbResponseRequest.swift
@@ -93,6 +93,7 @@ struct StoreItemDbRequest: DbResponseRequest {
         if self.preferRemoteData {
             item.deleted = false
             item.deleteAllChanges(database: database)
+            item.attachmentNeedsSync = false
         }
 
         return StoreItemDbRequest.update(item: item, libraryId: libraryId, with: self.response, schemaController: self.schemaController, dateParser: self.dateParser, database: database)

--- a/Zotero/Controllers/Database/Requests/SyncVersionsDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/SyncVersionsDbRequest.swift
@@ -16,7 +16,7 @@ struct SyncVersionsDbRequest: DbResponseRequest {
     let versions: [String: Int]
     let libraryId: LibraryIdentifier
     let syncObject: SyncObject
-    let syncType: SyncController.SyncType
+    let syncType: SyncController.Kind
     let delayIntervals: [Double]
 
     var needsWrite: Bool { return false }

--- a/Zotero/Controllers/Database/Requests/SyncVersionsDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/SyncVersionsDbRequest.swift
@@ -60,7 +60,7 @@ struct SyncVersionsDbRequest: DbResponseRequest {
                 guard !toUpdate.contains(object.key) else { continue }
                 toUpdate.append(object.key)
 
-            case .collectionsOnly, .normal, .keysOnly:
+            case .collectionsOnly, .normal, .keysOnly, .prioritizeDownloads:
                 // Check backoff schedule to see whether object can be synced again
                 let delayIdx = min(object.syncRetries, (self.delayIntervals.count - 1))
                 let delay = self.delayIntervals[delayIdx]

--- a/Zotero/Controllers/Sync/SyncActions/LoadLibraryDataSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/LoadLibraryDataSyncAction.swift
@@ -13,7 +13,7 @@ import RxSwift
 struct LoadLibraryDataSyncAction: SyncAction {
     typealias Result = [LibraryData]
 
-    let type: SyncController.LibrarySyncType
+    let type: SyncController.Libraries
     let fetchUpdates: Bool
     let loadVersions: Bool
     let webDavEnabled: Bool

--- a/Zotero/Controllers/Sync/SyncActions/RevertLibraryFilesSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/RevertLibraryFilesSyncAction.swift
@@ -95,6 +95,7 @@ struct RevertLibraryFilesSyncAction: SyncAction {
                 DDLogWarn("RevertLibraryFilesSyncAction: can't rename file - \(error)")
                 // If it can't be moved, at least delete the old one. It'll have to be re-downloaded anyway.
                 try? self.fileStorage.remove(oldFile)
+                try? self.fileStorage.remove(newFile)
             }
         }
     }

--- a/Zotero/Controllers/Sync/SyncActions/RevertLibraryFilesSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/RevertLibraryFilesSyncAction.swift
@@ -1,0 +1,101 @@
+//
+//  RevertLibraryFilesSyncAction.swift
+//  Zotero
+//
+//  Created by Michal Rentka on 13.06.2023.
+//  Copyright © 2023 Corporation for Digital Scholarship. All rights reserved.
+//
+
+import Foundation
+
+import CocoaLumberjackSwift
+import RxSwift
+
+struct RevertLibraryFilesSyncAction: SyncAction {
+    typealias Result = [String]
+
+    let libraryId: LibraryIdentifier
+
+    unowned let dbStorage: DbStorage
+    unowned let fileStorage: FileStorage
+    unowned let schemaController: SchemaController
+    unowned let dateParser: DateParser
+    let queue: DispatchQueue
+
+    var result: Single<[String]> {
+        return Single.create { subscriber -> Disposable in
+            DDLogInfo("RevertLibraryFilesSyncAction: revert files to upload")
+
+            do {
+                let toUpload = try self.dbStorage.perform(request: ReadAllAttachmentUploadsDbRequest(libraryId: self.libraryId), on: self.queue)
+                var cachedResponses: [ItemResponse] = []
+                var failedKeys: [String] = []
+
+                for item in toUpload {
+                    do {
+                        let file = Files.jsonCacheFile(for: .item, libraryId: self.libraryId, key: item.key)
+                        let data = try self.fileStorage.read(file)
+                        let jsonObject = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
+
+                        if let jsonData = jsonObject as? [String: Any] {
+                            let response = try ItemResponse(response: jsonData, schemaController: self.schemaController)
+                            cachedResponses.append(response)
+                        } else {
+                            failedKeys.append(item.key)
+                        }
+                    } catch let error {
+                        DDLogError("RevertLibraryFilesSyncAction: can't load cached file - \(error)")
+                        failedKeys.append(item.key)
+                    }
+                }
+
+                DDLogInfo("RevertLibraryFilesSyncAction: loaded \(cachedResponses.count) cached items, missing \(failedKeys.count)")
+                
+                DDLogInfo("RevertLibraryFilesSyncAction: delete files which were not uploaded yet")
+                for key in failedKeys {
+                    let file = Files.attachmentDirectory(in: self.libraryId, key: key)
+                    try? self.fileStorage.remove(file)
+                }
+
+                var changedFilenames: [StoreItemsResponse.FilenameChange] = []
+                try self.dbStorage.perform(on: self.queue) { coordinator in
+                    // Delete items that didn't sync before and weren't submitted to backend
+                    DDLogError("RevertLibraryFilesSyncAction: delete failed keys")
+                    try coordinator.perform(request: DeleteObjectsDbRequest<RItem>(keys: failedKeys, libraryId: self.libraryId))
+                    // Store cached objects from backend to local database to get rid of local changes.
+                    DDLogError("RevertLibraryFilesSyncAction: restore cached objects")
+                    let request = StoreItemsDbResponseRequest(responses: cachedResponses, schemaController: self.schemaController, dateParser: self.dateParser, preferResponseData: true)
+                    changedFilenames = try coordinator.perform(request: request).changedFilenames
+                    coordinator.invalidate()
+                }
+
+                DDLogError("RevertLibraryFilesSyncAction: rename local files to match file names")
+                self.renameExistingFiles(changes: changedFilenames, libraryId: self.libraryId)
+
+                subscriber(.success(failedKeys))
+            } catch let error {
+                subscriber(.failure(error))
+            }
+
+            return Disposables.create()
+        }
+    }
+
+    private func renameExistingFiles(changes: [StoreItemsResponse.FilenameChange], libraryId: LibraryIdentifier) {
+        for change in changes {
+            let oldFile = Files.attachmentFile(in: libraryId, key: change.key, filename: change.oldName, contentType: change.contentType)
+
+            guard self.fileStorage.has(oldFile) else { continue }
+
+            let newFile = Files.attachmentFile(in: libraryId, key: change.key, filename: change.newName, contentType: change.contentType)
+
+            do {
+                try self.fileStorage.move(from: oldFile, to: newFile)
+            } catch let error {
+                DDLogWarn("RevertLibraryFilesSyncAction: can't rename file - \(error)")
+                // If it can't be moved, at least delete the old one. It'll have to be re-downloaded anyway.
+                try? self.fileStorage.remove(oldFile)
+            }
+        }
+    }
+}

--- a/Zotero/Controllers/Sync/SyncActions/RevertLibraryFilesSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/RevertLibraryFilesSyncAction.swift
@@ -12,7 +12,7 @@ import CocoaLumberjackSwift
 import RxSwift
 
 struct RevertLibraryFilesSyncAction: SyncAction {
-    typealias Result = [String]
+    typealias Result = ()
 
     let libraryId: LibraryIdentifier
 
@@ -22,7 +22,7 @@ struct RevertLibraryFilesSyncAction: SyncAction {
     unowned let dateParser: DateParser
     let queue: DispatchQueue
 
-    var result: Single<[String]> {
+    var result: Single<()> {
         return Single.create { subscriber -> Disposable in
             DDLogInfo("RevertLibraryFilesSyncAction: revert files to upload")
 
@@ -72,7 +72,7 @@ struct RevertLibraryFilesSyncAction: SyncAction {
                 DDLogError("RevertLibraryFilesSyncAction: rename local files to match file names")
                 self.renameExistingFiles(changes: changedFilenames, libraryId: self.libraryId)
 
-                subscriber(.success(failedKeys))
+                subscriber(.success(()))
             } catch let error {
                 subscriber(.failure(error))
             }

--- a/Zotero/Controllers/Sync/SyncActions/SubmitUpdateSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/SubmitUpdateSyncAction.swift
@@ -130,7 +130,7 @@ struct SubmitUpdateSyncAction: SyncAction {
             switch response.code {
             case 412:
                 DDLogError("SubmitUpdateSyncAction: failed \(response.key ?? "unknown key") - \(response.message). Library \(libraryId)")
-                return PreconditionErrorType.objectConflict
+                return SyncActionError.objectPreconditionError
 
             case 400 where response.message.contains(self.splitMessage):
                 if let key = response.key {

--- a/Zotero/Controllers/Sync/SyncActions/SyncVersionsSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/SyncVersionsSyncAction.swift
@@ -87,7 +87,7 @@ struct SyncVersionsSyncAction: SyncAction {
                     switch syncType {
                     case .full:
                         try coordinator.perform(request: MarkOtherObjectsAsChangedByUser(syncObject: object, versions: response, libraryId: libraryId))
-                    case .collectionsOnly, .ignoreIndividualDelays, .normal, .keysOnly: break
+                    case .collectionsOnly, .ignoreIndividualDelays, .normal, .keysOnly, .prioritizeDownloads: break
                     }
 
                     let request = SyncVersionsDbRequest(versions: response, libraryId: libraryId, syncObject: object, syncType: syncType, delayIntervals: delayIntervals)

--- a/Zotero/Controllers/Sync/SyncActions/SyncVersionsSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/SyncVersionsSyncAction.swift
@@ -17,7 +17,7 @@ struct SyncVersionsSyncAction: SyncAction {
     let object: SyncObject
     let sinceVersion: Int?
     let currentVersion: Int?
-    let syncType: SyncController.SyncType
+    let syncType: SyncController.Kind
     let libraryId: LibraryIdentifier
     let userId: Int
     let syncDelayIntervals: [Double]
@@ -52,7 +52,7 @@ struct SyncVersionsSyncAction: SyncAction {
     }
 
     private func synchronizeVersions<Obj: SyncableObject & Deletable & Updatable>(for type: Obj.Type, libraryId: LibraryIdentifier, userId: Int, object: SyncObject, since sinceVersion: Int?,
-                                                                                  current currentVersion: Int?, syncType: SyncController.SyncType) -> Single<(Int, [String])> {
+                                                                                  current currentVersion: Int?, syncType: SyncController.Kind) -> Single<(Int, [String])> {
         if !self.checkRemote && self.syncType != .full {
             return self.loadChangedObjects(for: object, from: [:], in: libraryId, syncType: syncType, newVersion: (currentVersion ?? 0), delayIntervals: self.syncDelayIntervals)
                        .observe(on: self.scheduler)
@@ -71,13 +71,13 @@ struct SyncVersionsSyncAction: SyncAction {
                    }
     }
 
-    private func loadRemoteVersions(for object: SyncObject, in libraryId: LibraryIdentifier, userId: Int, since sinceVersion: Int?, syncType: SyncController.SyncType)
+    private func loadRemoteVersions(for object: SyncObject, in libraryId: LibraryIdentifier, userId: Int, since sinceVersion: Int?, syncType: SyncController.Kind)
                                                                                                                                                            -> Single<([String: Int], HTTPURLResponse)> {
         let request = VersionsRequest(libraryId: libraryId, userId: userId, objectType: object, version: sinceVersion)
         return self.apiClient.send(request: request, queue: self.queue)
     }
 
-    private func loadChangedObjects(for object: SyncObject, from response: [String: Int], in libraryId: LibraryIdentifier, syncType: SyncController.SyncType, newVersion: Int, delayIntervals: [Double])
+    private func loadChangedObjects(for object: SyncObject, from response: [String: Int], in libraryId: LibraryIdentifier, syncType: SyncController.Kind, newVersion: Int, delayIntervals: [Double])
                                                                                                                                                                             -> Single<(Int, [String])> {
         return Single.create { subscriber -> Disposable in
             do {

--- a/Zotero/Controllers/Sync/SyncActions/UploadFixSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/UploadFixSyncAction.swift
@@ -61,6 +61,7 @@ class UploadFixSyncAction: SyncAction {
                 case .failed(let error):
                     self.finishDownload?(.failure(error))
                     self.finishDownload = nil
+
                 case .ready:
                     self.finishDownload?(.success(()))
                     self.finishDownload = nil
@@ -81,7 +82,7 @@ class UploadFixSyncAction: SyncAction {
 
     private func markAsUploaded(attachment: Attachment) -> Single<()> {
         return Single.create { [weak self] subscriber in
-            guard let `self` = self else {
+            guard let self else {
                 subscriber(.failure(Error.expired))
                 return Disposables.create()
             }
@@ -103,7 +104,7 @@ class UploadFixSyncAction: SyncAction {
 
     private func download(attachment: Attachment) -> Single<()> {
         return Single.create { [weak self] subscriber in
-            guard let `self` = self else {
+            guard let self else {
                 subscriber(.failure(Error.expired))
                 return Disposables.create()
             }
@@ -116,7 +117,7 @@ class UploadFixSyncAction: SyncAction {
 
     private func fetchAndValidateAttachment() -> Single<Attachment> {
         return Single.create { [weak self] subscriber in
-            guard let `self` = self else {
+            guard let self else {
                 subscriber(.failure(Error.expired))
                 return Disposables.create()
             }

--- a/Zotero/Controllers/Sync/SyncActions/UploadFixSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/UploadFixSyncAction.swift
@@ -60,8 +60,10 @@ class UploadFixSyncAction: SyncAction {
                 switch update.kind {
                 case .failed(let error):
                     self.finishDownload?(.failure(error))
+                    self.finishDownload = nil
                 case .ready:
                     self.finishDownload?(.success(()))
+                    self.finishDownload = nil
                 case .progress, .cancelled: break
                 }
             })

--- a/Zotero/Controllers/Sync/SyncActions/UploadFixSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/UploadFixSyncAction.swift
@@ -65,7 +65,9 @@ class UploadFixSyncAction: SyncAction {
                 case .ready:
                     self.finishDownload?(.success(()))
                     self.finishDownload = nil
-                case .progress, .cancelled: break
+                    
+                case .progress, .cancelled:
+                    break
                 }
             })
             .disposed(by: self.downloadDisposeBag)
@@ -147,15 +149,17 @@ class UploadFixSyncAction: SyncAction {
                         case .remoteMissing:
                             DDLogError("UploadFixSyncAction: attachment missing remotely")
                             subscriber(.failure(Error.attachmentMissingRemotely))
-                            return Disposables.create()
 
-                        case .local, .localAndChangedRemotely, .remote: break
+                        case .local, .localAndChangedRemotely, .remote:
+                            // Create new attachment model with updated location so that `AttachmentDownloader` doesn't ignore it
+                            let newAttachment = Attachment(
+                                type: .file(filename: filename, contentType: contentType, location: .remote, linkType: linkType),
+                                title: attachment.title,
+                                key: attachment.key,
+                                libraryId: attachment.libraryId
+                            )
+                            subscriber(.success(newAttachment))
                         }
-
-                        // Create new attachment model with updated location so that `AttachmentDownloader` doesn't ignore it
-                        let newAttachment = Attachment(type: .file(filename: filename, contentType: contentType, location: .remote, linkType: linkType),
-                                                       title: attachment.title, key: attachment.key, libraryId: attachment.libraryId)
-                        subscriber(.success(newAttachment))
                     }
                 }
             } catch let error {

--- a/Zotero/Controllers/Sync/SyncActions/UploadFixSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/UploadFixSyncAction.swift
@@ -12,13 +12,21 @@ import Alamofire
 import CocoaLumberjackSwift
 import RxSwift
 
-struct UploadFixSyncAction: SyncAction {
+class UploadFixSyncAction: SyncAction {
     typealias Result = ()
+
+    enum Error: Swift.Error {
+        case attachmentMissingRemotely
+        case fileNotDownloaded
+        case itemNotAttachment
+        case incorrectAttachmentType(Attachment.Kind)
+        case incorrectLinkType(Attachment.FileLinkType)
+        case expired
+    }
 
     let key: String
     let libraryId: LibraryIdentifier
     let userId: Int
-
     unowned let attachmentDownloader: AttachmentDownloader
     unowned let fileStorage: FileStorage
     unowned let dbStorage: DbStorage
@@ -26,65 +34,123 @@ struct UploadFixSyncAction: SyncAction {
     let scheduler: SchedulerType
     private let downloadDisposeBag: DisposeBag
 
+    private var finishDownload: ((Swift.Result<(), Swift.Error>) -> Void)?
+
+    init(key: String, libraryId: LibraryIdentifier, userId: Int, attachmentDownloader: AttachmentDownloader, fileStorage: FileStorage, dbStorage: DbStorage, queue: DispatchQueue, scheduler: SchedulerType) {
+        self.key = key
+        self.libraryId = libraryId
+        self.userId = userId
+        self.attachmentDownloader = attachmentDownloader
+        self.fileStorage = fileStorage
+        self.dbStorage = dbStorage
+        self.queue = queue
+        self.scheduler = scheduler
+        self.downloadDisposeBag = DisposeBag()
+    }
+
     var result: Single<()> {
         DDLogInfo("UploadFixSyncAction: fix upload for \(self.key); \(self.libraryId)")
 
-        self.attachmentDownloader.observable.observe(on: self.scheduler).subscribe(with: self, onNext: { `self`, update in
+        self.attachmentDownloader
+            .observable
+            .observe(on: self.scheduler)
+            .subscribe(with: self, onNext: { `self`, update in
+                guard update.key == self.key && update.libraryId == self.libraryId else { return }
 
-        })
+                switch update.kind {
+                case .failed(let error):
+                    self.finishDownload?(.failure(error))
+                case .ready:
+                    self.finishDownload?(.success(()))
+                case .progress, .cancelled: break
+                }
+            })
+            .disposed(by: self.downloadDisposeBag)
 
         return self.fetchAndValidateAttachment()
                    .subscribe(on: self.scheduler)
+                   .flatMap({ attachment -> Single<Attachment> in
+                       return self.download(attachment: attachment).flatMap({ Single.just(attachment) })
+                   })
                    .flatMap({ attachment in
-                       return self.download(attachment: attachment)
+                       return self.markAsUploaded(attachment: attachment)
                    })
     }
 
     private func markAsUploaded(attachment: Attachment) -> Single<()> {
+        return Single.create { [weak self] subscriber in
+            guard let `self` = self, case .file(let filename, let contentType, _, _) = attachment.type else {
+                subscriber(.failure(Error.incorrectAttachmentType(attachment.type)))
+                return Disposables.create()
+            }
 
+            let file = Files.attachmentFile(in: attachment.libraryId, key: attachment.key, filename: filename, contentType: contentType)
+            guard let md5 = md5(from: file.createUrl()) else {
+                subscriber(.failure(Error.fileNotDownloaded))
+                return Disposables.create()
+            }
+
+            let request = MarkAttachmentUploadedDbRequest(libraryId: self.libraryId, key: self.key, version: nil, md5: md5)
+
+            do {
+                try self.dbStorage.perform(request: request, on: self.queue)
+                subscriber(.success(()))
+            } catch let error {
+                subscriber(.failure(error))
+            }
+
+            return Disposables.create()
+        }
     }
 
     private func download(attachment: Attachment) -> Single<()> {
-        return Single.create { subscriber in
-            self.attachmentDownloader.downloadIfNeeded(attachment: <#T##Attachment#>, parentKey: <#T##String?#>)
+        return Single.create { [weak self] subscriber in
+            guard let `self` = self else {
+                subscriber(.failure(Error.expired))
+                return Disposables.create()
+            }
+
+            self.finishDownload = subscriber
+            self.attachmentDownloader.downloadIfNeeded(attachment: attachment, parentKey: nil)
+            return Disposables.create()
         }
     }
 
     private func fetchAndValidateAttachment() -> Single<Attachment> {
-        return Single.create { subscriber in
+        return Single.create { [weak self] subscriber in
+            guard let `self` = self else {
+                subscriber(.failure(Error.expired))
+                return Disposables.create()
+            }
+
             do {
                 let item = try self.dbStorage.perform(request: ReadItemDbRequest(libraryId: self.libraryId, key: self.key), on: self.queue)
 
                 guard item.rawType == ItemTypes.attachment, let attachment = AttachmentCreator.attachment(for: item, options: .light, fileStorage: self.fileStorage, urlDetector: nil) else {
-                    DDLogError("UploadFixSyncAction: item not attachment")
-                    subscriber(.failure(SyncError.Fatal.preconditionErrorCantBeResolved(data: SyncError.ErrorData(itemKeys: [self.key], libraryId: self.libraryId))))
+                    DDLogError("UploadFixSyncAction: item not attachment - \(item.rawType)")
+                    subscriber(.failure(Error.itemNotAttachment))
                     return Disposables.create()
                 }
 
                 switch attachment.type {
                 case .url:
                     DDLogError("UploadFixSyncAction: incorrect item type - \(attachment.type)")
-                    subscriber(.failure(SyncError.Fatal.preconditionErrorCantBeResolved(data: SyncError.ErrorData(itemKeys: [self.key], libraryId: self.libraryId))))
+                    subscriber(.failure(Error.incorrectAttachmentType(attachment.type)))
 
                 case .file(let filename, let contentType, let location, let linkType):
                     switch linkType {
                     case .embeddedImage, .linkedFile:
                         DDLogError("UploadFixSyncAction: incorrect link type - \(linkType)")
-                        subscriber(.failure(SyncError.Fatal.preconditionErrorCantBeResolved(data: SyncError.ErrorData(itemKeys: [self.key], libraryId: self.libraryId))))
+                        subscriber(.failure(Error.incorrectLinkType(linkType)))
 
                     case .importedFile, .importedUrl:
                         switch location {
                         case .remoteMissing:
                             DDLogError("UploadFixSyncAction: attachment missing remotely")
-                            subscriber(.failure(SyncError.Fatal.preconditionErrorCantBeResolved(data: SyncError.ErrorData(itemKeys: [self.key], libraryId: self.libraryId))))
+                            subscriber(.failure(Error.attachmentMissingRemotely))
                             return Disposables.create()
 
-                        case .local, .localAndChangedRemotely:
-                            // Remove local file if available
-                            let file = Files.attachmentFile(in: self.libraryId, key: self.key, filename: filename, contentType: contentType)
-                            try? self.fileStorage.remove(file)
-
-                        case .remote: break
+                        case .local, .localAndChangedRemotely, .remote: break
                         }
 
                         // Create new attachment model with updated location so that `AttachmentDownloader` doesn't ignore it

--- a/Zotero/Controllers/Sync/SyncActions/UploadFixSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/UploadFixSyncAction.swift
@@ -1,0 +1,103 @@
+//
+//  UploadFixSyncAction.swift
+//  Zotero
+//
+//  Created by Michal Rentka on 06.06.2023.
+//  Copyright © 2023 Corporation for Digital Scholarship. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+import CocoaLumberjackSwift
+import RxSwift
+
+struct UploadFixSyncAction: SyncAction {
+    typealias Result = ()
+
+    let key: String
+    let libraryId: LibraryIdentifier
+    let userId: Int
+
+    unowned let attachmentDownloader: AttachmentDownloader
+    unowned let fileStorage: FileStorage
+    unowned let dbStorage: DbStorage
+    let queue: DispatchQueue
+    let scheduler: SchedulerType
+    private let downloadDisposeBag: DisposeBag
+
+    var result: Single<()> {
+        DDLogInfo("UploadFixSyncAction: fix upload for \(self.key); \(self.libraryId)")
+
+        self.attachmentDownloader.observable.observe(on: self.scheduler).subscribe(with: self, onNext: { `self`, update in
+
+        })
+
+        return self.fetchAndValidateAttachment()
+                   .subscribe(on: self.scheduler)
+                   .flatMap({ attachment in
+                       return self.download(attachment: attachment)
+                   })
+    }
+
+    private func markAsUploaded(attachment: Attachment) -> Single<()> {
+
+    }
+
+    private func download(attachment: Attachment) -> Single<()> {
+        return Single.create { subscriber in
+            self.attachmentDownloader.downloadIfNeeded(attachment: <#T##Attachment#>, parentKey: <#T##String?#>)
+        }
+    }
+
+    private func fetchAndValidateAttachment() -> Single<Attachment> {
+        return Single.create { subscriber in
+            do {
+                let item = try self.dbStorage.perform(request: ReadItemDbRequest(libraryId: self.libraryId, key: self.key), on: self.queue)
+
+                guard item.rawType == ItemTypes.attachment, let attachment = AttachmentCreator.attachment(for: item, options: .light, fileStorage: self.fileStorage, urlDetector: nil) else {
+                    DDLogError("UploadFixSyncAction: item not attachment")
+                    subscriber(.failure(SyncError.Fatal.preconditionErrorCantBeResolved(data: SyncError.ErrorData(itemKeys: [self.key], libraryId: self.libraryId))))
+                    return Disposables.create()
+                }
+
+                switch attachment.type {
+                case .url:
+                    DDLogError("UploadFixSyncAction: incorrect item type - \(attachment.type)")
+                    subscriber(.failure(SyncError.Fatal.preconditionErrorCantBeResolved(data: SyncError.ErrorData(itemKeys: [self.key], libraryId: self.libraryId))))
+
+                case .file(let filename, let contentType, let location, let linkType):
+                    switch linkType {
+                    case .embeddedImage, .linkedFile:
+                        DDLogError("UploadFixSyncAction: incorrect link type - \(linkType)")
+                        subscriber(.failure(SyncError.Fatal.preconditionErrorCantBeResolved(data: SyncError.ErrorData(itemKeys: [self.key], libraryId: self.libraryId))))
+
+                    case .importedFile, .importedUrl:
+                        switch location {
+                        case .remoteMissing:
+                            DDLogError("UploadFixSyncAction: attachment missing remotely")
+                            subscriber(.failure(SyncError.Fatal.preconditionErrorCantBeResolved(data: SyncError.ErrorData(itemKeys: [self.key], libraryId: self.libraryId))))
+                            return Disposables.create()
+
+                        case .local, .localAndChangedRemotely:
+                            // Remove local file if available
+                            let file = Files.attachmentFile(in: self.libraryId, key: self.key, filename: filename, contentType: contentType)
+                            try? self.fileStorage.remove(file)
+
+                        case .remote: break
+                        }
+
+                        // Create new attachment model with updated location so that `AttachmentDownloader` doesn't ignore it
+                        let newAttachment = Attachment(type: .file(filename: filename, contentType: contentType, location: .remote, linkType: linkType),
+                                                       title: attachment.title, key: attachment.key, libraryId: attachment.libraryId)
+                        subscriber(.success(newAttachment))
+                    }
+                }
+            } catch let error {
+                subscriber(.failure(error))
+            }
+
+            return Disposables.create()
+        }
+    }
+}

--- a/Zotero/Controllers/Sync/SyncController.swift
+++ b/Zotero/Controllers/Sync/SyncController.swift
@@ -223,7 +223,6 @@ final class SyncController: SynchronizationController {
     // MARK: - Testing
 
     var reportFinish: ((Result<([Action], [Error]), Error>) -> Void)?
-    var reportDelay: ((Int) -> Void)?
     private var allActions: [Action] = []
 
     // MARK: - Lifecycle
@@ -332,9 +331,10 @@ final class SyncController: SynchronizationController {
             DDLogInfo("Errors: \(self.nonFatalErrors)")
         }
 
-        self.reportFinish?(.success((self.allActions, self.nonFatalErrors)))
+        // Call finishAction after clearing `reportFinish` because tests may want to re-try through this closure when testing only `SyncController`
+        let finishAction = self.reportFinish
         self.reportFinish = nil
-        self.reportDelay = nil
+        finishAction?(.success((self.allActions, self.nonFatalErrors)))
 
         self.reportFinish(nonFatalErrors: self.nonFatalErrors)
         self.cleanup()
@@ -346,9 +346,10 @@ final class SyncController: SynchronizationController {
         DDLogInfo("Sync: aborted")
         DDLogInfo("Error: \(error)")
 
-        self.reportFinish?(.failure(error))
+        // Call finishAction after clearing `reportFinish` because tests may want to re-try through this closure when testing only `SyncController`
+        let finishAction = self.reportFinish
         self.reportFinish = nil
-        self.reportDelay = nil
+        finishAction?(.failure(error))
 
         self.report(fatalError: error)
         self.cleanup()

--- a/Zotero/Controllers/Sync/SyncScheduler.swift
+++ b/Zotero/Controllers/Sync/SyncScheduler.swift
@@ -13,9 +13,9 @@ import RxSwift
 
 protocol SynchronizationScheduler: AnyObject {
     var syncController: SynchronizationController { get }
+    var inProgress: BehaviorRelay<Bool> { get }
 
-    func request(sync type: SyncController.SyncType, libraries: SyncController.LibrarySyncType)
-    func request(sync type: SyncController.SyncType, libraries: SyncController.LibrarySyncType, applyDelay: Bool)
+    func request(sync type: SyncController.Kind, libraries: SyncController.Libraries)
     func cancelSync()
 }
 
@@ -23,74 +23,83 @@ protocol WebSocketScheduler: AnyObject {
     func webSocketUpdate(libraryId: LibraryIdentifier)
 }
 
-struct SyncSchedulerAction {
-    let syncType: SyncController.SyncType
-    let librarySyncType: SyncController.LibrarySyncType
-    let retryAttempt: Int
-    let retryOnce: Bool
-}
-
 final class SyncScheduler: SynchronizationScheduler, WebSocketScheduler {
-    /// Timeout in which a new `LibrarySyncType.specific` is started. It's required so that local changes are not submitted immediately or in case of multiple quick changes we don't enqueue multiple syncs.
-    private static let timeout: RxTimeInterval = .seconds(3)
+    struct Sync {
+        let type: SyncController.Kind
+        let libraries: SyncController.Libraries
+        let retryAttempt: Int
+        let retryOnce: Bool
+
+        init(type: SyncController.Kind, libraries: SyncController.Libraries, retryAttempt: Int = 0, retryOnce: Bool = false) {
+            self.type = type
+            self.libraries = libraries
+            self.retryAttempt = retryAttempt
+            self.retryOnce = retryOnce
+        }
+    }
+
+    // Minimum time between syncs
+    private static let syncTimeout: Int = 3000 // 3s
+    // Minimum time between full syncs
     private static let fullSyncTimeout: Double = 3600 // 1 hour
     let syncController: SynchronizationController
+    // Intervals in which retry attempts should be scheduled
+    private let retryIntervals: [Int]
     private let queue: DispatchQueue
     private let scheduler: SerialDispatchQueueScheduler
     private let disposeBag: DisposeBag
 
-    private var inProgress: SyncSchedulerAction?
-    private var nextAction: SyncSchedulerAction?
-    private(set) var lastSyncDate: Date?
-    private var lastFullSyncDate: Date?
+    private var syncInProgress: Sync?
+    private var syncQueue: [Sync]
+    private var lastSyncFinishDate: Date
+    private var lastFullSyncDate: Date
     private var timerDisposeBag: DisposeBag
 
     private var canPerformFullSync: Bool {
-        guard let date = self.lastFullSyncDate else { return true }
-        return Date().timeIntervalSince(date) <= SyncScheduler.fullSyncTimeout
+        return Date().timeIntervalSince(self.lastFullSyncDate) > SyncScheduler.fullSyncTimeout
     }
 
-    init(controller: SyncController) {
-        self.syncController = controller
+    var inProgress: BehaviorRelay<Bool>
+
+    init(controller: SyncController, retryIntervals: [Int]) {
         let queue = DispatchQueue(label: "org.zotero.SchedulerAccessQueue", qos: .utility, attributes: .concurrent)
+
+        self.syncController = controller
+        self.retryIntervals = retryIntervals
         self.queue = queue
+        self.inProgress = BehaviorRelay(value: false)
+        self.syncQueue = []
+        self.lastSyncFinishDate = Date(timeIntervalSince1970: 0)
+        self.lastFullSyncDate = Date(timeIntervalSince1970: 0)
         self.scheduler = SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: "org.zotero.SchedulerAccessQueue")
         self.disposeBag = DisposeBag()
         self.timerDisposeBag = DisposeBag()
 
         controller.observable
                   .observe(on: self.scheduler)
-                  .subscribe(onNext: { [weak self] data in
-                      self?.inProgress = nil
-                      if let data = data { // We're retrying, enqueue the new sync
-                          self?._enqueueAndStartTimer(action: data)
-                      } else if self?.nextAction != nil {
-                          // We're not retrying, start timer so that next in queue is processed
-                          self?.startTimer()
-                      }
-                  }, onError: { [weak self] _ in
-                      self?.inProgress = nil
-                      if self?.nextAction != nil {
-                          self?.startTimer()
+                  .subscribe(onNext: { [weak self] sync in
+                      guard let self else { return }
+
+                      self.syncInProgress = nil
+                      self.lastSyncFinishDate = Date()
+
+                      if let sync = sync {
+                          // We're retrying, enqueue the new sync
+                          self.enqueueAndStart(sync: sync)
+                      } else if !self.syncQueue.isEmpty {
+                          // We're not retrying, process next action
+                          self.startNextSync()
                       }
                   })
                   .disposed(by: self.disposeBag)
     }
 
-    func request(sync type: SyncController.SyncType, libraries: SyncController.LibrarySyncType) {
-        self.request(sync: type, libraries: libraries, applyDelay: false)
-    }
-
-    func request(sync type: SyncController.SyncType, libraries: SyncController.LibrarySyncType, applyDelay: Bool) {
-        if applyDelay {
-            self.enqueueAndStartTimer(action: (type, libraries))
-        } else {
-            self.enqueueAndStart(action: (type, libraries))
-        }
+    func request(sync type: SyncController.Kind, libraries: SyncController.Libraries) {
+        self.enqueueAndStart(sync: Sync(type: type, libraries: libraries))
     }
 
     func webSocketUpdate(libraryId: LibraryIdentifier) {
-        self.enqueueAndStartTimer(action: SyncSchedulerAction(syncType: .normal, librarySyncType: .specific([libraryId]), retryCount: 0))
+        self.enqueueAndStart(sync: Sync(type: .normal, libraries: .specific([libraryId])))
     }
 
     func cancelSync() {
@@ -98,97 +107,83 @@ final class SyncScheduler: SynchronizationScheduler, WebSocketScheduler {
             guard let self = self else { return }
             self.syncController.cancel()
             self.timerDisposeBag = DisposeBag()
-            self.inProgress = nil
-            self.nextAction = nil
+            self.syncInProgress = nil
+            self.syncQueue = []
         }
     }
 
-    private func enqueueAndStart(action: SyncSchedulerAction) {
+    private func enqueueAndStart(sync: Sync) {
         self.queue.async(flags: .barrier) { [weak self] in
-            self?._enqueueAndStart(action: action)
+            guard let self else { return }
+            self.enqueue(sync: sync)
+            self.startNextSync()
         }
     }
 
-    private func _enqueueAndStart(action: SyncSchedulerAction) {
-        guard action.syncType != .full || self.canPerformFullSync else { return }
-        self.enqueue(action: action)
-        self.startNextAction()
-    }
-
-    private func enqueueAndStartTimer(action: SyncSchedulerAction) {
-        self.queue.async(flags: .barrier) { [weak self] in
-            self?._enqueueAndStartTimer(action: action)
+    private func enqueue(sync: Sync) {
+        if sync.type == .full && sync.libraries == .all {
+            guard self.canPerformFullSync else { return }
+            // Full sync overrides all queued syncs, since it will sync up everything
+            self.syncQueue = [sync]
+            // Also reset timer in case we're already waiting for delayed re-sync
+            self.timerDisposeBag = DisposeBag()
+        } else if self.syncQueue.isEmpty {
+            self.syncQueue.append(sync)
+        } else if sync.retryAttempt > 0 {
+            // Retry sync should be added to the beginning of queue so that retries are processed before new syncs
+            if let index = self.syncQueue.firstIndex(where: { $0.retryAttempt == 0 }) {
+                self.syncQueue.insert(sync, at: index)
+            } else {
+                self.syncQueue.append(sync)
+            }
+        } else if !self.syncQueue.contains(where: { return $0.type == sync.type && $0.libraries == sync.libraries }) {
+            // New sync request should be added to the end of queue if it's not a duplicate
+            self.syncQueue.append(sync)
         }
     }
 
-    private func _enqueueAndStartTimer(action: SyncSchedulerAction) {
-        guard action.syncType != .full || self.canPerformFullSync else { return }
-        self.enqueue(action: action)
-        self.startTimer()
-    }
-
-    private func enqueue(action: SyncSchedulerAction) {
-        guard let nextAction = self.nextAction else {
-            self.nextAction = action
+    private func startNextSync() {
+        guard self.syncInProgress == nil, let nextSync = self.syncQueue.first else {
+            if self.syncInProgress == nil && self.syncQueue.isEmpty {
+                // Report finished queue
+                self.inProgress.accept(false)
+            }
             return
         }
 
-        let type = nextAction.syncType > action.syncType ? nextAction.syncType : action.syncType
-        let retryCount =
-
-        switch (nextAction.librarySyncType, action.librarySyncType) {
-        case (.all, .all):
-            self.nextAction = (type, .all)
-
-        case (.specific, .all):
-            self.nextAction = (type, .all)
-
-        case (.specific(let nextIds), .specific(let newIds)):
-            let unionedIds = Array(Set(nextIds).union(Set(newIds)))
-            self.nextAction = (type, .specific(unionedIds))
-        case (.all, .specific): break // If full sync is enqueued we don't "degrade" it to specific
+        let delay: Int
+        if nextSync.retryAttempt > 0 {
+            let index = min(nextSync.retryAttempt, self.retryIntervals.count)
+            delay = self.retryIntervals[index - 1]
+        } else {
+            delay = SyncScheduler.syncTimeout
         }
+
+        let timeSinceLastSync = Int(ceil(Date().timeIntervalSince(self.lastSyncFinishDate) * 1000))
+        if timeSinceLastSync < delay {
+            self.delay(for: delay - timeSinceLastSync)
+            return
+        }
+
+        if !self.inProgress.value {
+            // Report sync start
+            self.inProgress.accept(true)
+        }
+
+        self.syncQueue.removeFirst()
+        self.syncInProgress = nextSync
+        self.syncController.start(type: nextSync.type, libraries: nextSync.libraries, retryAttempt: nextSync.retryAttempt)
     }
 
-    private func startTimer() {
-        guard self.inProgress == nil else { return }
+    private func delay(for timeout: Int) {
+        guard self.syncInProgress == nil else { return }
 
         self.timerDisposeBag = DisposeBag()
 
-        Single<Int>.timer(SyncScheduler.timeout, scheduler: self.scheduler)
+        Single<Int>.timer(.milliseconds(timeout), scheduler: self.scheduler)
                    .subscribe(onSuccess: { [weak self] _ in
-                       self?.startNextAction()
+                       self?.startNextSync()
                    })
                    .disposed(by: self.timerDisposeBag)
-    }
-
-    private func startNextAction() {
-        guard self.inProgress == nil, let (syncType, librarySyncType) = self.nextAction else { return }
-
-        self.inProgress = self.nextAction
-        self.nextAction = nil
-        self.lastSyncDate = Date()
-        if syncType == .full {
-            self.lastFullSyncDate = self.lastSyncDate
-        }
-
-        self.syncController.start(type: syncType, libraries: librarySyncType)
-    }
-}
-
-extension SyncController.SyncType: Comparable {
-    static func < (lhs: SyncController.SyncType, rhs: SyncController.SyncType) -> Bool {
-        switch (lhs, rhs) {
-        case (.collectionsOnly, .normal),
-             (.collectionsOnly, .ignoreIndividualDelays),
-             (.collectionsOnly, .full),
-             (.normal, .ignoreIndividualDelays),
-             (.normal, .full),
-             (.ignoreIndividualDelays, .full):
-            return true
-
-        default:
-            return false
-        }
     }
 }

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -50,6 +50,8 @@ internal enum L10n {
   internal static let error = L10n.tr("Localizable", "error")
   /// Item Type
   internal static let itemType = L10n.tr("Localizable", "item_type")
+  /// Keep
+  internal static let keep = L10n.tr("Localizable", "keep")
   /// Last Updated
   internal static let lastUpdated = L10n.tr("Localizable", "last_updated")
   /// App failed to log in. Please log in again and report Debug ID %@ in the Zotero Forums.
@@ -84,6 +86,8 @@ internal enum L10n {
   internal static let publisher = L10n.tr("Localizable", "publisher")
   /// Recents
   internal static let recent = L10n.tr("Localizable", "recent")
+  /// Remove
+  internal static let remove = L10n.tr("Localizable", "remove")
   /// Report
   internal static let report = L10n.tr("Localizable", "report")
   /// Restore
@@ -589,6 +593,28 @@ internal enum L10n {
     internal enum StylesSearch {
       /// Could not load styles. Do you want to try again?
       internal static let loading = L10n.tr("Localizable", "errors.styles_search.loading")
+    }
+    internal enum Sync {
+      /// You no longer have file-editing access for the group ‘%@’, and files you’ve changed locally cannot be uploaded. If you continue, all group files will be reset to their state on %@.\n\nIf you would like a chance to copy modified files elsewhere or to request file-editing access from a group administrator, you can skip syncing of the group now.
+      internal static func fileWriteDenied(_ p1: Any, _ p2: Any) -> String {
+        return L10n.tr("Localizable", "errors.sync.file_write_denied", String(describing: p1), String(describing: p2))
+      }
+      /// Group '%@' is no longer accessible. What would you like to do?
+      internal static func groupRemoved(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "errors.sync.group_removed", String(describing: p1))
+      }
+      /// Keep changes
+      internal static let keepChanges = L10n.tr("Localizable", "errors.sync.keep_changes")
+      /// You can't write to group '%@' anymore. What would you like to do?
+      internal static func metadataWriteDenied(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "errors.sync.metadata_write_denied", String(describing: p1))
+      }
+      /// Reset Group Files and Sync
+      internal static let resetGroupFiles = L10n.tr("Localizable", "errors.sync.reset_group_files")
+      /// Revert to original
+      internal static let revertToOriginal = L10n.tr("Localizable", "errors.sync.revert_to_original")
+      /// Skip Group
+      internal static let skipGroup = L10n.tr("Localizable", "errors.sync.skip_group")
     }
     internal enum SyncToolbar {
       /// Unable to upload attachment: %@. Please try removing and re-adding the attachment.

--- a/Zotero/Models/Conflict.swift
+++ b/Zotero/Models/Conflict.swift
@@ -9,8 +9,9 @@
 import Foundation
 
 enum Conflict {
-    case groupRemoved(Int, String)
-    case groupWriteDenied(Int, String)
+    case groupRemoved(groupId: Int, name: String)
+    case groupMetadataWriteDenied(groupId: Int, name: String)
+    case groupFileWriteDenied(groupId: Int, name: String)
     case objectsRemovedRemotely(libraryId: LibraryIdentifier, collections: [String], items: [String], searches: [String], tags: [String])
     case removedItemsHaveLocalChanges(keys: [(String, String)], libraryId: LibraryIdentifier)
 }

--- a/Zotero/Models/ConflictResolution.swift
+++ b/Zotero/Models/ConflictResolution.swift
@@ -13,6 +13,8 @@ enum ConflictResolution {
     case markGroupAsLocalOnly(Int)
     case revertGroupChanges(LibraryIdentifier)
     case keepGroupChanges(LibraryIdentifier)
+    case revertGroupFiles(LibraryIdentifier)
+    case skipGroup(LibraryIdentifier)
     case remoteDeletionOfActiveObject(libraryId: LibraryIdentifier, toDeleteCollections: [String], toRestoreCollections: [String],
                                       toDeleteItems: [String], toRestoreItems: [String], searches: [String], tags: [String])
     case remoteDeletionOfChangedItem(libraryId: LibraryIdentifier, toDelete: [String], toRestore: [String])

--- a/Zotero/Models/DelayIntervals.swift
+++ b/Zotero/Models/DelayIntervals.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct DelayIntervals {
     static let sync: [Double] = createSyncIntervals()
-    static let conflict: [Int] = [0, 10000, 20000, 40000, 60000, 120000, 240000, 300000]
+    static let retry: [Int] = [0, 10000, 20000, 40000, 60000, 120000, 240000, 300000]
 
     private static func createSyncIntervals() -> [Double] {
         let hourIntervals = [0.5, 1, 4, 16, 16, 16, 16, 16, 16, 16, 64]

--- a/Zotero/Models/Sync/SyncErrors.swift
+++ b/Zotero/Models/Sync/SyncErrors.swift
@@ -77,6 +77,7 @@ enum SyncError {
         case webDavDeletionFailed(error: String, library: String)
         case webDavVerification(WebDavError.Verification)
         case webDavDownload(WebDavError.Download)
+        case preconditionFailed(LibraryIdentifier)
 
         var isVersionMismatch: Bool {
             switch self {
@@ -97,6 +98,7 @@ enum SyncError {
 /// - attachmentMissing: Attachment upload can't start because a file is missing.
 /// - authorizationFailed: File upload authorization failed. Most cases require special handling.
 /// - objectPreconditionError: 412 of individual object when submitted to backend.
+/// - preconditionError: 412 from request whole submission request (for example when submitting deletions)
 /// - submitUpdateFailures: Failures of individual objects when submitting changes to backend
 enum SyncActionError: Error {
     case annotationNeededSplitting(message: String, keys: Set<String>, libraryId: LibraryIdentifier)

--- a/Zotero/Models/Sync/SyncErrors.swift
+++ b/Zotero/Models/Sync/SyncErrors.swift
@@ -77,7 +77,6 @@ enum SyncError {
         case webDavDeletionFailed(error: String, library: String)
         case webDavVerification(WebDavError.Verification)
         case webDavDownload(WebDavError.Download)
-        case fileEditingDenied(LibraryIdentifier)
 
         var isVersionMismatch: Bool {
             switch self {

--- a/Zotero/Models/Sync/SyncErrors.swift
+++ b/Zotero/Models/Sync/SyncErrors.swift
@@ -53,13 +53,11 @@ enum SyncError {
         case dbError
         case groupSyncFailed
         case allLibrariesFetchFailed
-        case preconditionErrorWithoutVersion(data: ErrorData)
         case uploadObjectConflict(data: ErrorData)
         case cantSubmitAttachmentItem(data: ErrorData)
         case permissionLoadingFailed
         case missingGroupPermissions
         case cancelled
-        case preconditionErrorCantBeResolved(data: ErrorData)
         case serviceUnavailable
         case forbidden
     }

--- a/Zotero/Models/UpdatableObject.swift
+++ b/Zotero/Models/UpdatableObject.swift
@@ -285,7 +285,7 @@ extension RItem: Updatable {
     }
 
     func markAsChanged(in database: Realm) {
-        self.changes.append(RObjectChange.create(changes: self.currentChanges))
+        self.changes.append(RObjectChange.create(changes: self.allChanges))
         self.changeType = .user
         self.deleted = false
         self.version = 0
@@ -304,8 +304,19 @@ extension RItem: Updatable {
         }
     }
 
-    private var currentChanges: RItemChanges {
-        var changes: RItemChanges = [.type, .fields]
+    var allChanges: RItemChanges {
+        if self.rawType == ItemTypes.annotation {
+            var changes: RItemChanges = [.parent, .fields, .type, .tags]
+            if !self.rects.isEmpty {
+                changes.insert(.rects)
+            }
+            if !self.paths.isEmpty {
+                changes.insert(.paths)
+            }
+            return changes
+        }
+        
+        var changes: RItemChanges = [.type, .fields, .tags]
         if !self.creators.isEmpty {
             changes.insert(.creators)
         }
@@ -315,20 +326,11 @@ extension RItem: Updatable {
         if self.parent != nil {
             changes.insert(.parent)
         }
-        if !self.tags.isEmpty {
-            changes.insert(.tags)
-        }
         if self.trash {
             changes.insert(.trash)
         }
         if !self.relations.isEmpty {
             changes.insert(.relations)
-        }
-        if !self.rects.isEmpty {
-            changes.insert(.rects)
-        }
-        if !self.paths.isEmpty {
-            changes.insert(.paths)
         }
         return changes
     }

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
@@ -169,7 +169,6 @@ struct ItemsActionHandler: ViewModelActionHandler, BackgroundDbProcessingActionH
             self.fileCleanupController.delete(.allForItems(ids, viewModel.state.library.identifier), completed: nil)
 
         case .startSync:
-            guard !self.syncScheduler.syncController.inProgress else { return }
             self.syncScheduler.request(sync: .ignoreIndividualDelays, libraries: .specific([viewModel.state.library.identifier]))
 
         case .emptyTrash:

--- a/Zotero/Scenes/General/Views/SyncToolbarController.swift
+++ b/Zotero/Scenes/General/Views/SyncToolbarController.swift
@@ -120,7 +120,7 @@ final class SyncToolbarController {
             case .allLibrariesFetchFailed:
                 return (L10n.Errors.SyncToolbar.librariesMissing, nil)
 
-            case .cantResolveConflict, .preconditionErrorCantBeResolved:
+            case .preconditionErrorCantBeResolved:
                 return (L10n.Errors.SyncToolbar.conflictRetryLimit, nil)
 
             case .groupSyncFailed:

--- a/Zotero/Scenes/General/Views/SyncToolbarController.swift
+++ b/Zotero/Scenes/General/Views/SyncToolbarController.swift
@@ -110,7 +110,7 @@ final class SyncToolbarController {
     private func alertMessage(from error: Error) -> (message: String, additionalData: SyncError.ErrorData?) {
         if let error = error as? SyncError.Fatal {
             switch error {
-            case .cancelled, .uploadObjectConflict: break // should not happen
+            case .cancelled: break // should not happen
             case .apiError(let response, let data):
                 return (L10n.Errors.api(response), data)
 
@@ -120,7 +120,7 @@ final class SyncToolbarController {
             case .allLibrariesFetchFailed:
                 return (L10n.Errors.SyncToolbar.librariesMissing, nil)
 
-            case .preconditionErrorCantBeResolved:
+            case .uploadObjectConflict:
                 return (L10n.Errors.SyncToolbar.conflictRetryLimit, nil)
 
             case .groupSyncFailed:
@@ -137,6 +137,8 @@ final class SyncToolbarController {
 
             case .forbidden:
                 return (L10n.Errors.SyncToolbar.forbiddenMessage, nil)
+            case .cantSubmitAttachmentItem(let data):
+                return (L10n.Errors.db, data)
             }
         }
 
@@ -192,6 +194,7 @@ final class SyncToolbarController {
 
             case .annotationDidSplit(let string, let keys, let libraryId):
                 return (string, SyncError.ErrorData(itemKeys: Array(keys), libraryId: libraryId))
+            case .fileEditingDenied(let libraryId): break // TODO: - Add appropriate error message
             case .unchanged: break
             }
         }

--- a/Zotero/Scenes/General/Views/SyncToolbarController.swift
+++ b/Zotero/Scenes/General/Views/SyncToolbarController.swift
@@ -196,7 +196,12 @@ final class SyncToolbarController {
 
             case .annotationDidSplit(let string, let keys, let libraryId):
                 return (string, SyncError.ErrorData(itemKeys: Array(keys), libraryId: libraryId))
-            case .unchanged: break
+
+            case .unchanged:
+                break
+
+            case .preconditionFailed(let libraryId):
+                return (L10n.Errors.SyncToolbar.conflictRetryLimit, SyncError.ErrorData(itemKeys: nil, libraryId: libraryId))
             }
         }
 

--- a/Zotero/Scenes/General/Views/SyncToolbarController.swift
+++ b/Zotero/Scenes/General/Views/SyncToolbarController.swift
@@ -111,6 +111,7 @@ final class SyncToolbarController {
         if let error = error as? SyncError.Fatal {
             switch error {
             case .cancelled: break // should not happen
+                
             case .apiError(let response, let data):
                 return (L10n.Errors.api(response), data)
 
@@ -137,6 +138,7 @@ final class SyncToolbarController {
 
             case .forbidden:
                 return (L10n.Errors.SyncToolbar.forbiddenMessage, nil)
+
             case .cantSubmitAttachmentItem(let data):
                 return (L10n.Errors.db, data)
             }
@@ -194,7 +196,6 @@ final class SyncToolbarController {
 
             case .annotationDidSplit(let string, let keys, let libraryId):
                 return (string, SyncError.ErrorData(itemKeys: Array(keys), libraryId: libraryId))
-            case .fileEditingDenied(let libraryId): break // TODO: - Add appropriate error message
             case .unchanged: break
             }
         }

--- a/Zotero/Scenes/Master/Settings/Sync/ViewModels/SyncSettingsActionHandler.swift
+++ b/Zotero/Scenes/Master/Settings/Sync/ViewModels/SyncSettingsActionHandler.swift
@@ -80,6 +80,9 @@ struct SyncSettingsActionHandler: ViewModelActionHandler {
         case .cancelZoteroDirectoryCreation: break
 
         case .recheckKeys:
+            if self.syncScheduler.inProgress.value {
+                self.syncScheduler.cancelSync()
+            }
             self.observeSyncIssues(in: viewModel)
             self.syncScheduler.request(sync: .keysOnly, libraries: .all)
         }
@@ -163,6 +166,9 @@ struct SyncSettingsActionHandler: ViewModelActionHandler {
             self.webDavController.sessionStorage.isEnabled = type == .webDav
 
             if type == .zotero {
+                if self.syncScheduler.inProgress.value {
+                    self.syncScheduler.cancelSync()
+                }
                 self.syncScheduler.request(sync: .normal, libraries: .all)
             }
         }
@@ -229,6 +235,9 @@ struct SyncSettingsActionHandler: ViewModelActionHandler {
                    self.update(viewModel: viewModel) { state in
                        state.isVerifyingWebDav = false
                        state.webDavVerificationResult = .success(())
+                   }
+                   if self.syncScheduler.inProgress.value {
+                       self.syncScheduler.cancelSync()
                    }
                    self.syncScheduler.request(sync: .normal, libraries: .all)
                }, onFailure: { viewModel, error in

--- a/ZoteroTests/JSONs/test_item_attachment.json
+++ b/ZoteroTests/JSONs/test_item_attachment.json
@@ -1,0 +1,58 @@
+{
+    "key": "AAAAAAAA",
+    "version": 182,
+    "library": {
+      "type": "user",
+      "id": 1234123,
+      "name": "someuser",
+      "links": {
+        "alternate": {
+          "href": "https://www.zotero.org/someuser",
+          "type": "text/html"
+        }
+      }
+    },
+    "links": {
+      "self": {
+        "href": "https://api.zotero.org/users/1234123/items/AAAAAAAA",
+        "type": "application/json"
+      },
+      "alternate": {
+        "href": "https://www.zotero.org/someuser/items/AAAAAAAA",
+        "type": "text/html"
+      }
+    },
+    "meta": {
+      "creatorSummary": "Author",
+      "parsedDate": "2014",
+      "numChildren": 1
+    },
+    "data": {
+      "key": "AAAAAAAA",
+      "version": 182,
+      "itemType": "attachment",
+      "title": "Bachelor thesis",
+      "filename": "bachelor_thesis.txt",
+      "linkMode": "imported_file",
+      "mtime": 1000,
+      "md5": "abcdef",
+      "contentType": "plain/text",
+      "creators": [],
+      "tags": [
+        {
+          "tag": "High priority"
+        },
+        {
+          "tag": "Others"
+        }
+      ],
+      "collections": [
+        "2PDUK4DH"
+      ],
+      "relations": {
+        "dc:relation": "http://zotero.org/users/1234123/items/BBBBBBBB"
+      },
+      "dateAdded": "2019-02-11T19:10:55Z",
+      "dateModified": "2019-03-28T15:48:48Z"
+    }
+  }

--- a/ZoteroTests/SyncControllerSpec.swift
+++ b/ZoteroTests/SyncControllerSpec.swift
@@ -129,14 +129,14 @@ final class SyncControllerSpec: QuickSpec {
                                                         "data": ["name": "A",
                                                                  "conditions": [["condition": "itemType",
                                                                                  "operator": "is",
-                                                                                 "value": "thesis"]]]]]
+                                                                                 "value": "thesis"]]] as [String: Any]]]
 
                         case .item:
                             objectResponses[object] = [["key": "AAAAAAAA",
                                                         "version": 3,
                                                         "library": libraryJson,
                                                         "data": ["title": "A", "itemType": "thesis",
-                                                                 "tags": [["tag": "A"]]]]]
+                                                                 "tags": [["tag": "A"]]] as [String: Any]]]
 
                         case .trash:
                             objectResponses[object] = [["key": "BBBBBBBB",
@@ -145,19 +145,19 @@ final class SyncControllerSpec: QuickSpec {
                                                         "data": ["note": "<p>This is a note</p>",
                                                                  "parentItem": "AAAAAAAA",
                                                                  "itemType": "note",
-                                                                 "deleted": 1]]]
+                                                                 "deleted": 1] as [String: Any]]]
 
                         case .settings: break
                         }
                     }
 
-                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:])
+                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:] as [String: Any])
                     objects.forEach { object in
                         createStub(
                             for: VersionsRequest(libraryId: libraryId, userId: self.userId, objectType: object, version: 0),
                             baseUrl: baseUrl,
                             headers: header,
-                            jsonResponse: versionResponses[object] ?? [:]
+                            jsonResponse: versionResponses[object] ?? [:] as [String: Any]
                         )
                     }
                     objects.forEach { object in
@@ -165,7 +165,7 @@ final class SyncControllerSpec: QuickSpec {
                             for: ObjectsRequest(libraryId: libraryId, userId: self.userId, objectType: object, keys: (objectKeys[object] ?? "")),
                             baseUrl: baseUrl,
                             headers: header,
-                            jsonResponse: objectResponses[object] ?? [:]
+                            jsonResponse: objectResponses[object] ?? [:] as [String: Any]
                         )
                     }
                     createStub(for: KeyRequest(), baseUrl: baseUrl, url: Bundle(for: type(of: self)).url(forResource: "test_keys", withExtension: "json")!)
@@ -173,13 +173,13 @@ final class SyncControllerSpec: QuickSpec {
                         for: SettingsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["tagColors": ["value": [["name": "A", "color": "#CC66CC"]], "version": 2]]
+                        jsonResponse: ["tagColors": ["value": [["name": "A", "color": "#CC66CC"]], "version": 2] as [String: Any]]
                     )
                     createStub(
                         for: DeletionsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["collections": [], "searches": [], "items": [], "tags": []]
+                        jsonResponse: ["collections": [] as [Any], "searches": [] as [Any], "items": [] as [Any], "tags": [] as [Any]]
                     )
 
                     self.createNewSyncController()
@@ -315,32 +315,32 @@ final class SyncControllerSpec: QuickSpec {
                         case .collection:
                             objectResponses[object] = [["key": "AAAAAAAA",
                                                         "version": 1,
-                                                        "library": ["id": groupId, "type": "group", "name": "A"],
-                                                        "data": ["name": "A"]]]
+                                                        "library": ["id": groupId, "type": "group", "name": "A"] as [String: Any],
+                                                        "data": ["name": "A"]] as [String: Any]]
 
                         case .search:
                             objectResponses[object] = [["key": "AAAAAAAA",
                                                         "version": 2,
-                                                        "library": ["id": groupId, "type": "group", "name": "A"],
+                                                        "library": ["id": groupId, "type": "group", "name": "A"] as [String: Any],
                                                         "data": ["name": "A",
                                                                  "conditions": [["condition": "itemType",
                                                                                  "operator": "is",
-                                                                                 "value": "thesis"]]]]]
+                                                                                 "value": "thesis"]]] as [String: Any]] as [String: Any]]
 
                         case .item:
                             objectResponses[object] = [["key": "AAAAAAAA",
                                                         "version": 3,
-                                                        "library": ["id": groupId, "type": "group", "name": "A"],
-                                                        "data": ["title": "A", "itemType": "thesis", "tags": [["tag": "A"]]]]]
+                                                        "library": ["id": groupId, "type": "group", "name": "A"] as [String: Any],
+                                                        "data": ["title": "A", "itemType": "thesis", "tags": [["tag": "A"]]] as [String: Any]] as [String: Any]]
 
                         case .trash:
                             objectResponses[object] = [["key": "BBBBBBBB",
                                                         "version": 4,
-                                                        "library": ["id": groupId, "type": "group", "name": "A"],
+                                                        "library": ["id": groupId, "type": "group", "name": "A"] as [String: Any],
                                                         "data": ["note": "<p>This is a note</p>",
                                                                  "parentItem": "AAAAAAAA",
                                                                  "itemType": "note",
-                                                                 "deleted": 1]]]
+                                                                 "deleted": 1] as [String: Any]] as [String: Any]]
 
                         case .settings: break
                         }
@@ -355,7 +355,7 @@ final class SyncControllerSpec: QuickSpec {
                                                                        "description": "",
                                                                        "libraryEditing": "members",
                                                                        "libraryReading": "members",
-                                                                       "fileEditing": "members"]]
+                                                                       "fileEditing": "members"] as [String: Any]]
 
                     let myLibrary = self.userLibraryId
 
@@ -363,41 +363,41 @@ final class SyncControllerSpec: QuickSpec {
                                jsonResponse: groupVersionsResponse)
                     objects.forEach { object in
                         createStub(for: VersionsRequest(libraryId: myLibrary, userId: self.userId, objectType: object, version: 0),
-                                   baseUrl: baseUrl, headers: header, jsonResponse: [:])
+                                   baseUrl: baseUrl, headers: header, jsonResponse: [:] as [String: Any])
                     }
                     createStub(for: GroupRequest(identifier: groupId), baseUrl: baseUrl, headers: header, jsonResponse: groupObjectResponse)
                     for object in objects {
                         createStub(for: VersionsRequest(libraryId: libraryId, userId: self.userId, objectType: object, version: 0),
-                                   baseUrl: baseUrl, headers: header, jsonResponse: (versionResponses[object] ?? [:]))
+                                   baseUrl: baseUrl, headers: header, jsonResponse: (versionResponses[object] ?? [:] as [String: Any]))
                     }
                     for object in objects {
                         createStub(for: ObjectsRequest(libraryId: libraryId, userId: self.userId, objectType: object, keys: (objectKeys[object] ?? "")),
-                                   baseUrl: baseUrl, headers: header, jsonResponse: (objectResponses[object] ?? [:]))
+                                   baseUrl: baseUrl, headers: header, jsonResponse: (objectResponses[object] ?? [:] as [String: Any]))
                     }
                     createStub(for: KeyRequest(), baseUrl: baseUrl, url: Bundle(for: type(of: self)).url(forResource: "test_keys", withExtension: "json")!)
                     createStub(
                         for: SettingsRequest(libraryId: myLibrary, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["tagColors": ["value": [], "version": 2]]
+                        jsonResponse: ["tagColors": ["value": [] as [Any], "version": 2] as [String: Any]]
                     )
                     createStub(
                         for: SettingsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["tagColors": ["value": [["name": "A", "color": "#CC66CC"]], "version": 2]]
+                        jsonResponse: ["tagColors": ["value": [["name": "A", "color": "#CC66CC"]], "version": 2] as [String: Any]]
                     )
                     createStub(
                         for: DeletionsRequest(libraryId: myLibrary, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["collections": [], "searches": [], "items": [], "tags": []]
+                        jsonResponse: ["collections": [] as [Any], "searches": [] as [Any], "items": [] as [Any], "tags": [] as [Any]]
                     )
                     createStub(
                         for: DeletionsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["collections": [], "searches": [], "items": [], "tags": []]
+                        jsonResponse: ["collections": [] as [Any], "searches": [] as [Any], "items": [] as [Any], "tags": [] as [Any]]
                     )
 
                     self.createNewSyncController()
@@ -480,13 +480,13 @@ final class SyncControllerSpec: QuickSpec {
                     let toBeDeletedItem = self.realm.objects(RItem.self).filter(.key(itemToDelete, in: .custom(.myLibrary))).first
                     expect(toBeDeletedItem).toNot(beNil())
 
-                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:])
+                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:] as [String: Any])
                     objects.forEach { object in
                         createStub(
                             for: VersionsRequest(libraryId: libraryId, userId: self.userId, objectType: object, version: 0),
                             baseUrl: baseUrl,
                             headers: header,
-                            jsonResponse: [:]
+                            jsonResponse: [:] as [String: Any]
                         )
                     }
                     createStub(for: KeyRequest(), baseUrl: baseUrl, url: Bundle(for: type(of: self)).url(forResource: "test_keys", withExtension: "json")!)
@@ -494,13 +494,13 @@ final class SyncControllerSpec: QuickSpec {
                         for: SettingsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["tagColors": ["value": [], "version": 2]]
+                        jsonResponse: ["tagColors": ["value": [] as [Any], "version": 2] as [String: Any]]
                     )
                     createStub(
                         for: DeletionsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["collections": [], "searches": [], "items": [itemToDelete], "tags": []]
+                        jsonResponse: ["collections": [] as [Any], "searches": [] as [Any], "items": [itemToDelete], "tags": [] as [Any]]
                     )
 
                     waitUntil(timeout: .seconds(10)) { doneAction in
@@ -599,8 +599,8 @@ final class SyncControllerSpec: QuickSpec {
                     let collectionKey = "CCCCCCCC"
                     let itemResponse = [["key": itemKey,
                                          "version": 3,
-                                         "library": ["id": 0, "type": "user", "name": "A"],
-                                         "data": ["title": "A", "itemType": "thesis", "collections": [collectionKey]]]]
+                                         "library": ["id": 0, "type": "user", "name": "A"] as [String: Any],
+                                         "data": ["title": "A", "itemType": "thesis", "collections": [collectionKey]] as [String: Any]] as [String: Any]]
 
                     self.createNewSyncController()
 
@@ -608,7 +608,7 @@ final class SyncControllerSpec: QuickSpec {
                     let collection = realm.objects(RItem.self).filter("key = %@", collectionKey).first
                     expect(collection).to(beNil())
 
-                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:])
+                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:] as [String: Any])
                     objects.forEach { object in
                         if object == .item {
                             createStub(
@@ -622,7 +622,7 @@ final class SyncControllerSpec: QuickSpec {
                                 for: VersionsRequest(libraryId: libraryId, userId: self.userId, objectType: object, version: 0),
                                 baseUrl: baseUrl,
                                 headers: header,
-                                jsonResponse: [:]
+                                jsonResponse: [:] as [String: Any]
                             )
                         }
                     }
@@ -637,13 +637,13 @@ final class SyncControllerSpec: QuickSpec {
                         for: SettingsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["tagColors": ["value": [], "version": 2]]
+                        jsonResponse: ["tagColors": ["value": [] as [Any], "version": 2] as [String: Any]]
                     )
                     createStub(
                         for: DeletionsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["collections": [], "searches": [], "items": [], "tags": []]
+                        jsonResponse: ["collections": [] as [Any], "searches": [] as [Any], "items": [] as [Any], "tags": [] as [Any]]
                     )
 
                     waitUntil(timeout: .seconds(10)) { doneAction in
@@ -676,11 +676,11 @@ final class SyncControllerSpec: QuickSpec {
                     let responseItemKey = "BBBBBBBB"
                     let itemResponse = [["key": responseItemKey,
                                          "version": 3,
-                                         "library": ["id": 0, "type": "user", "name": "A"],
-                                         "data": ["title": "A", "itemType": "thesis"]],
+                                         "library": ["id": 0, "type": "user", "name": "A"] as [String: Any],
+                                         "data": ["title": "A", "itemType": "thesis"]] as [String: Any],
                                         ["key": unsyncedItemKey,
                                          "version": 3,
-                                         "library": ["id": 0, "type": "user", "name": "A"],
+                                         "library": ["id": 0, "type": "user", "name": "A"] as [String: Any],
                                          "data": ["title": "B", "itemType": "thesis"]]]
 
                     self.createNewSyncController()
@@ -698,7 +698,7 @@ final class SyncControllerSpec: QuickSpec {
                     expect(unsynced).toNot(beNil())
                     expect(unsynced?.syncState).to(equal(.dirty))
 
-                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:])
+                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:] as [String: Any])
                     objects.forEach { object in
                         if object == .item {
                             createStub(
@@ -712,7 +712,7 @@ final class SyncControllerSpec: QuickSpec {
                                 for: VersionsRequest(libraryId: libraryId, userId: self.userId, objectType: object, version: 0),
                                 baseUrl: baseUrl,
                                 headers: header,
-                                jsonResponse: [:]
+                                jsonResponse: [:] as [String: Any]
                             )
                         }
                     }
@@ -733,13 +733,13 @@ final class SyncControllerSpec: QuickSpec {
                         for: SettingsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["tagColors": ["value": [], "version": 2]]
+                        jsonResponse: ["tagColors": ["value": [] as [Any], "version": 2] as [String: Any]]
                     )
                     createStub(
                         for: DeletionsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["collections": [], "searches": [], "items": [], "tags": []]
+                        jsonResponse: ["collections": [] as [Any], "searches": [] as [Any], "items": [] as [Any], "tags": [] as [Any]]
                     )
 
                     waitUntil(timeout: .seconds(10)) { doneAction in
@@ -791,13 +791,13 @@ final class SyncControllerSpec: QuickSpec {
                     let incorrectKey = "BBBBBBBB"
                     let itemResponse = [["key": correctKey,
                                          "version": 3,
-                                         "library": ["id": 0, "type": "user", "name": "A"],
-                                         "data": ["title": "A", "itemType": "thesis"]],
+                                         "library": ["id": 0, "type": "user", "name": "A"] as [String: Any],
+                                         "data": ["title": "A", "itemType": "thesis"]] as [String: Any],
                                         ["key": incorrectKey,
                                          "version": 3,
                                          "data": ["title": "A", "itemType": "thesis"]]]
 
-                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:])
+                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:] as [String: Any])
                     objects.forEach { object in
                         if object == .item {
                             createStub(
@@ -811,7 +811,7 @@ final class SyncControllerSpec: QuickSpec {
                                 for: VersionsRequest(libraryId: libraryId, userId: self.userId, objectType: object, version: 0),
                                 baseUrl: baseUrl,
                                 headers: header,
-                                jsonResponse: [:]
+                                jsonResponse: [:] as [String: Any]
                             )
                         }
                     }
@@ -832,13 +832,13 @@ final class SyncControllerSpec: QuickSpec {
                         for: SettingsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["tagColors": ["value": [], "version": 2]]
+                        jsonResponse: ["tagColors": ["value": [] as [Any], "version": 2] as [String: Any]]
                     )
                     createStub(
                         for: DeletionsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["collections": [], "searches": [], "items": [], "tags": []]
+                        jsonResponse: ["collections": [] as [Any], "searches": [] as [Any], "items": [] as [Any], "tags": [] as [Any]]
                     )
 
                     self.createNewSyncController()
@@ -900,66 +900,66 @@ final class SyncControllerSpec: QuickSpec {
                         case .collection:
                             objectResponses[object] = [["key": "AAAAAAAA",
                                                         "version": 1,
-                                                        "library": ["id": 0, "type": "user", "name": "A"],
-                                                        "data": ["name": "A"]],
+                                                        "library": ["id": 0, "type": "user", "name": "A"] as [String: Any],
+                                                        "data": ["name": "A"]] as [String: Any],
                                                        // Missing parent - should be synced, parent queued
                                                        ["key": "BBBBBBBB",
                                                         "version": 1,
-                                                        "library": ["id": 0, "type": "user", "name": "A"],
+                                                        "library": ["id": 0, "type": "user", "name": "A"] as [String: Any],
                                                         "data": ["name": "B",
                                                                  "parentCollection": "ZZZZZZZZ"]],
                                                        // Unknown field - should be rejected
                                                        ["key": "CCCCCCCC",
                                                         "version": 1,
-                                                        "library": ["id": 0, "type": "user", "name": "A"],
-                                                        "data": ["name": "C", "unknownField": 5]]]
+                                                        "library": ["id": 0, "type": "user", "name": "A"] as [String: Any],
+                                                        "data": ["name": "C", "unknownField": 5] as [String: Any]]]
 
                         case .search:
                                                        // Unknown condition - should be queued
                             objectResponses[object] = [["key": "GGGGGGGG",
                                                         "version": 2,
-                                                        "library": ["id": 0, "type": "user", "name": "A"],
+                                                        "library": ["id": 0, "type": "user", "name": "A"] as [String: Any],
                                                         "data": ["name": "G",
                                                                  "conditions": [["condition": "unknownCondition",
                                                                                  "operator": "is",
-                                                                                 "value": "thesis"]]]],
+                                                                                 "value": "thesis"]]] as [String: Any]] as [String: Any],
                                                        // Unknown operator - should be queued
                                                        ["key": "HHHHHHHH",
                                                         "version": 2,
-                                                        "library": ["id": 0, "type": "user", "name": "A"],
+                                                        "library": ["id": 0, "type": "user", "name": "A"] as [String: Any],
                                                         "data": ["name": "H",
                                                                  "conditions": [["condition": "itemType",
                                                                                  "operator": "unknownOperator",
-                                                                                 "value": "thesis"]]]]]
+                                                                                 "value": "thesis"]]] as [String: Any]]]
 
                         case .item:
                                                        // Unknown field - should be rejected
                             objectResponses[object] = [["key": "DDDDDDDD",
                                                         "version": 3,
-                                                        "library": ["id": 0, "type": "user", "name": "A"],
-                                                        "data": ["title": "D", "itemType": "thesis", "tags": [], "unknownField": "B"]],
+                                                        "library": ["id": 0, "type": "user", "name": "A"] as [String: Any],
+                                                        "data": ["title": "D", "itemType": "thesis", "tags": [] as [Any], "unknownField": "B"] as [String: Any]],
                                                        // Unknown item type - should be queued
                                                        ["key": "EEEEEEEE",
                                                         "version": 3,
-                                                        "library": ["id": 0, "type": "user", "name": "A"],
-                                                        "data": ["title": "E", "itemType": "unknownType", "tags": []]],
+                                                        "library": ["id": 0, "type": "user", "name": "A"] as [String: Any],
+                                                        "data": ["title": "E", "itemType": "unknownType", "tags": [] as [Any]] as [String: Any]] as [String: Any],
                                                        // Parent didn't sync, but item is fine - should be synced
                                                        ["key": "FFFFFFFF",
                                                         "version": 3,
-                                                        "library": ["id": 0, "type": "user", "name": "A"],
+                                                        "library": ["id": 0, "type": "user", "name": "A"] as [String: Any],
                                                         "data": ["note": "This is a note", "itemType": "note",
-                                                                 "tags": [], "parentItem": "EEEEEEEE"]]]
+                                                                 "tags": [] as [Any], "parentItem": "EEEEEEEE"] as [String: Any]]]
                         case .trash, .settings: break
                         }
                     }
 
-                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:])
+                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:] as [String: Any])
                     objects.forEach { object in
                         createStub(
                             for: VersionsRequest(libraryId: libraryId, userId: self.userId, objectType: object, version: 0),
                             baseUrl: baseUrl,
                             headers: header,
-                            jsonResponse: versionResponses[object] ?? [:]
+                            jsonResponse: versionResponses[object] ?? [:] as [String: Any]
                         )
                     }
                     objects.forEach { object in
@@ -967,7 +967,7 @@ final class SyncControllerSpec: QuickSpec {
                             for: ObjectsRequest(libraryId: libraryId, userId: self.userId, objectType: object, keys: (objectKeys[object] ?? "")),
                             baseUrl: baseUrl,
                             headers: header,
-                            jsonResponse: objectResponses[object] ?? [:]
+                            jsonResponse: objectResponses[object] ?? [:] as [String: Any]
                         )
                     }
                     createStub(for: KeyRequest(), baseUrl: baseUrl, url: Bundle(for: type(of: self)).url(forResource: "test_keys", withExtension: "json")!)
@@ -975,13 +975,13 @@ final class SyncControllerSpec: QuickSpec {
                         for: SettingsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["tagColors": ["value": [["name": "A", "color": "#CC66CC"]], "version": 2]]
+                        jsonResponse: ["tagColors": ["value": [["name": "A", "color": "#CC66CC"]], "version": 2] as [String: Any]]
                     )
                     createStub(
                         for: DeletionsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["collections": [], "searches": [], "items": [], "tags": []]
+                        jsonResponse: ["collections": [] as [Any], "searches": [] as [Any], "items": [] as [Any], "tags": [] as [Any]]
                     )
 
                     self.createNewSyncController()
@@ -1134,15 +1134,15 @@ final class SyncControllerSpec: QuickSpec {
                         baseUrl: baseUrl,
                         headers: header,
                         statusCode: 412,
-                        jsonResponse: [:]
+                        jsonResponse: [:] as [String: Any]
                     )
-                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:])
+                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:] as [String: Any])
                     objects.forEach { object in
                         createStub(
                             for: VersionsRequest(libraryId: libraryId, userId: self.userId, objectType: object, version: 0),
                             baseUrl: baseUrl,
                             headers: header,
-                            jsonResponse: versionResponses[object] ?? [:]
+                            jsonResponse: versionResponses[object] ?? [:] as [String: Any]
                         )
                     }
                     objects.forEach { object in
@@ -1150,7 +1150,7 @@ final class SyncControllerSpec: QuickSpec {
                             for: ObjectsRequest(libraryId: libraryId, userId: self.userId, objectType: object, keys: (objectKeys[object] ?? "")),
                             baseUrl: baseUrl,
                             headers: header,
-                            jsonResponse: objectResponses[object] ?? [:]
+                            jsonResponse: objectResponses[object] ?? [:] as [String: Any]
                         )
                     }
                     createStub(for: KeyRequest(), baseUrl: baseUrl, url: Bundle(for: type(of: self)).url(forResource: "test_keys", withExtension: "json")!)
@@ -1158,55 +1158,64 @@ final class SyncControllerSpec: QuickSpec {
                         for: SettingsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["tagColors": ["value": [["name": "A", "color": "#CC66CC"]], "version": 1]]
+                        jsonResponse: ["tagColors": ["value": [["name": "A", "color": "#CC66CC"]], "version": 1] as [String: Any]]
                     )
                     createStub(
                         for: DeletionsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["collections": [], "searches": [], "items": [], "tags": []]
+                        jsonResponse: ["collections": [] as [Any], "searches": [] as [Any], "items": [] as [Any], "tags": [] as [Any]]
                     )
 
                     waitUntil(timeout: .seconds(10)) { doneAction in
                         self.syncController.reportFinish = { result in
                             switch result {
                             case .failure(let error):
-                                DDLogInfo("error: \(error)")
-                                
-                            case .success:
-                                DDLogInfo("success")
+                                fail("Failure: \(error)")
+
+                            case .success(let data):
+                                // precondition error should be reported first time, retry
+                                guard let error = data.1.first as? Zotero.SyncError.NonFatal, case .preconditionFailed(let libraryId) = error else {
+                                    fail("Failure: \(result)")
+                                    return
+                                }
+
+                                self.syncController.reportFinish = { _ in
+                                    let realm = try! Realm(configuration: self.realmConfig)
+                                    realm.refresh()
+
+                                    let library = realm.objects(RCustomLibrary.self).first
+                                    expect(libraryId).toNot(beNil())
+                                    expect(library?.type).to(equal(.myLibrary))
+
+                                    let collections = realm.objects(RCollection.self).filter(.library(with: .custom(.myLibrary)))
+                                    let items = realm.objects(RItem.self).filter(.library(with: .custom(.myLibrary)))
+
+                                    expect(collections.count).to(equal(1))
+                                    expect(items.count).to(equal(2))
+                                    expect(realm.objects(RCollection.self).count).to(equal(1))
+                                    expect(realm.objects(RItem.self).count).to(equal(2))
+
+                                    let item = realm.objects(RItem.self).filter("key = %@", "CCCCCCCC").first
+                                    expect(item).toNot(beNil())
+                                    expect(item?.deleted).to(beFalse())
+                                    expect(item?.trash).to(beFalse())
+
+                                    let collection = realm.objects(RCollection.self).filter("key = %@", collectionKey).first
+                                    expect(collection).toNot(beNil())
+                                    expect(collection?.syncState).to(equal(.synced))
+                                    expect(collection?.version).to(equal(1))
+                                    expect(collection?.deleted).to(beFalse())
+                                    expect(collection?.trash).to(beFalse())
+                                    expect(collection?.customLibraryKey).to(equal(RCustomLibraryType.myLibrary))
+                                    expect(collection?.parentKey).to(beNil())
+                                    expect(collection?.items.count).to(equal(2))
+
+                                    doneAction()
+                                }
+
+                                self.syncController.start(type: .prioritizeDownloads, libraries: .specific([libraryId]), retryAttempt: 4)
                             }
-                            let realm = try! Realm(configuration: self.realmConfig)
-                            realm.refresh()
-
-                            let library = realm.objects(RCustomLibrary.self).first
-                            expect(libraryId).toNot(beNil())
-                            expect(library?.type).to(equal(.myLibrary))
-
-                            let collections = realm.objects(RCollection.self).filter(.library(with: .custom(.myLibrary)))
-                            let items = realm.objects(RItem.self).filter(.library(with: .custom(.myLibrary)))
-
-                            expect(collections.count).to(equal(1))
-                            expect(items.count).to(equal(2))
-                            expect(realm.objects(RCollection.self).count).to(equal(1))
-                            expect(realm.objects(RItem.self).count).to(equal(2))
-
-                            let item = realm.objects(RItem.self).filter("key = %@", "CCCCCCCC").first
-                            expect(item).toNot(beNil())
-                            expect(item?.deleted).to(beFalse())
-                            expect(item?.trash).to(beFalse())
-
-                            let collection = realm.objects(RCollection.self).filter("key = %@", collectionKey).first
-                            expect(collection).toNot(beNil())
-                            expect(collection?.syncState).to(equal(.synced))
-                            expect(collection?.version).to(equal(1))
-                            expect(collection?.deleted).to(beFalse())
-                            expect(collection?.trash).to(beFalse())
-                            expect(collection?.customLibraryKey).to(equal(RCustomLibraryType.myLibrary))
-                            expect(collection?.parentKey).to(beNil())
-                            expect(collection?.items.count).to(equal(2))
-
-                            doneAction()
                         }
 
                         self.syncController.start(type: .normal, libraries: .all, retryAttempt: 0)
@@ -1275,22 +1284,22 @@ final class SyncControllerSpec: QuickSpec {
                         baseUrl: baseUrl,
                         headers: header,
                         statusCode: 412,
-                        jsonResponse: [:]
+                        jsonResponse: [:] as [String: Any]
                     )
                     createStub(
                         for: SubmitDeletionsRequest(libraryId: libraryId, userId: self.userId, objectType: .item, keys: [deletedItemKey], version: 1),
                         baseUrl: baseUrl,
                         headers: header,
                         statusCode: 412,
-                        jsonResponse: [:]
+                        jsonResponse: [:] as [String: Any]
                     )
-                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:])
+                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:] as [String: Any])
                     objects.forEach { object in
                         createStub(
                             for: VersionsRequest(libraryId: libraryId, userId: self.userId, objectType: object, version: 1),
                             baseUrl: baseUrl,
                             headers: header,
-                            jsonResponse: versionResponses[object] ?? [:]
+                            jsonResponse: versionResponses[object] ?? [:] as [String: Any]
                         )
                     }
                     objects.forEach { object in
@@ -1298,57 +1307,73 @@ final class SyncControllerSpec: QuickSpec {
                             for: ObjectsRequest(libraryId: libraryId, userId: self.userId, objectType: object, keys: (objectKeys[object] ?? "")),
                             baseUrl: baseUrl,
                             headers: header,
-                            jsonResponse: objectResponses[object] ?? [:]
+                            jsonResponse: objectResponses[object] ?? [:] as [String: Any]
                         )
                     }
                     createStub(
                         for: SettingsRequest(libraryId: libraryId, userId: self.userId, version: 1),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["tagColors": ["value": [["name": "A", "color": "#CC66CC"]], "version": 1]]
+                        jsonResponse: ["tagColors": ["value": [["name": "A", "color": "#CC66CC"]], "version": 1] as [String: Any]]
                     )
                     createStub(
                         for: DeletionsRequest(libraryId: libraryId, userId: self.userId, version: 1),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["collections": [], "searches": [], "items": [], "tags": []]
+                        jsonResponse: ["collections": [] as [Any], "searches": [] as [Any], "items": [] as [Any], "tags": [] as [Any]]
                     )
 
                     waitUntil(timeout: .seconds(10)) { doneAction in
-                        self.syncController.reportFinish = { _ in
-                            let realm = try! Realm(configuration: self.realmConfig)
-                            realm.refresh()
+                        self.syncController.reportFinish = { result in
+                            switch result {
+                            case .failure(let error):
+                                fail("Failure: \(error)")
 
-                            let library = realm.objects(RCustomLibrary.self).first
-                            expect(library?.type).to(equal(.myLibrary))
+                            case .success(let data):
+                                // precondition error should be reported first time, retry
+                                guard let error = data.1.first as? Zotero.SyncError.NonFatal, case .preconditionFailed(let libraryId) = error else {
+                                    fail("Failure: \(result)")
+                                    return
+                                }
 
-                            let collections = realm.objects(RCollection.self).filter(.library(with: .custom(.myLibrary)))
-                            let items = realm.objects(RItem.self).filter(.library(with: .custom(.myLibrary)))
+                                self.syncController.reportFinish = { _ in
+                                    let realm = try! Realm(configuration: self.realmConfig)
+                                    realm.refresh()
 
-                            expect(collections.count).to(equal(1))
-                            expect(items.count).to(equal(2))
-                            expect(realm.objects(RCollection.self).count).to(equal(1))
-                            expect(realm.objects(RItem.self).count).to(equal(2))
+                                    let library = realm.objects(RCustomLibrary.self).first
+                                    expect(library?.type).to(equal(.myLibrary))
 
-                            let collection = realm.objects(RCollection.self).filter("key = %@", collectionKey).first
-                            expect(collection).toNot(beNil())
-                            expect(collection?.syncState).to(equal(.synced))
-                            expect(collection?.version).to(equal(2))
-                            expect(collection?.deleted).to(beFalse())
-                            expect(collection?.trash).to(beFalse())
-                            expect(collection?.customLibraryKey?.rawValue).to(equal(RCustomLibraryType.myLibrary.rawValue))
-                            expect(collection?.parentKey).to(beNil())
-                            expect(collection?.items.count).to(equal(2))
-                            if let collection = collection {
-                                expect(collection.items.map({ $0.key })).to(contain(["BBBBBBBB", "CCCCCCCC"]))
+                                    let collections = realm.objects(RCollection.self).filter(.library(with: .custom(.myLibrary)))
+                                    let items = realm.objects(RItem.self).filter(.library(with: .custom(.myLibrary)))
+
+                                    expect(collections.count).to(equal(1))
+                                    expect(items.count).to(equal(2))
+                                    expect(realm.objects(RCollection.self).count).to(equal(1))
+                                    expect(realm.objects(RItem.self).count).to(equal(2))
+
+                                    let collection = realm.objects(RCollection.self).filter("key = %@", collectionKey).first
+                                    expect(collection).toNot(beNil())
+                                    expect(collection?.syncState).to(equal(.synced))
+                                    expect(collection?.version).to(equal(2))
+                                    expect(collection?.deleted).to(beFalse())
+                                    expect(collection?.trash).to(beFalse())
+                                    expect(collection?.customLibraryKey?.rawValue).to(equal(RCustomLibraryType.myLibrary.rawValue))
+                                    expect(collection?.parentKey).to(beNil())
+                                    expect(collection?.items.count).to(equal(2))
+                                    if let collection = collection {
+                                        expect(collection.items.map({ $0.key })).to(contain(["BBBBBBBB", "CCCCCCCC"]))
+                                    }
+
+                                    let item = realm.objects(RItem.self).filter("key = %@", "CCCCCCCC").first
+                                    expect(item).toNot(beNil())
+                                    expect(item?.deleted).to(beFalse())
+                                    expect(item?.trash).to(beFalse())
+
+                                    doneAction()
+                                }
+
+                                self.syncController.start(type: .prioritizeDownloads, libraries: .specific([libraryId]), retryAttempt: 4)
                             }
-
-                            let item = realm.objects(RItem.self).filter("key = %@", "CCCCCCCC").first
-                            expect(item).toNot(beNil())
-                            expect(item?.deleted).to(beFalse())
-                            expect(item?.trash).to(beFalse())
-
-                            doneAction()
                         }
 
                         self.syncController.start(type: .normal, libraries: .all, retryAttempt: 0)
@@ -1366,23 +1391,32 @@ final class SyncControllerSpec: QuickSpec {
                     let objectKeys: [SyncObject: String] = [.item: itemKey]
                     let versionResponses: [SyncObject: Any] = [.item: [itemKey: 3]]
                     let libraryJson: [String: Any] = ["id": 0, "type": "user", "name": "A"]
-                    let objectResponses: [SyncObject: Any] = [.item: [["key": itemKey, "version": 3, "library": libraryJson,
-                                                                       "data": ["title": "New title", "filename": newFilename, "contentType": contentType, "itemType": "attachment", "linkMode": LinkMode.importedFile.rawValue]]]]
+                    let objectResponses: [SyncObject: Any] = [
+                        .item:
+                            [
+                                [
+                                    "key": itemKey,
+                                    "version": 3,
+                                    "library": libraryJson,
+                                    "data": ["title": "New title", "filename": newFilename, "contentType": contentType, "itemType": "attachment", "linkMode": LinkMode.importedFile.rawValue]
+                                ] as [String: Any]
+                            ]
+                    ]
 
                     createStub(for: KeyRequest(), baseUrl: baseUrl, url: Bundle(for: type(of: self)).url(forResource: "test_keys", withExtension: "json")!)
                     createStub(
                         for: SettingsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["tagColors": ["value": [], "version": 3]]
+                        jsonResponse: ["tagColors": ["value": [] as [Any], "version": 3] as [String: Any]]
                     )
-                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:])
+                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:] as [String: Any])
                     objects.forEach { object in
                         createStub(
                             for: VersionsRequest(libraryId: libraryId, userId: self.userId, objectType: object, version: 0),
                             baseUrl: baseUrl,
                             headers: header,
-                            jsonResponse: versionResponses[object] ?? [:]
+                            jsonResponse: versionResponses[object] ?? [:] as [String: Any]
                         )
                     }
                     objects.forEach { object in
@@ -1390,14 +1424,14 @@ final class SyncControllerSpec: QuickSpec {
                             for: ObjectsRequest(libraryId: libraryId, userId: self.userId, objectType: object, keys: (objectKeys[object] ?? "")),
                             baseUrl: baseUrl,
                             headers: header,
-                            jsonResponse: objectResponses[object] ?? [:]
+                            jsonResponse: objectResponses[object] ?? [:] as [String: Any]
                         )
                     }
                     createStub(
                         for: DeletionsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["collections": [], "searches": [], "items": [], "tags": []]
+                        jsonResponse: ["collections": [] as [Any], "searches": [] as [Any], "items": [] as [Any], "tags": [] as [Any]]
                     )
 
                     let file = Files.attachmentFile(in: libraryId, key: itemKey, filename: oldFilename, contentType: contentType)
@@ -1517,8 +1551,8 @@ final class SyncControllerSpec: QuickSpec {
                         let collectionResponseJson: [String: Any] = [
                             "key": collectionKey,
                             "version": newVersion,
-                            "library": ["library": "user", "id": 123, "name": ""],
-                            "data": ["name": "New name", "isTrash": false]
+                            "library": ["library": "user", "id": 123, "name": ""] as [String: Any],
+                            "data": ["name": "New name", "isTrash": false] as [String: Any]
                         ]
 
                         let params = request.httpBodyStream.flatMap({ self.jsonParameters(from: $0) })
@@ -1528,7 +1562,7 @@ final class SyncControllerSpec: QuickSpec {
                         expect(firstParams["version"] as? Int).to(equal(oldVersion))
                         expect(firstParams["name"] as? String).to(equal("New name"))
                         return HTTPStubsResponse(
-                            jsonObject: ["success": ["0": collectionKey], "successful": ["0": collectionResponseJson], "unchanged": [:], "failed": [:]],
+                            jsonObject: ["success": ["0": collectionKey], "successful": ["0": collectionResponseJson], "unchanged": [:] as [String: Any], "failed": [:] as [String: Any]],
                             statusCode: 200,
                             headers: ["last-modified-version": "\(newVersion)"]
                         )
@@ -1548,7 +1582,7 @@ final class SyncControllerSpec: QuickSpec {
                         expect(firstParams["numPages"] as? String).to(equal("1"))
                         expect(firstParams["callNumber"]).to(beNil())
                         return HTTPStubsResponse(
-                            jsonObject: ["success": ["0": itemKey], "successful": ["0": itemResponseJson], "unchanged": [:], "failed": [:]],
+                            jsonObject: ["success": ["0": itemKey] as [String: Any], "successful": ["0": itemResponseJson], "unchanged": [:] as [String: Any], "failed": [:] as [String: Any]],
                             statusCode: 200,
                             headers: ["last-modified-version": "\(newVersion)"]
                         )
@@ -1657,7 +1691,11 @@ final class SyncControllerSpec: QuickSpec {
                         expect(childPos).toNot(equal(-1))
                         expect(parentPos).to(beLessThan(childPos))
 
-                        return HTTPStubsResponse(jsonObject: ["success": ["0": [:]], "unchanged": [], "failed": []], statusCode: 200, headers: ["last-modified-version": "\(newVersion)"])
+                        return HTTPStubsResponse(
+                            jsonObject: ["success": ["0": [:] as [String: Any]], "unchanged": [] as [Any], "failed": [] as [Any]] as [String: Any],
+                            statusCode: 200,
+                            headers: ["last-modified-version": "\(newVersion)"]
+                        )
                     })
                     createStub(for: KeyRequest(), baseUrl: baseUrl, url: Bundle(for: type(of: self)).url(forResource: "test_keys", withExtension: "json")!)
 
@@ -1738,7 +1776,11 @@ final class SyncControllerSpec: QuickSpec {
                         expect(params[1]["key"] as? String).to(equal(secondKey))
                         expect(params[2]["key"] as? String).to(equal(thirdKey))
 
-                        return HTTPStubsResponse(jsonObject: ["success": ["0": [:]], "unchanged": [], "failed": []], statusCode: 200, headers: ["last-modified-version": "\(newVersion)"])
+                        return HTTPStubsResponse(
+                            jsonObject: ["success": ["0": [:] as [String: Any]], "unchanged": [] as [Any], "failed": [] as [Any]] as [String: Any],
+                            statusCode: 200,
+                            headers: ["last-modified-version": "\(newVersion)"]
+                        )
                     })
                     createStub(for: KeyRequest(), baseUrl: baseUrl, url: Bundle(for: type(of: self)).url(forResource: "test_keys", withExtension: "json")!)
 
@@ -1788,7 +1830,7 @@ final class SyncControllerSpec: QuickSpec {
                         baseUrl: baseUrl,
                         headers: ["last-modified-version": "\(newVersion)"],
                         statusCode: 200,
-                        jsonResponse: ["success": ["0": [:]], "unchanged": [], "failed": []]
+                        jsonResponse: ["success": ["0": [:] as [String: Any]], "unchanged": [] as [Any], "failed": [] as [Any]] as [String: Any]
                     )
 
                     waitUntil(timeout: .seconds(10)) { doneAction in
@@ -1818,28 +1860,28 @@ final class SyncControllerSpec: QuickSpec {
                     stub(condition: request.stubCondition(with: baseUrl), response: { _ -> HTTPStubsResponse in
                         let code = statusCode
                         statusCode = 200
-                        return HTTPStubsResponse(jsonObject: [:], statusCode: code, headers: header)
+                        return HTTPStubsResponse(jsonObject: [:] as [String: Any], statusCode: code, headers: header)
                     })
-                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:])
+                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:] as [String: Any])
                     objects.forEach { object in
                         createStub(
                             for: VersionsRequest(libraryId: libraryId, userId: self.userId, objectType: object, version: 0),
                             baseUrl: baseUrl,
                             headers: header,
-                            jsonResponse: [:]
+                            jsonResponse: [:] as [String: Any]
                         )
                     }
                     stub(condition: SettingsRequest(libraryId: libraryId, userId: self.userId, version: 0).stubCondition(with: baseUrl),
                          response: { _ -> HTTPStubsResponse in
                         downloadCalled = true
-                        return HTTPStubsResponse(jsonObject: [:], statusCode: 200, headers: header)
+                        return HTTPStubsResponse(jsonObject: [:] as [String: Any], statusCode: 200, headers: header)
                     })
                     createStub(for: KeyRequest(), baseUrl: baseUrl, url: Bundle(for: type(of: self)).url(forResource: "test_keys", withExtension: "json")!)
                     createStub(
                         for: DeletionsRequest(libraryId: libraryId, userId: self.userId, version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: ["collections": [], "searches": [], "items": [], "tags": []]
+                        jsonResponse: ["collections": [] as [Any], "searches": [] as [Any], "items": [] as [Any], "tags": [] as [Any]]
                     )
 
                     self.createNewSyncController()
@@ -1895,24 +1937,24 @@ final class SyncControllerSpec: QuickSpec {
                     }
 
                     createStub(for: KeyRequest(), baseUrl: baseUrl, url: Bundle(for: type(of: self)).url(forResource: "test_keys", withExtension: "json")!)
-                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:])
+                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: header, jsonResponse: [:] as [String: Any])
                     createStub(
                         for: SubmitDeletionsRequest(libraryId: libraryId, userId: self.userId, objectType: .collection, keys: [collectionKey], version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: [:]
+                        jsonResponse: [:] as [String: Any]
                     )
                     createStub(
                         for: SubmitDeletionsRequest(libraryId: libraryId, userId: self.userId, objectType: .search, keys: [searchKey], version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: [:]
+                        jsonResponse: [:] as [String: Any]
                     )
                     createStub(
                         for: SubmitDeletionsRequest(libraryId: libraryId, userId: self.userId, objectType: .item, keys: [itemKey], version: 0),
                         baseUrl: baseUrl,
                         headers: header,
-                        jsonResponse: [:]
+                        jsonResponse: [:] as [String: Any]
                     )
 
                     waitUntil(timeout: .seconds(10)) { doneAction in
@@ -2025,8 +2067,8 @@ final class SyncControllerSpec: QuickSpec {
                     ]
 
                     createStub(for: KeyRequest(), baseUrl: baseUrl, url: Bundle(for: type(of: self)).url(forResource: "test_keys", withExtension: "json")!)
-                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: nil, statusCode: 200, jsonResponse: [:])
-                    createStub(for: SettingsRequest(libraryId: libraryId, userId: self.userId, version: 0), baseUrl: baseUrl, statusCode: 304, jsonResponse: [:])
+                    createStub(for: GroupVersionsRequest(userId: self.userId), baseUrl: baseUrl, headers: nil, statusCode: 200, jsonResponse: [:] as [String: Any])
+                    createStub(for: SettingsRequest(libraryId: libraryId, userId: self.userId, version: 0), baseUrl: baseUrl, statusCode: 304, jsonResponse: [:] as [String: Any])
 
                     self.createNewSyncController()
 

--- a/ZoteroTests/SyncControllerSpec.swift
+++ b/ZoteroTests/SyncControllerSpec.swift
@@ -1899,7 +1899,7 @@ final class SyncControllerSpec: QuickSpec {
                         item.libraryId = .custom(.myLibrary)
                     }
 
-                    waitUntil(timeout: .seconds(1000)) { doneAction in
+                    waitUntil(timeout: .seconds(10)) { doneAction in
                         self.syncController.reportFinish = { result in
                             switch result {
                             case .failure(let error):

--- a/ZoteroTests/TranslatorsControllerSpec.swift
+++ b/ZoteroTests/TranslatorsControllerSpec.swift
@@ -54,7 +54,7 @@ final class TranslatorsControllerSpec: QuickSpec {
             self.controller.setupTest(timestamp: 0, hash: "", deleted: 0)
 
             // Perform update and wait for results
-            waitUntil(timeout: .seconds(1000000)) { doneAction in
+            waitUntil(timeout: .seconds(10)) { doneAction in
                 self.controller.isLoading.skip(1).filter({ !$0 }).first()
                     .observe(on: MainScheduler.instance)
                     .subscribe(onSuccess: { _ in

--- a/ZoteroTests/TranslatorsControllerSpec.swift
+++ b/ZoteroTests/TranslatorsControllerSpec.swift
@@ -23,8 +23,8 @@ final class TranslatorsControllerSpec: QuickSpec {
     private let bundledTimestamp = 1585834479
     private let translatorId = "bbf1617b-d836-4665-9aae-45f223264460"
     private let translatorUrl = "https://acontracorriente.chass.ncsu.edu/index.php/acontracorriente/article/view/1956"
-    private let bundledTranslatorTimestamp = 1471546264 // 2016-08-18 20:51:04
-    private let remoteTranslatorTimestamp = 1586181600 // 2020-04-06 16:00:00
+    private let bundledTranslatorTimestamp = 1471553464 // 2016-08-18 20:51:04
+    private let remoteTranslatorTimestamp = 1586188800 // 2020-04-06 16:00:00
     private let remoteTimestamp = 1586182261 // 2020-04-06 16:00:00
     // We need to retain realm with memory identifier so that data are not deleted
     private var realm: Realm!
@@ -54,7 +54,7 @@ final class TranslatorsControllerSpec: QuickSpec {
             self.controller.setupTest(timestamp: 0, hash: "", deleted: 0)
 
             // Perform update and wait for results
-            waitUntil(timeout: .seconds(10)) { doneAction in
+            waitUntil(timeout: .seconds(1000000)) { doneAction in
                 self.controller.isLoading.skip(1).filter({ !$0 }).first()
                     .observe(on: MainScheduler.instance)
                     .subscribe(onSuccess: { _ in


### PR DESCRIPTION
Background uploads can sometime pass and file is successfully uploaded to backend, but main app is not notified and local state is not updated, so when user opens main app it tries to upload the same file during sync again and receives 412 `If-None-Match: * set but file exists`. In this case we re-download the remote file version to be sure both are the same and mark file as uploaded.