### PR TITLE
Handle lookup item & attachment creation in IdentifierLookupController

### DIFF
--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -22,10 +22,11 @@
 		6144B5E12A4AE95E00914B3C /* WebDavControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3202C6B271048FF00485BE4 /* WebDavControllerSpec.swift */; };
 		614D65822A79C9AC007CF449 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 614D65802A79C9AC007CF449 /* Localizable.stringsdict */; };
 		614D65832A79C9B0007CF449 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 614D65802A79C9AC007CF449 /* Localizable.stringsdict */; };
+		614D65872A8030C9007CF449 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 614D65862A8030C9007CF449 /* OrderedCollections */; };
+		618404262A4456A9005AAF22 /* IdentifierLookupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618404252A4456A9005AAF22 /* IdentifierLookupController.swift */; };
 		61ABA7512A6137D1002A4219 /* ShareableImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61ABA7502A6137D1002A4219 /* ShareableImage.swift */; };
 		61BD13952A5831EF008A0704 /* TextKit1TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BD13942A5831EF008A0704 /* TextKit1TextView.swift */; };
 		61C817F22A49B5D30085B1E6 /* CollectionResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1EDEE250242E700D8BC1E /* CollectionResponseSpec.swift */; };
-		618404262A4456A9005AAF22 /* IdentifierLookupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618404252A4456A9005AAF22 /* IdentifierLookupController.swift */; };
 		B300B33324291C8D00C1FE1E /* RTranslatorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = B300B33224291C8D00C1FE1E /* RTranslatorMetadata.swift */; };
 		B300B3352429222B00C1FE1E /* TranslatorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = B300B3342429222B00C1FE1E /* TranslatorMetadata.swift */; };
 		B300B3362429234C00C1FE1E /* TranslatorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = B300B3342429222B00C1FE1E /* TranslatorMetadata.swift */; };
@@ -1201,9 +1202,9 @@
 		611486502A9CD511002EEBEF /* ci_post_xcodebuild.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_xcodebuild.sh; sourceTree = "<group>"; };
 		614D65812A79C9AC007CF449 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		614D65842A7BCC22007CF449 /* ci_post_clone.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_clone.sh; sourceTree = "<group>"; };
+		618404252A4456A9005AAF22 /* IdentifierLookupController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierLookupController.swift; sourceTree = "<group>"; };
 		61ABA7502A6137D1002A4219 /* ShareableImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableImage.swift; sourceTree = "<group>"; };
 		61BD13942A5831EF008A0704 /* TextKit1TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextKit1TextView.swift; sourceTree = "<group>"; };
-		618404252A4456A9005AAF22 /* IdentifierLookupController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierLookupController.swift; sourceTree = "<group>"; };
 		B300B33224291C8D00C1FE1E /* RTranslatorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTranslatorMetadata.swift; sourceTree = "<group>"; };
 		B300B3342429222B00C1FE1E /* TranslatorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslatorMetadata.swift; sourceTree = "<group>"; };
 		B300B3372429254900C1FE1E /* SyncTranslatorsDbRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTranslatorsDbRequest.swift; sourceTree = "<group>"; };
@@ -2036,6 +2037,7 @@
 				B356A39E2524A703003F1943 /* CocoaLumberjackSwift in Frameworks */,
 				B356A363252490B3003F1943 /* Alamofire in Frameworks */,
 				B356A369252490DB003F1943 /* KeychainSwift in Frameworks */,
+				614D65872A8030C9007CF449 /* OrderedCollections in Frameworks */,
 				B356A37B2524A63D003F1943 /* SwiftyGif in Frameworks */,
 				B356A3A02524A703003F1943 /* CocoaLumberjack in Frameworks */,
 				B35C9C082642A0BC0004C47E /* RealmSwift in Frameworks */,
@@ -4054,6 +4056,7 @@
 				B35C9C072642A0BC0004C47E /* RealmSwift */,
 				B3445F4526EF5EE9007D4009 /* CrashReporter */,
 				B3D84BEF27919FDE005DDD7C /* Starscream */,
+				614D65862A8030C9007CF449 /* OrderedCollections */,
 			);
 			productName = Zotero;
 			productReference = B30D59552206F60400884C4A /* Zotero.app */;
@@ -4195,6 +4198,7 @@
 				B35C9C042642A0BC0004C47E /* XCRemoteSwiftPackageReference "realm-cocoa" */,
 				B3445F4426EF5EE9007D4009 /* XCRemoteSwiftPackageReference "plcrashreporter" */,
 				B3D84BEE27919FDE005DDD7C /* XCRemoteSwiftPackageReference "Starscream" */,
+				614D65852A8030C9007CF449 /* XCRemoteSwiftPackageReference "swift-collections" */,
 			);
 			productRefGroup = B30D59562206F60400884C4A /* Products */;
 			projectDirPath = "";
@@ -6003,6 +6007,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		614D65852A8030C9007CF449 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-collections.git";
+			requirement = {
+				kind = exactVersion;
+				version = 1.0.4;
+			};
+		};
 		B3445F4426EF5EE9007D4009 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/microsoft/plcrashreporter";
@@ -6118,6 +6130,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		614D65862A8030C9007CF449 /* OrderedCollections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 614D65852A8030C9007CF449 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = OrderedCollections;
+		};
 		B3445F4526EF5EE9007D4009 /* CrashReporter */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = B3445F4426EF5EE9007D4009 /* XCRemoteSwiftPackageReference "plcrashreporter" */;

--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		61ABA7512A6137D1002A4219 /* ShareableImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61ABA7502A6137D1002A4219 /* ShareableImage.swift */; };
 		61BD13952A5831EF008A0704 /* TextKit1TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BD13942A5831EF008A0704 /* TextKit1TextView.swift */; };
 		61C817F22A49B5D30085B1E6 /* CollectionResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1EDEE250242E700D8BC1E /* CollectionResponseSpec.swift */; };
+		618404262A4456A9005AAF22 /* IdentifierLookupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618404252A4456A9005AAF22 /* IdentifierLookupController.swift */; };
 		B300B33324291C8D00C1FE1E /* RTranslatorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = B300B33224291C8D00C1FE1E /* RTranslatorMetadata.swift */; };
 		B300B3352429222B00C1FE1E /* TranslatorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = B300B3342429222B00C1FE1E /* TranslatorMetadata.swift */; };
 		B300B3362429234C00C1FE1E /* TranslatorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = B300B3342429222B00C1FE1E /* TranslatorMetadata.swift */; };
@@ -1202,6 +1203,7 @@
 		614D65842A7BCC22007CF449 /* ci_post_clone.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_clone.sh; sourceTree = "<group>"; };
 		61ABA7502A6137D1002A4219 /* ShareableImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableImage.swift; sourceTree = "<group>"; };
 		61BD13942A5831EF008A0704 /* TextKit1TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextKit1TextView.swift; sourceTree = "<group>"; };
+		618404252A4456A9005AAF22 /* IdentifierLookupController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierLookupController.swift; sourceTree = "<group>"; };
 		B300B33224291C8D00C1FE1E /* RTranslatorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTranslatorMetadata.swift; sourceTree = "<group>"; };
 		B300B3342429222B00C1FE1E /* TranslatorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslatorMetadata.swift; sourceTree = "<group>"; };
 		B300B3372429254900C1FE1E /* SyncTranslatorsDbRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTranslatorsDbRequest.swift; sourceTree = "<group>"; };
@@ -2164,6 +2166,7 @@
 				B36A988C2428E059005D5790 /* TranslatorsAndStylesController.swift */,
 				B3972688247D403200A8B469 /* UrlDetector.swift */,
 				B324276C25C81F2000567504 /* WebSocketController.swift */,
+				618404252A4456A9005AAF22 /* IdentifierLookupController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -5091,6 +5094,7 @@
 				B340ECA6290FDC9F00EE920D /* AnnotationToolbarViewController.swift in Sources */,
 				B3401D572567D8F700BB8D6E /* AnnotationViewController.swift in Sources */,
 				B3830CE2255451C200910FE0 /* TagPickerActionHandler.swift in Sources */,
+				618404262A4456A9005AAF22 /* IdentifierLookupController.swift in Sources */,
 				B305662223FC051F003304F2 /* StoreVersionSyncAction.swift in Sources */,
 				B3BC25CD247E6BA000AC27B5 /* DateParser.swift in Sources */,
 				B305662523FC051F003304F2 /* RevertLibraryUpdatesSyncAction.swift in Sources */,

--- a/Zotero.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Zotero.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -136,6 +136,15 @@
       }
     },
     {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -134,6 +134,7 @@
 "items.filters.title" = "Filters";
 "items.filters.downloads" = "Downloaded Files";
 "items.filters.tags" = "Tags";
+"items.toolbar_saved" = "Saved %d / %d";
 "items.toolbar_downloaded" = "Downloaded %d / %d";
 "items.generating_bib" = "Generating Bibliography";
 "items.creator_summary.and" = "%@ and %@";

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -472,7 +472,8 @@
 "errors.citation.invalid_types" = "Invalid item types selected.";
 "errors.citation.missing_style" = "No citation style selected. Go to Settings → Quick Copy and select a new style.";
 "errors.citation.open_settings" = "Open Settings";
-"errors.lookup" = "Zotero could not find any identifiers in your input. Please verify your input and try again.";
+"errors.lookup.no_identifiers_and_no_lookup_data" = "Zotero could not find any identifiers in your input. Please verify your input and try again.";
+"errors.lookup.no_identifiers_with_lookup_data" = "Zotero could not find any new identifiers in your input, or they are already being added. Please verify your input and try again.";
 "errors.pdf.merge_too_big_title" = "Unable to merge annotations";
 "errors.pdf.merge_too_big" = "The combined annotation would be too large.";
 "errors.pdf.cant_update_annotation" = "Can't update annotation.";

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -53,6 +53,7 @@
 "size" = "Size";
 "remove" = "Remove";
 "keep" = "Keep";
+"cancel_all" = "Cancel All";
 
 "beta_wipe_title" = "Resync Required";
 "beta_wipe_message" = "Due to a beta update, your data must be redownloaded from zotero.org.";

--- a/Zotero/Controllers/Attachment Downloader/AttachmentDownloadOperation.swift
+++ b/Zotero/Controllers/Attachment Downloader/AttachmentDownloadOperation.swift
@@ -37,7 +37,16 @@ class AttachmentDownloadOperation: AsynchronousOperation {
 
     var finishedDownload: ((Result<(), Swift.Error>) -> Void)?
 
-    init(file: File, download: AttachmentDownloader.Download, progress: Progress, userId: Int, apiClient: ApiClient, webDavController: WebDavController, fileStorage: FileStorage, queue: DispatchQueue) {
+    init(
+        file: File,
+        download: AttachmentDownloader.Download,
+        progress: Progress,
+        userId: Int,
+        apiClient: ApiClient,
+        webDavController: WebDavController,
+        fileStorage: FileStorage,
+        queue: DispatchQueue
+    ) {
         self.file = file
         self.download = download
         self.progress = progress
@@ -231,7 +240,9 @@ class AttachmentDownloadOperation: AsynchronousOperation {
             self.zipProgress = nil
             // Try removing downloaded file.
             try? self.fileStorage.remove(Files.attachmentDirectory(in: self.download.libraryId, key: self.download.key))
-        case .done: break
+            
+        case .done:
+            break
         }
 
         self.finishedDownload?(.failure(Error.cancelled))

--- a/Zotero/Controllers/Attachment Downloader/AttachmentDownloader.swift
+++ b/Zotero/Controllers/Attachment Downloader/AttachmentDownloader.swift
@@ -123,11 +123,13 @@ final class AttachmentDownloader {
 
                 case .file(let filename, let contentType, let location, let linkType):
                     switch linkType {
-                    case .linkedFile, .embeddedImage: break
+                    case .linkedFile, .embeddedImage:
+                        break
 
                     case .importedFile, .importedUrl:
                         switch location {
-                        case .local: break
+                        case .local:
+                            break
 
                         case .remote, .remoteMissing, .localAndChangedRemotely:
                             DDLogInfo("AttachmentDownloader: batch download remote\(location == .remoteMissing ? "ly missing" : "") file \(attachment.key)")
@@ -269,8 +271,16 @@ final class AttachmentDownloader {
         let observer = progress.observe(\.fractionCompleted) { [weak self] progress, _ in
             self?.observable.on(.next(Update(download: download, parentKey: parentKey, kind: .progress(CGFloat(progress.fractionCompleted)))))
         }
-        let operation = AttachmentDownloadOperation(file: file, download: download, progress: progress, userId: self.userId, apiClient: self.apiClient, webDavController: self.webDavController,
-                                                    fileStorage: self.fileStorage, queue: self.processingQueue)
+        let operation = AttachmentDownloadOperation(
+            file: file,
+            download: download,
+            progress: progress,
+            userId: userId,
+            apiClient: apiClient,
+            webDavController: webDavController,
+            fileStorage: fileStorage,
+            queue: processingQueue
+        )
         operation.finishedDownload = { [weak self] result in
             guard let self = self else { return }
 

--- a/Zotero/Controllers/Attachment Downloader/RemoteAttachmentDownloadOperation.swift
+++ b/Zotero/Controllers/Attachment Downloader/RemoteAttachmentDownloadOperation.swift
@@ -137,7 +137,9 @@ class RemoteAttachmentDownloadOperation: AsynchronousOperation {
             self.request?.cancel()
             self.disposeBag = nil
             self.request = nil
-        case .done: break
+            
+        case .done:
+            break
         }
 
         self.finishedDownload?(.failure(Error.cancelled))

--- a/Zotero/Controllers/Attachment Downloader/RemoteAttachmentDownloader.swift
+++ b/Zotero/Controllers/Attachment Downloader/RemoteAttachmentDownloader.swift
@@ -122,13 +122,13 @@ final class RemoteAttachmentDownloader {
             let progress = Progress(totalUnitCount: 100)
             let operation = RemoteAttachmentDownloadOperation(url: url, file: file, progress: progress, apiClient: apiClient, fileStorage: fileStorage, queue: processingQueue)
             operation.finishedDownload = { [weak self] result in
-                self?.processingQueue.async(flags: .barrier) {
+                self?.accessQueue.async(flags: .barrier) {
                     guard let self else { return }
                     self.finish(download: download, file: file, attachment: attachment, parentKey: parentKey, result: result)
                 }
             }
             operation.progressHandler = { [weak self] progress in
-                self?.processingQueue.async(flags: .barrier) {
+                self?.accessQueue.async(flags: .barrier) {
                     guard let self else { return }
                     self.observe(progress: progress, attachment: attachment, download: download)
                 }

--- a/Zotero/Controllers/Controllers.swift
+++ b/Zotero/Controllers/Controllers.swift
@@ -264,6 +264,10 @@ final class Controllers {
         controllers?.disableSync(apiKey: self.apiKey)
         // Cancel all downloads
         controllers?.fileDownloader.stop()
+        // Cancel all identifier lookups
+        controllers?.identifierLookupController.cancelAllLookups()
+        // Cancel all remote downloads
+        controllers?.remoteFileDownloader.stop()
         // Cancel all background uploads
         controllers?.backgroundUploadObserver.cancelAllUploads()
         // Clear user controllers

--- a/Zotero/Controllers/Controllers.swift
+++ b/Zotero/Controllers/Controllers.swift
@@ -296,6 +296,7 @@ final class UserControllers {
     let backgroundUploadObserver: BackgroundUploadObserver
     let fileDownloader: AttachmentDownloader
     let remoteFileDownloader: RemoteAttachmentDownloader
+    let identifierLookupController: IdentifierLookupController
     let webSocketController: WebSocketController
     let fileCleanupController: AttachmentFileCleanupController
     let citationController: CitationController
@@ -362,6 +363,13 @@ final class UserControllers {
         self.backgroundUploadObserver = backgroundUploadObserver
         self.fileDownloader = fileDownloader
         self.remoteFileDownloader = RemoteAttachmentDownloader(apiClient: controllers.apiClient, fileStorage: controllers.fileStorage)
+        self.identifierLookupController = IdentifierLookupController(
+            dbStorage: dbStorage,
+            fileStorage: controllers.fileStorage,
+            schemaController: controllers.schemaController,
+            dateParser: controllers.dateParser,
+            remoteFileDownloader: remoteFileDownloader
+        )
         self.webSocketController = webSocketController
         self.fileCleanupController = fileCleanupController
         self.citationController = CitationController(stylesController: controllers.translatorsAndStylesController, fileStorage: controllers.fileStorage,

--- a/Zotero/Controllers/Controllers.swift
+++ b/Zotero/Controllers/Controllers.swift
@@ -366,6 +366,7 @@ final class UserControllers {
         self.identifierLookupController = IdentifierLookupController(
             dbStorage: dbStorage,
             fileStorage: controllers.fileStorage,
+            translatorsController: controllers.translatorsAndStylesController,
             schemaController: controllers.schemaController,
             dateParser: controllers.dateParser,
             remoteFileDownloader: remoteFileDownloader

--- a/Zotero/Controllers/IdentifierLookupController.swift
+++ b/Zotero/Controllers/IdentifierLookupController.swift
@@ -21,7 +21,7 @@ protocol IdentifierLookupPresenter: AnyObject {
     func isPresenting() -> Bool
 }
 
-final class IdentifierLookupController: BackgroundDbProcessingActionHandler {
+final class IdentifierLookupController {
     // MARK: Types
     struct Update {
         enum Kind {

--- a/Zotero/Controllers/IdentifierLookupController.swift
+++ b/Zotero/Controllers/IdentifierLookupController.swift
@@ -127,23 +127,24 @@ final class IdentifierLookupController {
             defer {
                 completion(lookupData)
             }
-            guard let self = self else { return }
+            guard let self else { return }
             let lookupSettings = LookupWebViewHandler.LookupSettings(libraryIdentifier: libraryId, collectionKeys: collectionKeys)
-            if self.lookupWebViewHandlersByLookupSettings[lookupSettings] != nil {
+            if lookupWebViewHandlersByLookupSettings[lookupSettings] != nil {
                 lookupData = self.lookupData
                 return
             }
+            var lookupWebViewHandler: LookupWebViewHandler?
             inMainThread(sync: true) {
                 if let webView = self.webViewProvider?.addWebView() {
-                    let lookupWebViewHandler = LookupWebViewHandler(lookupSettings: lookupSettings, webView: webView, translatorsController: self.translatorsController)
-                    self.lookupWebViewHandlersByLookupSettings[lookupSettings] = lookupWebViewHandler
+                    lookupWebViewHandler = LookupWebViewHandler(lookupSettings: lookupSettings, webView: webView, translatorsController: self.translatorsController)
                 }
             }
-            guard let lookupWebViewHandler = self.lookupWebViewHandlersByLookupSettings[lookupSettings] else {
+            guard let lookupWebViewHandler else {
                 DDLogError("IdentifierLookupController: can't create LookupWebViewHandler instance")
                 return
             }
-            self.setupObserver(for: lookupWebViewHandler)
+            lookupWebViewHandlersByLookupSettings[lookupSettings] = lookupWebViewHandler
+            setupObserver(for: lookupWebViewHandler)
             lookupData = self.lookupData
         }
     }

--- a/Zotero/Controllers/IdentifierLookupController.swift
+++ b/Zotero/Controllers/IdentifierLookupController.swift
@@ -271,7 +271,10 @@ final class IdentifierLookupController {
                     }
                     
                 case .item(let data):
-                    guard let lookupId = data["identifier"] as? [String: String] else { return }
+                    guard let lookupId = data["identifier"] as? [String: String] else {
+                        DDLogWarn("IdentifierLookupController: lookup item data don't contain identifier")
+                        return
+                    }
                     let identifier = identifier(from: lookupId)
 
                     if data.keys.count == 1 {

--- a/Zotero/Controllers/IdentifierLookupController.swift
+++ b/Zotero/Controllers/IdentifierLookupController.swift
@@ -175,15 +175,13 @@ final class IdentifierLookupController {
                     return nil
                 }
             }
-            for (response, libraryId) in storedItemResponses {
-                self.backgroundQueue.async { [weak self] in
-                    guard let self else { return }
-                    do {
-                        let request = MarkItemsAsTrashedDbRequest(keys: [response.key], libraryId: libraryId, trashed: true)
-                        try dbStorage.perform(request: request, on: backgroundQueue)
-                    } catch let error {
-                        DDLogError("IdentifierLookupController: can't trash item(s) - \(error)")
-                    }
+            self.backgroundQueue.async { [weak self] in
+                guard let self else { return }
+                do {
+                    let requests = storedItemResponses.map({ MarkItemsAsTrashedDbRequest(keys: [$0.0.key], libraryId: $0.1, trashed: true) })
+                    try dbStorage.perform(writeRequests: requests, on: backgroundQueue)
+                } catch let error {
+                    DDLogError("IdentifierLookupController: can't trash item(s) - \(error)")
                 }
             }
         }

--- a/Zotero/Controllers/IdentifierLookupController.swift
+++ b/Zotero/Controllers/IdentifierLookupController.swift
@@ -21,16 +21,22 @@ final class IdentifierLookupController: BackgroundDbProcessingActionHandler {
     // MARK: Types
     struct Update {
         enum Kind {
+            case lookupError(error: Swift.Error)
+            case noIdentifiersDetected
+            case identifiersDetected(identifiers: [String])
+            case lookupInProgress(identifier: String)
+            case lookupFailed(identifier: String)
+            case parseFailed(identifier: String)
+            case itemCreationFailed(identifier: String, response: ItemResponse, attachments: [(Attachment, URL)])
             case itemStored(identifier: String, response: ItemResponse, attachments: [(Attachment, URL)])
             case pendingAttachments(identifier: String, response: ItemResponse, attachments: [(Attachment, URL)])
-            case itemCreationFailed(identifier: String, response: ItemResponse, attachments: [(Attachment, URL)])
         }
 
         let kind: Kind
     }
     
     // MARK: Properties
-    let observable: PublishSubject<Update>
+    private let observable: PublishSubject<Update>
     internal let backgroundQueue: DispatchQueue
     internal unowned let dbStorage: DbStorage
     private unowned let fileStorage: FileStorage
@@ -43,6 +49,8 @@ final class IdentifierLookupController: BackgroundDbProcessingActionHandler {
     internal weak var webViewProvider: IdentifierLookupWebViewProvider?
     private var webView: WKWebView?
     private var lookupWebViewHandler: LookupWebViewHandler?
+    private var libraryId: LibraryIdentifier?
+    private var collectionKeys: Set<String>?
     
     // MARK: Object Lifecycle
     init(
@@ -68,14 +76,15 @@ final class IdentifierLookupController: BackgroundDbProcessingActionHandler {
     }
     
     // MARK: Actions
-    func initialize(completion: @escaping (LookupWebViewHandler?) -> Void) {
+    func initialize(libraryId: LibraryIdentifier, collectionKeys: Set<String>, completion: @escaping (PublishSubject<Update>?) -> Void) {
         backgroundQueue.async { [weak self] in
-            var lookupWebViewHandler: LookupWebViewHandler?
+            var observable: PublishSubject<Update>?
             defer {
-                completion(lookupWebViewHandler)
+                completion(observable)
             }
             guard let self = self else { return }
-            
+            self.libraryId = libraryId
+            self.collectionKeys = collectionKeys
             if self.lookupWebViewHandler == nil {
                 inMainThread(sync: true) {
                     if let webView = self.webViewProvider?.addWebView() {
@@ -83,41 +92,19 @@ final class IdentifierLookupController: BackgroundDbProcessingActionHandler {
                         self.lookupWebViewHandler = .init(webView: webView, translatorsController: self.translatorsController)
                     }
                 }
+                if let lookupWebViewHandler = self.lookupWebViewHandler {
+                    self.setupObserver(for: lookupWebViewHandler)
+                } else {
+                    DDLogError("IdentifierLookupController: can't create LookupWebViewHandler instance")
+                }
             }
-            lookupWebViewHandler = self.lookupWebViewHandler
-            guard lookupWebViewHandler != nil else {
-                return
-            }
+            guard self.lookupWebViewHandler != nil else { return }
+            observable = self.observable
         }
     }
     
     func lookUp(identifier: String) {
         lookupWebViewHandler?.lookUp(identifier: identifier)
-    }
-    
-    func process(identifier: String, response: ItemResponse, attachments: [(Attachment, URL)]) {
-        func storeDataAndDownloadAttachmentIfNecessary(identifier: String, response: ItemResponse, attachments: [(Attachment, URL)]) throws {
-            let request = CreateTranslatedItemsDbRequest(responses: [response], schemaController: schemaController, dateParser: dateParser)
-            try dbStorage.perform(request: request, on: backgroundQueue)
-            observable.on(.next(Update(kind: .itemStored(identifier: identifier, response: response, attachments: attachments))))
-            
-            guard Defaults.shared.shareExtensionIncludeAttachment else { return }
-
-            let downloadData = attachments.map({ ($0, $1, response.key) })
-            guard !downloadData.isEmpty else { return }
-            remoteFileDownloader.download(data: downloadData)
-            observable.on(.next(Update(kind: .pendingAttachments(identifier: identifier, response: response, attachments: attachments))))
-        }
-
-        backgroundQueue.async { [weak self] in
-            guard let self = self else { return }
-            do {
-                try storeDataAndDownloadAttachmentIfNecessary(identifier: identifier, response: response, attachments: attachments)
-            } catch let error {
-                DDLogError("IdentifierLookupController: can't create item(s) - \(error)")
-                self.observable.on(.next(Update(kind: .itemCreationFailed(identifier: identifier, response: response, attachments: attachments))))
-            }
-        }
     }
     
     // MARK: Setups
@@ -158,6 +145,128 @@ final class IdentifierLookupController: BackgroundDbProcessingActionHandler {
                 case .cancelled, .failed, .progress:
                     break
                 }
+            }
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func setupObserver(for lookupWebViewHandler: LookupWebViewHandler) {
+        func process(result: Result<LookupWebViewHandler.LookupData, Error>) {
+            func process(data: LookupWebViewHandler.LookupData) {
+                func identifier(from data: [String: String]) -> String {
+                    var result = ""
+                    for (key, value) in data {
+                        result += key + ":" + value
+                    }
+                    return result
+                }
+
+                /// Tries to parse `ItemResponse` from data returned by translation server. It prioritizes items with attachments if there are multiple items.
+                /// - parameter itemData: Data to parse
+                /// - parameter schemaController: SchemaController which is used for validating item type and field types
+                /// - returns: `ItemResponse` of parsed item and optional attachment dictionary with title and url.
+                func parse(_ itemData: [String: Any]) -> (ItemResponse, [(Attachment, URL)])? {
+                    guard let libraryId, let collectionKeys else { return nil }
+                    do {
+                        let item = try ItemResponse(translatorResponse: itemData, schemaController: schemaController).copy(libraryId: libraryId, collectionKeys: collectionKeys, tags: [])
+
+                        let attachments = ((itemData["attachments"] as? [[String: Any]]) ?? []).compactMap { data -> (Attachment, URL)? in
+                            // We can't process snapshots yet, so ignore all text/html attachments
+                            guard let mimeType = data["mimeType"] as? String, mimeType != "text/html", let ext = mimeType.extensionFromMimeType,
+                                  let urlString = data["url"] as? String, let url = URL(string: urlString)
+                            else { return nil }
+
+                            let key = KeyGenerator.newKey
+                            let filename = FilenameFormatter.filename(from: item, defaultTitle: "Full Text", ext: ext, dateParser: dateParser)
+                            let attachment = Attachment(
+                                type: .file(filename: filename, contentType: mimeType, location: .local, linkType: .importedFile),
+                                title: filename,
+                                key: key,
+                                libraryId: libraryId
+                            )
+
+                            return (attachment, url)
+                        }
+
+                        return (item, attachments)
+                    } catch let error {
+                        DDLogError("IdentifierLookupController: can't parse data - \(error)")
+                        return nil
+                    }
+                }
+                
+                func process(identifier: String, response: ItemResponse, attachments: [(Attachment, URL)]) {
+                    func storeDataAndDownloadAttachmentIfNecessary(identifier: String, response: ItemResponse, attachments: [(Attachment, URL)]) throws {
+                        let request = CreateTranslatedItemsDbRequest(responses: [response], schemaController: schemaController, dateParser: dateParser)
+                        try dbStorage.perform(request: request, on: backgroundQueue)
+                        observable.on(.next(Update(kind: .itemStored(identifier: identifier, response: response, attachments: attachments))))
+                        
+                        guard Defaults.shared.shareExtensionIncludeAttachment else { return }
+
+                        let downloadData = attachments.map({ ($0, $1, response.key) })
+                        guard !downloadData.isEmpty else { return }
+                        remoteFileDownloader.download(data: downloadData)
+                        observable.on(.next(Update(kind: .pendingAttachments(identifier: identifier, response: response, attachments: attachments))))
+                    }
+
+                    backgroundQueue.async { [weak self] in
+                        guard let self = self else { return }
+                        do {
+                            try storeDataAndDownloadAttachmentIfNecessary(identifier: identifier, response: response, attachments: attachments)
+                        } catch let error {
+                            DDLogError("IdentifierLookupController: can't create item(s) - \(error)")
+                            self.observable.on(.next(Update(kind: .itemCreationFailed(identifier: identifier, response: response, attachments: attachments))))
+                        }
+                    }
+                }
+                
+                switch data {
+                case .identifiers(let identifiers):
+                    if identifiers.isEmpty {
+                        observable.on(.next(Update(kind: .noIdentifiersDetected)))
+                    } else {
+                        observable.on(.next(Update(kind: .identifiersDetected(identifiers: identifiers.map({ identifier(from: $0) })))))
+                    }
+                    
+                case .item(let data):
+                    guard let lookupId = data["identifier"] as? [String: String] else { return }
+                    let identifier = identifier(from: lookupId)
+
+                    if data.keys.count == 1 {
+                        observable.on(.next(Update(kind: .lookupInProgress(identifier: identifier))))
+                        return
+                    }
+
+                    if let error = data["error"] {
+                        DDLogError("IdentifierLookupController: \(identifier) lookup failed - \(error)")
+                        observable.on(.next(Update(kind: .lookupFailed(identifier: identifier))))
+                        return
+                    }
+
+                    guard let itemData = data["data"] as? [[String: Any]],
+                          let item = itemData.first,
+                          let (response, attachments) = parse(item)
+                    else {
+                        observable.on(.next(Update(kind: .parseFailed(identifier: identifier))))
+                        return
+                    }
+
+                    process(identifier: identifier, response: response, attachments: attachments)
+                }
+            }
+            
+            switch result {
+            case .success(let data):
+                process(data: data)
+                
+            case .failure(let error):
+                DDLogError("IdentifierLookupController: lookup failed - \(error)")
+                observable.on(.next(Update(kind: .lookupError(error: error))))
+            }
+        }
+        
+        lookupWebViewHandler.observable
+            .subscribe { result in
+                process(result: result)
             }
             .disposed(by: self.disposeBag)
     }

--- a/Zotero/Controllers/IdentifierLookupController.swift
+++ b/Zotero/Controllers/IdentifierLookupController.swift
@@ -158,10 +158,9 @@ final class IdentifierLookupController {
             DDLogInfo("IdentifierLookupController: cancel all lookups")
             let keys = self.lookupWebViewHandlersByLookupSettings.keys
             for key in keys {
-                if let webView = self.lookupWebViewHandlersByLookupSettings.removeValue(forKey: key)?.webViewHandler.webView {
-                    inMainThread {
-                        webView.removeFromSuperview()
-                    }
+                guard let webView = self.lookupWebViewHandlersByLookupSettings.removeValue(forKey: key)?.webViewHandler.webView else { continue }
+                inMainThread {
+                    webView.removeFromSuperview()
                 }
             }
             self.remoteFileDownloader.stop()

--- a/Zotero/Controllers/IdentifierLookupController.swift
+++ b/Zotero/Controllers/IdentifierLookupController.swift
@@ -14,7 +14,6 @@ import RxSwift
 
 protocol IdentifierLookupWebViewProvider: AnyObject {
     func addWebView() -> WKWebView
-    func removeWebView(_ webView: WKWebView)
 }
 
 protocol IdentifierLookupPresenter: AnyObject {
@@ -161,7 +160,7 @@ final class IdentifierLookupController {
             for key in keys {
                 if let webView = self.lookupWebViewHandlersByLookupSettings.removeValue(forKey: key)?.webViewHandler.webView {
                     inMainThread {
-                        self.webViewProvider?.removeWebView(webView)
+                        webView.removeFromSuperview()
                     }
                 }
             }

--- a/Zotero/Controllers/IdentifierLookupController.swift
+++ b/Zotero/Controllers/IdentifierLookupController.swift
@@ -146,7 +146,11 @@ final class IdentifierLookupController {
     
     func lookUp(libraryId: LibraryIdentifier, collectionKeys: Set<String>, identifier: String) {
         let lookupSettings = LookupWebViewHandler.LookupSettings(libraryIdentifier: libraryId, collectionKeys: collectionKeys)
-        lookupWebViewHandlersByLookupSettings[lookupSettings]?.lookUp(identifier: identifier)
+        guard let lookupWebViewHandler = lookupWebViewHandlersByLookupSettings[lookupSettings] else {
+            DDLogError("IdentifierLookupController: can't find lookup web view handler for settings - \(lookupSettings)")
+            return
+        }
+        lookupWebViewHandler.lookUp(identifier: identifier)
     }
     
     func cancelAllLookups() {

--- a/Zotero/Controllers/IdentifierLookupController.swift
+++ b/Zotero/Controllers/IdentifierLookupController.swift
@@ -1,0 +1,118 @@
+//
+//  IdentifierLookupController.swift
+//  Zotero
+//
+//  Created by Miltiadis Vasilakis on 22/6/23.
+//  Copyright © 2023 Corporation for Digital Scholarship. All rights reserved.
+//
+
+import Foundation
+
+import CocoaLumberjackSwift
+import RxSwift
+
+final class IdentifierLookupController: BackgroundDbProcessingActionHandler {
+    // MARK: Types
+    struct Update {
+        enum Kind: Hashable {
+            case itemStored
+            case pendingAttachments
+            case itemCreationFailed
+        }
+
+        let identifier: String
+        let response: ItemResponse
+        let attachments: [(Attachment, URL)]
+        let kind: Kind
+    }
+    
+    // MARK: Properties
+    let observable: PublishSubject<Update>
+    internal let backgroundQueue: DispatchQueue
+    internal unowned let dbStorage: DbStorage
+    private unowned let fileStorage: FileStorage
+    private unowned let schemaController: SchemaController
+    private unowned let dateParser: DateParser
+    private unowned let remoteFileDownloader: RemoteAttachmentDownloader
+    private let disposeBag: DisposeBag
+    
+    // MARK: Object Lifecycle
+    init(dbStorage: DbStorage, fileStorage: FileStorage, schemaController: SchemaController, dateParser: DateParser, remoteFileDownloader: RemoteAttachmentDownloader) {
+        self.fileStorage = fileStorage
+        self.dbStorage = dbStorage
+        self.schemaController = schemaController
+        self.dateParser = dateParser
+        self.remoteFileDownloader = remoteFileDownloader
+        
+        self.backgroundQueue = DispatchQueue(label: "org.zotero.IdentifierLookupController.backgroundProcessing", qos: .userInitiated)
+        self.observable = PublishSubject()
+        self.disposeBag = DisposeBag()
+        
+        remoteFileDownloader.observable
+            .subscribe { [weak self] update in
+                guard let self else { return }
+                switch update.kind {
+                case .ready(let attachment):
+                    self.finish(download: update.download, attachment: attachment)
+                    
+                case .cancelled, .failed, .progress:
+                    break
+                }
+            }
+            .disposed(by: self.disposeBag)
+    }
+    
+    // MARK: Actions
+    func process(identifier: String, response: ItemResponse, attachments: [(Attachment, URL)]) {
+        backgroundQueue.async { [weak self] in
+            guard let self = self else { return }
+            do {
+                try self.storeDataAndDownloadAttachmentIfNecessary(identifier: identifier, response: response, attachments: attachments)
+            } catch let error {
+                DDLogError("IdentifierLookupController: can't create item(s) - \(error)")
+                observable.on(.next(Update(identifier: identifier, response: response, attachments: attachments, kind: .itemCreationFailed)))
+            }
+        }
+    }
+    
+    // MARK: Helper Methods
+    private func storeDataAndDownloadAttachmentIfNecessary(identifier: String, response: ItemResponse, attachments: [(Attachment, URL)]) throws {
+        let request = CreateTranslatedItemsDbRequest(responses: [response], schemaController: schemaController, dateParser: dateParser)
+        try dbStorage.perform(request: request, on: backgroundQueue)
+        observable.on(.next(Update(identifier: identifier, response: response, attachments: attachments, kind: .itemStored)))
+        
+        guard Defaults.shared.shareExtensionIncludeAttachment else { return }
+
+        let downloadData = attachments.map({ ($0, $1, response.key) })
+        guard !downloadData.isEmpty else { return }
+        remoteFileDownloader.download(data: downloadData)
+        observable.on(.next(Update(identifier: identifier, response: response, attachments: attachments, kind: .pendingAttachments)))
+    }
+    
+    private func finish(download: RemoteAttachmentDownloader.Download, attachment: Attachment) {
+        let localizedType = schemaController.localized(itemType: ItemTypes.attachment) ?? ItemTypes.attachment
+        
+        backgroundQueue.async { [weak self] in
+            guard let self else { return }
+            
+            do {
+                let request = CreateAttachmentDbRequest(
+                    attachment: attachment,
+                    parentKey: download.parentKey,
+                    localizedType: localizedType,
+                    includeAccessDate: attachment.hasUrl,
+                    collections: [],
+                    tags: []
+                )
+                _ = try self.dbStorage.perform(request: request, on: self.backgroundQueue)
+            } catch let error {
+                DDLogError("IdentifierLookupController: can't store attachment after download - \(error)")
+                
+                // Storing item failed, remove downloaded file
+                guard case .file(let filename, let contentType, _, _) = attachment.type else { return }
+                let file = Files.attachmentFile(in: attachment.libraryId, key: attachment.key, filename: filename, contentType: contentType)
+                try? self.fileStorage.remove(file)
+            }
+        }
+    }
+}

--- a/Zotero/Controllers/IdentifierLookupController.swift
+++ b/Zotero/Controllers/IdentifierLookupController.swift
@@ -70,7 +70,7 @@ final class IdentifierLookupController: BackgroundDbProcessingActionHandler {
                 try self.storeDataAndDownloadAttachmentIfNecessary(identifier: identifier, response: response, attachments: attachments)
             } catch let error {
                 DDLogError("IdentifierLookupController: can't create item(s) - \(error)")
-                observable.on(.next(Update(identifier: identifier, response: response, attachments: attachments, kind: .itemCreationFailed)))
+                self.observable.on(.next(Update(identifier: identifier, response: response, attachments: attachments, kind: .itemCreationFailed)))
             }
         }
     }

--- a/Zotero/Controllers/Web View Handling/LookupWebViewHandler.swift
+++ b/Zotero/Controllers/Web View Handling/LookupWebViewHandler.swift
@@ -14,6 +14,11 @@ import RxCocoa
 import RxSwift
 
 final class LookupWebViewHandler {
+    struct LookupSettings: Hashable {
+        let libraryIdentifier: LibraryIdentifier
+        let collectionKeys: Set<String>
+    }
+
     /// Handlers for communication with JS in `webView`
     enum JSHandlers: String, CaseIterable {
         /// Handler used for reporting new items.
@@ -46,6 +51,7 @@ final class LookupWebViewHandler {
         case failed(Swift.Error)
     }
 
+    let lookupSettings: LookupSettings
     private let webViewHandler: WebViewHandler
     private let translatorsController: TranslatorsAndStylesController
     private let disposeBag: DisposeBag
@@ -53,7 +59,8 @@ final class LookupWebViewHandler {
 
     private var isLoading: BehaviorRelay<InitializationResult>
 
-    init(webView: WKWebView, translatorsController: TranslatorsAndStylesController) {
+    init(lookupSettings: LookupSettings, webView: WKWebView, translatorsController: TranslatorsAndStylesController) {
+        self.lookupSettings = lookupSettings
         self.translatorsController = translatorsController
         self.webViewHandler = WebViewHandler(webView: webView, javascriptHandlers: JSHandlers.allCases.map({ $0.rawValue }))
         self.observable = PublishSubject()
@@ -75,6 +82,11 @@ final class LookupWebViewHandler {
                 self.isLoading.accept(.failed(error))
             })
             .disposed(by: self.disposeBag)
+    }
+    
+    convenience init(libraryIdentifier: LibraryIdentifier, collectionKeys: Set<String>, webView: WKWebView, translatorsController: TranslatorsAndStylesController) {
+        let lookupSettings = LookupSettings(libraryIdentifier: libraryIdentifier, collectionKeys: collectionKeys)
+        self.init(lookupSettings: lookupSettings, webView: webView, translatorsController: translatorsController)
     }
 
     func lookUp(identifier: String) {

--- a/Zotero/Controllers/Web View Handling/LookupWebViewHandler.swift
+++ b/Zotero/Controllers/Web View Handling/LookupWebViewHandler.swift
@@ -52,7 +52,7 @@ final class LookupWebViewHandler {
     }
 
     let lookupSettings: LookupSettings
-    private let webViewHandler: WebViewHandler
+    let webViewHandler: WebViewHandler
     private let translatorsController: TranslatorsAndStylesController
     private let disposeBag: DisposeBag
     let observable: PublishSubject<Result<LookupData, Swift.Error>>

--- a/Zotero/Controllers/Web View Handling/WebViewHandler.swift
+++ b/Zotero/Controllers/Web View Handling/WebViewHandler.swift
@@ -20,7 +20,7 @@ final class WebViewHandler: NSObject {
 
     private let session: URLSession
 
-    private weak var webView: WKWebView?
+    private(set) weak var webView: WKWebView?
     private var webDidLoad: ((SingleEvent<()>) -> Void)?
     var receivedMessageHandler: ((String, Any) -> Void)?
     // Cookies, User-Agent and Referrer from original website are stored and added to requests in `sendRequest(with:)`.

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -22,6 +22,8 @@ internal enum L10n {
   internal static let betaWipeTitle = L10n.tr("Localizable", "beta_wipe_title", fallback: "Resync Required")
   /// Cancel
   internal static let cancel = L10n.tr("Localizable", "cancel", fallback: "Cancel")
+  /// Cancel All
+  internal static let cancelAll = L10n.tr("Localizable", "cancel_all", fallback: "Cancel All")
   /// Clear
   internal static let clear = L10n.tr("Localizable", "clear", fallback: "Clear")
   /// Localizable.strings

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -369,8 +369,6 @@ internal enum L10n {
     internal static let db = L10n.tr("Localizable", "errors.db", fallback: "Could not connect to database. The device storage might be full.")
     /// Error creating database. Please try logging in again.
     internal static let dbFailure = L10n.tr("Localizable", "errors.db_failure", fallback: "Error creating database. Please try logging in again.")
-    /// Zotero could not find any identifiers in your input. Please verify your input and try again.
-    internal static let lookup = L10n.tr("Localizable", "errors.lookup", fallback: "Zotero could not find any identifiers in your input. Please verify your input and try again.")
     /// Could not parse some data. Other data will continue to sync.
     internal static let parsing = L10n.tr("Localizable", "errors.parsing", fallback: "Could not parse some data. Other data will continue to sync.")
     /// Some data in My Library could not be downloaded. It may have been saved with a newer version of Zotero.
@@ -496,6 +494,12 @@ internal enum L10n {
       internal static let invalidPassword = L10n.tr("Localizable", "errors.login.invalid_password", fallback: "Invalid password")
       /// Invalid username
       internal static let invalidUsername = L10n.tr("Localizable", "errors.login.invalid_username", fallback: "Invalid username")
+    }
+    internal enum Lookup {
+      /// Zotero could not find any identifiers in your input. Please verify your input and try again.
+      internal static let noIdentifiersAndNoLookupData = L10n.tr("Localizable", "errors.lookup.no_identifiers_and_no_lookup_data", fallback: "Zotero could not find any identifiers in your input. Please verify your input and try again.")
+      /// Zotero could not find any new identifiers in your input, or they are already being added. Please verify your input and try again.
+      internal static let noIdentifiersWithLookupData = L10n.tr("Localizable", "errors.lookup.no_identifiers_with_lookup_data", fallback: "Zotero could not find any new identifiers in your input, or they are already being added. Please verify your input and try again.")
     }
     internal enum Pdf {
       /// Can't add annotations.

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -795,6 +795,10 @@ internal enum L10n {
     internal static func toolbarFilter(_ p1: Int) -> String {
       return L10n.tr("Localizable", "items.toolbar_filter", p1, fallback: "Plural format key: \"%#@toolbar_filter@\"")
     }
+    /// Saved %d / %d
+    internal static func toolbarSaved(_ p1: Int, _ p2: Int) -> String {
+      return L10n.tr("Localizable", "items.toolbar_saved", p1, p2, fallback: "Saved %d / %d")
+    }
     internal enum Action {
       /// Add to Collection
       internal static let addToCollection = L10n.tr("Localizable", "items.action.add_to_collection", fallback: "Add to Collection")

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -319,7 +319,7 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
         controller.popoverPresentationController?.barButtonItem = button
 
         controller.addAction(UIAlertAction(title: L10n.Items.lookup, style: .default, handler: { [weak self] _ in
-            self?.showLookup(startWith: .manual)
+            self?.showLookup(startWith: .manual(restoreLookupState: false))
         }))
 
         controller.addAction(UIAlertAction(title: L10n.Items.barcode, style: .default, handler: { [weak self] _ in

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -38,6 +38,7 @@ protocol DetailItemsCoordinatorDelegate: AnyObject {
     func showMissingStyleError()
     func showAttachment(key: String, parentKey: String?, libraryId: LibraryIdentifier)
     func show(error: ItemsError)
+    func showLookup()
 }
 
 protocol DetailItemDetailCoordinatorDelegate: AnyObject {
@@ -641,6 +642,10 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
         coordinator.start(animated: false)
 
         self.navigationController?.present(navigationController, animated: true, completion: nil)
+    }
+    
+    func showLookup() {
+        showLookup(startWith: .manual(restoreLookupState: true))
     }
 }
 

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -122,6 +122,8 @@ final class DetailCoordinator: Coordinator {
             library: self.library,
             dbStorage: userControllers.dbStorage,
             fileDownloader: userControllers.fileDownloader,
+            remoteFileDownloader: userControllers.remoteFileDownloader,
+            identifierLookupController: userControllers.identifierLookupController,
             syncScheduler: userControllers.syncScheduler,
             citationController: userControllers.citationController,
             fileCleanupController: userControllers.fileCleanupController,
@@ -136,6 +138,8 @@ final class DetailCoordinator: Coordinator {
         library: Library,
         dbStorage: DbStorage,
         fileDownloader: AttachmentDownloader,
+        remoteFileDownloader: RemoteAttachmentDownloader,
+        identifierLookupController: IdentifierLookupController,
         syncScheduler: SynchronizationScheduler,
         citationController: CitationController,
         fileCleanupController: AttachmentFileCleanupController,
@@ -145,7 +149,20 @@ final class DetailCoordinator: Coordinator {
         itemsTagFilterDelegate?.clearSelection()
 
         let searchTerm = self.searchItemKeys?.joined(separator: " ")
-        let state = ItemsState(collection: collection, library: library, sortType: .default, searchTerm: searchTerm, filters: [], error: nil)
+        let downloadBatchData = ItemsState.DownloadBatchData(batchData: fileDownloader.batchData)
+        let remoteDownloadBatchData = ItemsState.DownloadBatchData(batchData: remoteFileDownloader.batchData)
+        let identifierLookupBatchData = ItemsState.IdentifierLookupBatchData(batchData: identifierLookupController.batchData)
+        let state = ItemsState(
+            collection: collection,
+            library: library,
+            sortType: .default,
+            searchTerm: searchTerm,
+            filters: [],
+            downloadBatchData: downloadBatchData,
+            remoteDownloadBatchData: remoteDownloadBatchData,
+            identifierLookupBatchData: identifierLookupBatchData,
+            error: nil
+        )
         let handler = ItemsActionHandler(
             dbStorage: dbStorage,
             fileStorage: self.controllers.fileStorage,

--- a/Zotero/Scenes/Detail/Items/Models/ItemsAction.swift
+++ b/Zotero/Scenes/Detail/Items/Models/ItemsAction.swift
@@ -41,6 +41,7 @@ enum ItemsAction {
     case cacheItemAccessory(item: RItem)
     case updateAttachments(AttachmentFileDeletedNotification)
     case updateDownload(update: AttachmentDownloader.Update, batchData: ItemsState.DownloadBatchData?)
+    case updateIdentifierLookup(update: IdentifierLookupController.Update, batchData: ItemsState.IdentifierLookupBatchData)
     case updateRemoteDownload(update: RemoteAttachmentDownloader.Update, batchData: ItemsState.DownloadBatchData?)
     case openAttachment(attachment: Attachment, parentKey: String?)
     case attachmentOpened(String)

--- a/Zotero/Scenes/Detail/Items/Models/ItemsAction.swift
+++ b/Zotero/Scenes/Detail/Items/Models/ItemsAction.swift
@@ -41,6 +41,7 @@ enum ItemsAction {
     case cacheItemAccessory(item: RItem)
     case updateAttachments(AttachmentFileDeletedNotification)
     case updateDownload(update: AttachmentDownloader.Update, batchData: ItemsState.DownloadBatchData?)
+    case updateRemoteDownload(update: RemoteAttachmentDownloader.Update, batchData: ItemsState.DownloadBatchData?)
     case openAttachment(attachment: Attachment, parentKey: String?)
     case attachmentOpened(String)
     case updateKeys(items: Results<RItem>, deletions: [Int], insertions: [Int], modifications: [Int])

--- a/Zotero/Scenes/Detail/Items/Models/ItemsState.swift
+++ b/Zotero/Scenes/Detail/Items/Models/ItemsState.swift
@@ -51,6 +51,17 @@ struct ItemsState: ViewModelState {
             return .init(fraction: fraction, downloaded: downloaded, total: total)
         }
     }
+    
+    struct IdentifierLookupBatchData: Equatable {
+        static let zero: Self = .init(saved: 0, total: 0)
+        
+        let saved: Int
+        let total: Int
+        
+        var isFinished: Bool {
+            saved == total
+        }
+    }
 
     let collection: Collection
     let library: Library
@@ -83,6 +94,7 @@ struct ItemsState: ViewModelState {
         guard data.count > 1 else { return firstData }
         return data[1..<data.endIndex].reduce(firstData) { $0 + $1 }
     }
+    var identifierLookupBatchData: IdentifierLookupBatchData = .zero
     var itemTitleFont: UIFont {
         return UIFont.preferredFont(for: .headline, weight: .regular)
     }

--- a/Zotero/Scenes/Detail/Items/Models/ItemsState.swift
+++ b/Zotero/Scenes/Detail/Items/Models/ItemsState.swift
@@ -38,7 +38,7 @@ struct ItemsState: ViewModelState {
         }
         
         init?(progress: Progress, remaining: Int, total: Int) {
-            guard total > 1 else { return nil }
+            guard total > 0 else { return nil }
             self.fraction = progress.fractionCompleted
             self.downloaded = total - remaining
             self.total = total

--- a/Zotero/Scenes/Detail/Items/Models/ItemsState.swift
+++ b/Zotero/Scenes/Detail/Items/Models/ItemsState.swift
@@ -31,11 +31,24 @@ struct ItemsState: ViewModelState {
         let downloaded: Int
         let total: Int
 
+        init(fraction: Double, downloaded: Int, total: Int) {
+            self.fraction = fraction
+            self.downloaded = downloaded
+            self.total = total
+        }
+        
         init?(progress: Progress, remaining: Int, total: Int) {
             guard total > 1 else { return nil }
             self.fraction = progress.fractionCompleted
             self.downloaded = total - remaining
             self.total = total
+        }
+        
+        static func + (lhs: DownloadBatchData, rhs: DownloadBatchData) -> DownloadBatchData {
+            let fraction = (lhs.fraction + rhs.fraction) / 2.0
+            let downloaded = lhs.downloaded + rhs.downloaded
+            let total = lhs.total + rhs.total
+            return .init(fraction: fraction, downloaded: downloaded, total: total)
         }
     }
 
@@ -63,6 +76,13 @@ struct ItemsState: ViewModelState {
     var bibliographyError: Error?
     var attachmentToOpen: String?
     var downloadBatchData: DownloadBatchData?
+    var remoteDownloadBatchData: DownloadBatchData?
+    var combinedDownloadBatchData: DownloadBatchData? {
+        let data = [downloadBatchData, remoteDownloadBatchData].compactMap { $0 }
+        guard let firstData = data.first else { return nil }
+        guard data.count > 1 else { return firstData }
+        return data[1..<data.endIndex].reduce(firstData) { $0 + $1 }
+    }
     var itemTitleFont: UIFont {
         return UIFont.preferredFont(for: .headline, weight: .regular)
     }

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
@@ -151,7 +151,10 @@ struct ItemsActionHandler: ViewModelActionHandler, BackgroundDbProcessingActionH
 
         case .updateDownload(let update, let batchData):
             self.process(downloadUpdate: update, batchData: batchData, in: viewModel)
-            
+
+        case .updateIdentifierLookup(let update, let batchData):
+            self.process(identifierLookupUpdate: update, batchData: batchData, in: viewModel)
+
         case .updateRemoteDownload(let update, let batchData):
             self.process(remoteDownloadUpdate: update, batchData: batchData, in: viewModel)
 
@@ -381,6 +384,15 @@ struct ItemsActionHandler: ViewModelActionHandler, BackgroundDbProcessingActionH
                     state.downloadBatchData = batchData
                     state.changes = .batchData
                 }
+            }
+        }
+    }
+    
+    private func process(identifierLookupUpdate update: IdentifierLookupController.Update, batchData: ItemsState.IdentifierLookupBatchData, in viewModel: ViewModel<ItemsActionHandler>) {
+        self.update(viewModel: viewModel) { state in
+            if state.identifierLookupBatchData != batchData {
+                state.identifierLookupBatchData = batchData
+                state.changes = .batchData
             }
         }
     }

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
@@ -151,6 +151,9 @@ struct ItemsActionHandler: ViewModelActionHandler, BackgroundDbProcessingActionH
 
         case .updateDownload(let update, let batchData):
             self.process(downloadUpdate: update, batchData: batchData, in: viewModel)
+            
+        case .updateRemoteDownload(let update, let batchData):
+            self.process(remoteDownloadUpdate: update, batchData: batchData, in: viewModel)
 
         case .openAttachment(let attachment, let parentKey):
             self.open(attachment: attachment, parentKey: parentKey, in: viewModel)
@@ -378,6 +381,15 @@ struct ItemsActionHandler: ViewModelActionHandler, BackgroundDbProcessingActionH
                     state.downloadBatchData = batchData
                     state.changes = .batchData
                 }
+            }
+        }
+    }
+    
+    private func process(remoteDownloadUpdate update: RemoteAttachmentDownloader.Update, batchData: ItemsState.DownloadBatchData?, in viewModel: ViewModel<ItemsActionHandler>) {
+        self.update(viewModel: viewModel) { state in
+            if state.remoteDownloadBatchData != batchData {
+                state.remoteDownloadBatchData = batchData
+                state.changes = .batchData
             }
         }
     }

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
@@ -20,7 +20,6 @@ final class ItemsToolbarController {
     private static let barButtonItemSingleTag = 2
     private static let barButtonItemFilterTag = 3
     private static let barButtonItemTitleTag = 4
-    private static let finishVisibilityTime: RxTimeInterval = .seconds(2)
 
     private unowned let viewController: UIViewController
     private let editingActions: [ItemAction]

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
@@ -164,7 +164,7 @@ final class ItemsToolbarController {
                     // Show "Saved x / y" only if lookup hasn't finished, or there are also ongoing remote downloads
                     isUserInteractionEnabled = true
                     let identifierLookupText = L10n.Items.toolbarSaved(identifierLookupBatchData.saved, identifierLookupBatchData.total)
-                    let identifierLookupAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: Asset.Colors.zoteroBlueWithDarkMode.color, .font: UIFont.preferredFont(forTextStyle: .callout)]
+                    let identifierLookupAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: Asset.Colors.zoteroBlueWithDarkMode.color, .font: UIFont.preferredFont(forTextStyle: .footnote)]
                     attributedText.append(.init(string: identifierLookupText, attributes: identifierLookupAttributes))
                 }
                 if let combinedDownloadBatchData = ItemsState.DownloadBatchData.combineDownloadBatchData([downloadBatchData, remoteDownloadBatchData]) {

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
@@ -64,7 +64,7 @@ final class ItemsToolbarController {
         } else {
             let filters = self.sizeClassSpecificFilters(from: state.filters)
             self.viewController.toolbarItems = self.createNormalToolbarItems(for: filters)
-            self.updateNormalToolbarItems(for: filters, downloadBatchData: state.downloadBatchData, results: state.results)
+            self.updateNormalToolbarItems(for: filters, downloadBatchData: state.combinedDownloadBatchData, results: state.results)
         }
     }
 
@@ -72,7 +72,7 @@ final class ItemsToolbarController {
         if state.isEditing {
             self.updateEditingToolbarItems(for: state.selectedItems, results: state.results)
         } else {
-            self.updateNormalToolbarItems(for: self.sizeClassSpecificFilters(from: state.filters), downloadBatchData: state.downloadBatchData, results: state.results)
+            self.updateNormalToolbarItems(for: self.sizeClassSpecificFilters(from: state.filters), downloadBatchData: state.combinedDownloadBatchData, results: state.results)
         }
     }
 

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
@@ -30,7 +30,7 @@ final class ItemsToolbarController {
     init(viewController: UIViewController, initialState: ItemsState, delegate: ItemsToolbarControllerDelegate) {
         self.viewController = viewController
         self.delegate = delegate
-        self.editingActions = ItemsToolbarController.editingActions(for: initialState)
+        self.editingActions = Self.editingActions(for: initialState)
         self.disposeBag = DisposeBag()
 
         self.createToolbarItems(for: initialState)
@@ -99,10 +99,10 @@ final class ItemsToolbarController {
     private func updateEditingToolbarItems(for selectedItems: Set<String>, results: Results<RItem>?) {
         self.viewController.toolbarItems?.forEach({ item in
             switch item.tag {
-            case ItemsToolbarController.barButtonItemEmptyTag:
+            case Self.barButtonItemEmptyTag:
                 item.isEnabled = !selectedItems.isEmpty
 
-            case ItemsToolbarController.barButtonItemSingleTag:
+            case Self.barButtonItemSingleTag:
                 item.isEnabled = selectedItems.count == 1
             default: break
             }
@@ -110,12 +110,12 @@ final class ItemsToolbarController {
     }
 
     private func updateNormalToolbarItems(for filters: [ItemsFilter], downloadBatchData: ItemsState.DownloadBatchData?, results: Results<RItem>?) {
-        if let item = self.viewController.toolbarItems?.first(where: { $0.tag == ItemsToolbarController.barButtonItemFilterTag }) {
+        if let item = self.viewController.toolbarItems?.first(where: { $0.tag == Self.barButtonItemFilterTag }) {
             let filterImageName = filters.isEmpty ? "line.horizontal.3.decrease.circle" : "line.horizontal.3.decrease.circle.fill"
             item.image = UIImage(systemName: filterImageName)
         }
 
-        if let item = self.viewController.toolbarItems?.first(where: { $0.tag == ItemsToolbarController.barButtonItemTitleTag }),
+        if let item = self.viewController.toolbarItems?.first(where: { $0.tag == Self.barButtonItemTitleTag }),
            let stackView = item.customView as? UIStackView {
             if let filterLabel = stackView.subviews.first as? UILabel {
                 let itemCount = results?.count ?? 0
@@ -147,7 +147,7 @@ final class ItemsToolbarController {
 
         let filterImageName = filters.isEmpty ? "line.horizontal.3.decrease.circle" : "line.horizontal.3.decrease.circle.fill"
         let filterButton = UIBarButtonItem(image: UIImage(systemName: filterImageName), style: .plain, target: nil, action: nil)
-        filterButton.tag = ItemsToolbarController.barButtonItemFilterTag
+        filterButton.tag = Self.barButtonItemFilterTag
         filterButton.accessibilityLabel = L10n.Accessibility.Items.filterItems
         filterButton.rx.tap.subscribe(onNext: { [weak self] _ in
             self?.delegate?.process(action: .filter, button: filterButton)
@@ -163,7 +163,7 @@ final class ItemsToolbarController {
         .disposed(by: self.disposeBag)
 
         let titleButton = UIBarButtonItem(customView: self.createTitleView())
-        titleButton.tag = ItemsToolbarController.barButtonItemTitleTag
+        titleButton.tag = Self.barButtonItemTitleTag
 
         return [fixedSpacer, filterButton, flexibleSpacer, titleButton, flexibleSpacer, sortButton, fixedSpacer]
     }
@@ -174,7 +174,7 @@ final class ItemsToolbarController {
             let item = UIBarButtonItem(image: action.image, style: .plain, target: nil, action: nil)
             switch action.type {
             case .addToCollection, .trash, .delete, .removeFromCollection, .restore:
-                item.tag = ItemsToolbarController.barButtonItemEmptyTag
+                item.tag = Self.barButtonItemEmptyTag
             case .sort, .filter, .createParent, .copyCitation, .copyBibliography, .share, .removeDownload, .download, .duplicate: break
             }
             switch action.type {

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
@@ -160,7 +160,7 @@ final class ItemsToolbarController {
                 var progress: Float?
                 let remoteDownloading = remoteDownloadBatchData != nil
                 let defaultAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.label, .font: UIFont.preferredFont(forTextStyle: .footnote)]
-                if identifierLookupBatchData != .zero, (!identifierLookupBatchData.isFinished || remoteDownloading) {
+                if identifierLookupBatchData != .zero, !identifierLookupBatchData.isFinished || remoteDownloading {
                     // Show "Saved x / y" only if lookup hasn't finished, or there are also ongoing remote downloads
                     isUserInteractionEnabled = true
                     let identifierLookupText = L10n.Items.toolbarSaved(identifierLookupBatchData.saved, identifierLookupBatchData.total)

--- a/Zotero/Scenes/Detail/Items/Views/ItemsToolbarDownloadProgressView.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsToolbarDownloadProgressView.swift
@@ -22,9 +22,18 @@ final class ItemsToolbarDownloadProgressView: UIView {
         self.createViews()
     }
 
+    func set(text: String, progress: Float?) {
+        label.text = text
+        if let progress {
+            progressView.progress = progress
+            progressView.isHidden = false
+        } else {
+            progressView.isHidden = true
+        }
+    }
+
     func set(downloaded: Int, total: Int, progress: Float) {
-        self.label.text = L10n.Items.toolbarDownloaded(downloaded, total)
-        self.progressView.progress = progress
+        set(text: L10n.Items.toolbarDownloaded(downloaded, total), progress: progress)
     }
 
     private func createViews() {

--- a/Zotero/Scenes/Detail/Items/Views/ItemsToolbarDownloadProgressView.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsToolbarDownloadProgressView.swift
@@ -24,6 +24,15 @@ final class ItemsToolbarDownloadProgressView: UIView {
 
     func set(text: String, progress: Float?) {
         label.text = text
+        set(progress: progress)
+    }
+
+    func set(attributedText: NSAttributedString, progress: Float?) {
+        label.attributedText = attributedText
+        set(progress: progress)
+    }
+
+    private func set(progress: Float?) {
         if let progress {
             progressView.progress = progress
             progressView.isHidden = false
@@ -31,7 +40,7 @@ final class ItemsToolbarDownloadProgressView: UIView {
             progressView.isHidden = true
         }
     }
-
+    
     func set(downloaded: Int, total: Int, progress: Float) {
         set(text: L10n.Items.toolbarDownloaded(downloaded, total), progress: progress)
     }

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -497,8 +497,7 @@ final class ItemsViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(with: self, onNext: { [weak downloader] `self`, update in
                 if let downloader {
-                    let (progress, remainingCount, totalCount) = downloader.batchData
-                    let batchData = progress.flatMap({ ItemsState.DownloadBatchData(progress: $0, remaining: remainingCount, total: totalCount) })
+                    let batchData = ItemsState.DownloadBatchData(batchData: downloader.batchData)
                     self.viewModel.process(action: .updateDownload(update: update, batchData: batchData))
                 }
                 
@@ -525,8 +524,7 @@ final class ItemsViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(with: self, onNext: { [weak identifierLookupController] `self`, update in
                 guard let identifierLookupController else { return }
-                 let identifierLookupBatchData = identifierLookupController.batchData
-                let batchData = ItemsState.IdentifierLookupBatchData(saved: identifierLookupBatchData.savedCount, total: identifierLookupBatchData.totalCount - identifierLookupBatchData.failedCount)
+                let batchData = ItemsState.IdentifierLookupBatchData(batchData: identifierLookupController.batchData)
                 self.viewModel.process(action: .updateIdentifierLookup(update: update, batchData: batchData))
             })
             .disposed(by: self.disposeBag)
@@ -536,8 +534,7 @@ final class ItemsViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(with: self, onNext: { [weak remoteDownloader] `self`, update in
                 guard let remoteDownloader else { return }
-                let (progress, remainingCount, totalCount) = remoteDownloader.batchData
-                let batchData = progress.flatMap({ ItemsState.DownloadBatchData(progress: $0, remaining: remainingCount, total: totalCount) })
+                let batchData = ItemsState.DownloadBatchData(batchData: remoteDownloader.batchData)
                 self.viewModel.process(action: .updateRemoteDownload(update: update, batchData: batchData))
             })
             .disposed(by: self.disposeBag)

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -525,7 +525,7 @@ final class ItemsViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(with: self, onNext: { [weak identifierLookupController] `self`, update in
                 guard let identifierLookupController else { return }
-                identifierLookupController.getIdentifiersLookupCount { saved, failed, total in
+                identifierLookupController.getIdentifiersLookupCount { saved, failed, total, _ in
                     inMainThread {
                         let batchData = ItemsState.IdentifierLookupBatchData(saved: saved, total: total - failed)
                         self.viewModel.process(action: .updateIdentifierLookup(update: update, batchData: batchData))

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -525,9 +525,12 @@ final class ItemsViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(with: self, onNext: { [weak identifierLookupController] `self`, update in
                 guard let identifierLookupController else { return }
-                let (saved, total) = identifierLookupController.processingIdentifiersCount
-                let batchData = ItemsState.IdentifierLookupBatchData(saved: saved, total: total)
-                self.viewModel.process(action: .updateIdentifierLookup(update: update, batchData: batchData))
+                identifierLookupController.getIdentifiersLookupCount { saved, failed, total in
+                    inMainThread {
+                        let batchData = ItemsState.IdentifierLookupBatchData(saved: saved, total: total - failed)
+                        self.viewModel.process(action: .updateIdentifierLookup(update: update, batchData: batchData))
+                    }
+                }
             })
             .disposed(by: self.disposeBag)
         

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -720,6 +720,10 @@ extension ItemsViewController: ItemsToolbarControllerDelegate {
     func process(action: ItemAction.Kind, button: UIBarButtonItem) {
         self.process(action: action, for: self.viewModel.state.selectedItems, button: button, completionAction: nil)
     }
+    
+    func showLookup() {
+        coordinatorDelegate?.showLookup()
+    }
 }
 
 extension ItemsViewController: TagFilterDelegate {

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -525,12 +525,9 @@ final class ItemsViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(with: self, onNext: { [weak identifierLookupController] `self`, update in
                 guard let identifierLookupController else { return }
-                identifierLookupController.getIdentifiersLookupCount { saved, failed, total, _ in
-                    inMainThread {
-                        let batchData = ItemsState.IdentifierLookupBatchData(saved: saved, total: total - failed)
-                        self.viewModel.process(action: .updateIdentifierLookup(update: update, batchData: batchData))
-                    }
-                }
+                 let identifierLookupBatchData = identifierLookupController.batchData
+                let batchData = ItemsState.IdentifierLookupBatchData(saved: identifierLookupBatchData.savedCount, total: identifierLookupBatchData.totalCount - identifierLookupBatchData.failedCount)
+                self.viewModel.process(action: .updateIdentifierLookup(update: update, batchData: batchData))
             })
             .disposed(by: self.disposeBag)
         

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -519,6 +519,17 @@ final class ItemsViewController: UIViewController {
                 }
             })
             .disposed(by: self.disposeBag)
+
+        let identifierLookupController = self.controllers.userControllers?.identifierLookupController
+        identifierLookupController?.observable
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self, onNext: { [weak identifierLookupController] `self`, update in
+                guard let identifierLookupController else { return }
+                let (saved, total) = identifierLookupController.processingIdentifiersCount
+                let batchData = ItemsState.IdentifierLookupBatchData(saved: saved, total: total)
+                self.viewModel.process(action: .updateIdentifierLookup(update: update, batchData: batchData))
+            })
+            .disposed(by: self.disposeBag)
         
         let remoteDownloader = self.controllers.userControllers?.remoteFileDownloader
         remoteDownloader?.observable

--- a/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
+++ b/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
@@ -61,7 +61,7 @@ final class LookupCoordinator: NSObject, Coordinator {
         let collectionKeys = Defaults.shared.selectedCollectionId.key.flatMap({ Set([$0]) }) ?? []
         let state = LookupState(multiLookupEnabled: multiLookupEnabled, hasDarkBackground: hasDarkBackground, collectionKeys: collectionKeys, libraryId: Defaults.shared.selectedLibrary)
         let handler = LookupActionHandler(
-            identifierLookupController: controllers.userControllers!.identifierLookupController,
+            identifierLookupController: userControllers.identifierLookupController,
             translatorsController: controllers.translatorsAndStylesController,
             schemaController: controllers.schemaController,
             dateParser: controllers.dateParser

--- a/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
+++ b/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
@@ -39,6 +39,7 @@ final class LookupCoordinator: NSObject, Coordinator {
         super.init()
 
         navigationController.dismissHandler = {
+            self.controllers.userControllers?.identifierLookupController.presenter = nil
             self.parentCoordinator?.childDidFinish(self)
         }
     }
@@ -76,6 +77,7 @@ final class LookupCoordinator: NSObject, Coordinator {
         let handler = ScannerActionHandler()
         let controller = ScannerViewController(viewModel: ViewModel(initialState: state, handler: handler))
         controller.coordinatorDelegate = self
+        controllers.userControllers?.identifierLookupController.presenter = controller
         return controller
     }
 
@@ -84,6 +86,7 @@ final class LookupCoordinator: NSObject, Coordinator {
         let handler = ManualLookupActionHandler()
         let controller = ManualLookupViewController(viewModel: ViewModel(initialState: state, handler: handler))
         controller.coordinatorDelegate = self
+        controllers.userControllers?.identifierLookupController.presenter = controller
         return controller
     }
 }

--- a/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
+++ b/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
@@ -13,11 +13,11 @@ import RxSwift
 
 enum LookupStartingView {
     case scanner
-    case manual
+    case manual(restoreLookupState: Bool)
 }
 
 protocol LookupCoordinatorDelegate: AnyObject {
-    func lookupController(multiLookupEnabled: Bool, hasDarkBackground: Bool) -> LookupViewController?
+    func lookupController(restoreLookupState: Bool, hasDarkBackground: Bool) -> LookupViewController?
 }
 
 final class LookupCoordinator: NSObject, Coordinator {
@@ -47,9 +47,9 @@ final class LookupCoordinator: NSObject, Coordinator {
     func start(animated: Bool) {
         let controller: UIViewController
         switch self.startingView {
-        case .manual:
-            DDLogInfo("LookupCoordinator: show manual lookup")
-            controller = self.manualController
+        case .manual(let restoreLookupState):
+            DDLogInfo("LookupCoordinator: show manual lookup \(restoreLookupState ? " with restored lookup state" : "")")
+            controller = self.manualController(restoreLookupState: restoreLookupState)
 
         case .scanner:
             DDLogInfo("LookupCoordinator: show scanner lookup")
@@ -58,9 +58,9 @@ final class LookupCoordinator: NSObject, Coordinator {
         self.navigationController?.setViewControllers([controller], animated: animated)
     }
 
-    private func lookupController(multiLookupEnabled: Bool, hasDarkBackground: Bool, userControllers: UserControllers) -> LookupViewController {
+    private func lookupController(restoreLookupState: Bool, hasDarkBackground: Bool, userControllers: UserControllers) -> LookupViewController {
         let collectionKeys = Defaults.shared.selectedCollectionId.key.flatMap({ Set([$0]) }) ?? []
-        let state = LookupState(multiLookupEnabled: multiLookupEnabled, hasDarkBackground: hasDarkBackground, collectionKeys: collectionKeys, libraryId: Defaults.shared.selectedLibrary)
+        let state = LookupState(restoreLookupState: restoreLookupState, hasDarkBackground: hasDarkBackground, collectionKeys: collectionKeys, libraryId: Defaults.shared.selectedLibrary)
         let handler = LookupActionHandler(identifierLookupController: userControllers.identifierLookupController)
         let viewModel = ViewModel(initialState: state, handler: handler)
 
@@ -81,8 +81,8 @@ final class LookupCoordinator: NSObject, Coordinator {
         return controller
     }
 
-    private var manualController: UIViewController {
-        let state = ManualLookupState()
+    private func manualController(restoreLookupState: Bool) -> UIViewController {
+        let state = ManualLookupState(restoreLookupState: restoreLookupState)
         let handler = ManualLookupActionHandler()
         let controller = ManualLookupViewController(viewModel: ViewModel(initialState: state, handler: handler))
         controller.coordinatorDelegate = self
@@ -92,8 +92,8 @@ final class LookupCoordinator: NSObject, Coordinator {
 }
 
 extension LookupCoordinator: LookupCoordinatorDelegate {
-    func lookupController(multiLookupEnabled: Bool, hasDarkBackground: Bool) -> LookupViewController? {
+    func lookupController(restoreLookupState: Bool, hasDarkBackground: Bool) -> LookupViewController? {
         guard let userControllers = self.controllers.userControllers else { return nil }
-        return self.lookupController(multiLookupEnabled: multiLookupEnabled, hasDarkBackground: hasDarkBackground, userControllers: userControllers)
+        return self.lookupController(restoreLookupState: restoreLookupState, hasDarkBackground: hasDarkBackground, userControllers: userControllers)
     }
 }

--- a/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
+++ b/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
@@ -61,12 +61,10 @@ final class LookupCoordinator: NSObject, Coordinator {
         let collectionKeys = Defaults.shared.selectedCollectionId.key.flatMap({ Set([$0]) }) ?? []
         let state = LookupState(multiLookupEnabled: multiLookupEnabled, hasDarkBackground: hasDarkBackground, collectionKeys: collectionKeys, libraryId: Defaults.shared.selectedLibrary)
         let handler = LookupActionHandler(
-            dbStorage: userControllers.dbStorage,
-            fileStorage: self.controllers.fileStorage,
-            translatorsController: self.controllers.translatorsAndStylesController,
-            schemaController: self.controllers.schemaController,
-            dateParser: self.controllers.dateParser,
-            remoteFileDownloader: userControllers.remoteFileDownloader
+            identifierLookupController: controllers.userControllers!.identifierLookupController,
+            translatorsController: controllers.translatorsAndStylesController,
+            schemaController: controllers.schemaController,
+            dateParser: controllers.dateParser
         )
         let viewModel = ViewModel(initialState: state, handler: handler)
 

--- a/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
+++ b/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
@@ -62,7 +62,6 @@ final class LookupCoordinator: NSObject, Coordinator {
         let state = LookupState(multiLookupEnabled: multiLookupEnabled, hasDarkBackground: hasDarkBackground, collectionKeys: collectionKeys, libraryId: Defaults.shared.selectedLibrary)
         let handler = LookupActionHandler(
             identifierLookupController: userControllers.identifierLookupController,
-            translatorsController: controllers.translatorsAndStylesController,
             schemaController: controllers.schemaController,
             dateParser: controllers.dateParser
         )

--- a/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
+++ b/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
@@ -60,11 +60,7 @@ final class LookupCoordinator: NSObject, Coordinator {
     private func lookupController(multiLookupEnabled: Bool, hasDarkBackground: Bool, userControllers: UserControllers) -> LookupViewController {
         let collectionKeys = Defaults.shared.selectedCollectionId.key.flatMap({ Set([$0]) }) ?? []
         let state = LookupState(multiLookupEnabled: multiLookupEnabled, hasDarkBackground: hasDarkBackground, collectionKeys: collectionKeys, libraryId: Defaults.shared.selectedLibrary)
-        let handler = LookupActionHandler(
-            identifierLookupController: userControllers.identifierLookupController,
-            schemaController: controllers.schemaController,
-            dateParser: controllers.dateParser
-        )
+        let handler = LookupActionHandler(identifierLookupController: userControllers.identifierLookupController)
         let viewModel = ViewModel(initialState: state, handler: handler)
 
         return LookupViewController(

--- a/Zotero/Scenes/Detail/Lookup/Models/LookupAction.swift
+++ b/Zotero/Scenes/Detail/Lookup/Models/LookupAction.swift
@@ -10,6 +10,6 @@ import Foundation
 import WebKit
 
 enum LookupAction {
-    case initialize(WKWebView)
+    case initialize
     case lookUp(String)
 }

--- a/Zotero/Scenes/Detail/Lookup/Models/LookupAction.swift
+++ b/Zotero/Scenes/Detail/Lookup/Models/LookupAction.swift
@@ -12,4 +12,5 @@ import WebKit
 enum LookupAction {
     case initialize
     case lookUp(String)
+    case cancelAllLookups
 }

--- a/Zotero/Scenes/Detail/Lookup/Models/LookupState.swift
+++ b/Zotero/Scenes/Detail/Lookup/Models/LookupState.swift
@@ -9,22 +9,8 @@
 import Foundation
 
 struct LookupState: ViewModelState {
-    struct LookupData {
-        enum State {
-            case enqueued
-            case inProgress
-            case failed
-            case translated(TranslatedLookupData)
-        }
-
-        let identifier: String
-        let state: State
-    }
-
-    struct TranslatedLookupData {
-        let response: ItemResponse
-        let attachments: [(Attachment, URL)]
-    }
+    typealias LookupData = IdentifierLookupController.LookupData
+    typealias TranslatedLookupData = LookupData.State.TranslatedLookupData
 
     enum State {
         case failed(Swift.Error)

--- a/Zotero/Scenes/Detail/Lookup/Models/LookupState.swift
+++ b/Zotero/Scenes/Detail/Lookup/Models/LookupState.swift
@@ -19,8 +19,19 @@ struct LookupState: ViewModelState {
         case lookup([LookupData])
     }
 
-    enum Error: Swift.Error {
-        case noIdentifiersDetected
+    enum Error: Swift.Error, LocalizedError {
+        case noIdentifiersDetectedAndNoLookupData
+        case noIdentifiersDetectedWithLookupData
+        
+        var errorDescription: String? {
+            switch self {
+            case .noIdentifiersDetectedAndNoLookupData:
+                return L10n.Errors.Lookup.noIdentifiersAndNoLookupData
+                
+            case .noIdentifiersDetectedWithLookupData:
+                return L10n.Errors.Lookup.noIdentifiersWithLookupData
+            }
+        }
     }
 
     let collectionKeys: Set<String>

--- a/Zotero/Scenes/Detail/Lookup/Models/LookupState.swift
+++ b/Zotero/Scenes/Detail/Lookup/Models/LookupState.swift
@@ -24,14 +24,13 @@ struct LookupState: ViewModelState {
 
     let collectionKeys: Set<String>
     let libraryId: LibraryIdentifier
-    // If enabled, when `lookup(identifier:)` is called, previous identifiers won't be removed.
-    let multiLookupEnabled: Bool
+    let restoreLookupState: Bool
     let hasDarkBackground: Bool
 
     var lookupState: State
 
-    init(multiLookupEnabled: Bool, hasDarkBackground: Bool, collectionKeys: Set<String>, libraryId: LibraryIdentifier) {
-        self.multiLookupEnabled = multiLookupEnabled
+    init(restoreLookupState: Bool, hasDarkBackground: Bool, collectionKeys: Set<String>, libraryId: LibraryIdentifier) {
+        self.restoreLookupState = restoreLookupState
         self.collectionKeys = collectionKeys
         self.libraryId = libraryId
         self.lookupState = .loadingIdentifiers

--- a/Zotero/Scenes/Detail/Lookup/Models/LookupState.swift
+++ b/Zotero/Scenes/Detail/Lookup/Models/LookupState.swift
@@ -14,6 +14,7 @@ struct LookupState: ViewModelState {
 
     enum State {
         case failed(Swift.Error)
+        case waitingInput
         case loadingIdentifiers
         case lookup([LookupData])
     }
@@ -33,7 +34,7 @@ struct LookupState: ViewModelState {
         self.restoreLookupState = restoreLookupState
         self.collectionKeys = collectionKeys
         self.libraryId = libraryId
-        self.lookupState = .loadingIdentifiers
+        self.lookupState = .waitingInput
         self.hasDarkBackground = hasDarkBackground
     }
 

--- a/Zotero/Scenes/Detail/Lookup/Models/ManualLookupState.swift
+++ b/Zotero/Scenes/Detail/Lookup/Models/ManualLookupState.swift
@@ -10,8 +10,10 @@ import Foundation
 
 struct ManualLookupState: ViewModelState {
     var scannedText: String?
+    let restoreLookupState: Bool
 
-    init() {
+    init(restoreLookupState: Bool) {
+        self.restoreLookupState = restoreLookupState
     }
 
     mutating func cleanup() {

--- a/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
+++ b/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
@@ -16,35 +16,61 @@ final class LookupActionHandler: ViewModelActionHandler {
     typealias Action = LookupAction
 
     private unowned let identifierLookupController: IdentifierLookupController
-    private unowned let schemaController: SchemaController
-    private unowned let dateParser: DateParser
     private let disposeBag: DisposeBag
 
-    init(identifierLookupController: IdentifierLookupController, schemaController: SchemaController, dateParser: DateParser) {
+    init(identifierLookupController: IdentifierLookupController) {
         self.identifierLookupController = identifierLookupController
-        self.schemaController = schemaController
-        self.dateParser = dateParser
         self.disposeBag = DisposeBag()
     }
 
     func process(action: LookupAction, in viewModel: ViewModel<LookupActionHandler>) {
         switch action {
         case .initialize:
-            identifierLookupController.initialize { [weak self] lookupWebViewHandler in
-                guard let self, let lookupWebViewHandler else { return }
-                
-                lookupWebViewHandler.observable
-                    .observe(on: MainScheduler.instance)
-                    .subscribe(with: viewModel, onNext: { [weak self] viewModel, result in
-                        self?.process(result: result, in: viewModel)
-                    })
-                    .disposed(by: self.disposeBag)
-                
-                self.identifierLookupController.observable
+            let collectionKeys = viewModel.state.collectionKeys
+            let libraryId = viewModel.state.libraryId
+            identifierLookupController.initialize(libraryId: libraryId, collectionKeys: collectionKeys) { [weak self] observable in
+                guard let self, let observable else {
+                    DDLogError("LookupActionHandler: can't create observer")
+                    return
+                }
+                observable
                     .observe(on: MainScheduler.instance)
                     .subscribe(with: viewModel) { [weak self] viewModel, update in
                         guard let self else { return }
                         switch update.kind {
+                        case .lookupError(let error):
+                            self.update(viewModel: viewModel) { state in
+                                state.lookupState = .failed(error)
+                            }
+
+                        case .noIdentifiersDetected:
+                            self.update(viewModel: viewModel) { state in
+                                state.lookupState = .failed(LookupState.Error.noIdentifiersDetected)
+                            }
+                            
+                        case .identifiersDetected(let identifiers):
+                            var lookupData = identifiers.map({ LookupState.LookupData(identifier: $0, state: .enqueued) })
+
+                            self.update(viewModel: viewModel) { state in
+                                if !state.multiLookupEnabled {
+                                    state.lookupState = .lookup(lookupData)
+                                } else {
+                                    switch state.lookupState {
+                                    case .lookup(let data):
+                                        lookupData.append(contentsOf: data)
+                                    default: break
+                                    }
+
+                                    state.lookupState = .lookup(lookupData)
+                                }
+                            }
+                            
+                        case .lookupInProgress(let identifier):
+                            self.update(lookupData: LookupState.LookupData(identifier: identifier, state: .inProgress), in: viewModel)
+                            
+                        case .lookupFailed(let identifier), .parseFailed(let identifier), .itemCreationFailed(let identifier, _, _):
+                            self.update(lookupData: LookupState.LookupData(identifier: identifier, state: .failed), in: viewModel)
+                            
                         case .itemStored:
                             break
                             
@@ -52,10 +78,6 @@ final class LookupActionHandler: ViewModelActionHandler {
                             let parsedData = LookupState.TranslatedLookupData(response: response, attachments: attachments)
                             let translatedData = LookupState.LookupData(identifier: identifier, state: .translated(parsedData))
                             self.update(lookupData: translatedData, in: viewModel)
-                            
-                        case .itemCreationFailed(let identifier, _, _):
-                            let failedData = LookupState.LookupData(identifier: identifier, state: .failed)
-                            self.update(lookupData: failedData, in: viewModel)
                         }
                     }
                     .disposed(by: self.disposeBag)
@@ -63,19 +85,6 @@ final class LookupActionHandler: ViewModelActionHandler {
 
         case .lookUp(let identifier):
             self.lookUp(identifier: identifier, in: viewModel)
-        }
-    }
-
-    private func process(result: Result<LookupWebViewHandler.LookupData, Error>, in viewModel: ViewModel<LookupActionHandler>) {
-        switch result {
-        case .success(let data):
-            self.process(data: data, in: viewModel)
-
-        case .failure(let error):
-            DDLogError("LookupActionHandler: lookup failed - \(error)")
-            self.update(viewModel: viewModel) { state in
-                state.lookupState = .failed(error)
-            }
         }
     }
 
@@ -95,56 +104,6 @@ final class LookupActionHandler: ViewModelActionHandler {
         self.identifierLookupController.lookUp(identifier: newIdentifier)
     }
 
-    private func process(data: LookupWebViewHandler.LookupData, in viewModel: ViewModel<LookupActionHandler>) {
-        switch data {
-        case .identifiers(let identifiers):
-            guard !identifiers.isEmpty else {
-                self.update(viewModel: viewModel) { state in
-                    state.lookupState = .failed(LookupState.Error.noIdentifiersDetected)
-                }
-                return
-            }
-
-            var lookupData = identifiers.map({ LookupState.LookupData(identifier: self.identifier(from: $0), state: .enqueued) })
-
-            self.update(viewModel: viewModel) { state in
-                if !state.multiLookupEnabled {
-                    state.lookupState = .lookup(lookupData)
-                } else {
-                    switch state.lookupState {
-                    case .lookup(let data):
-                        lookupData.append(contentsOf: data)
-                    default: break
-                    }
-
-                    state.lookupState = .lookup(lookupData)
-                }
-            }
-
-        case .item(let data):
-            guard let lookupId = data["identifier"] as? [String: String] else { return }
-            let identifier = self.identifier(from: lookupId)
-
-            if data.keys.count == 1 {
-                self.update(lookupData: LookupState.LookupData(identifier: identifier, state: .inProgress), in: viewModel)
-                return
-            }
-
-            if let error = data["error"] {
-                DDLogError("LookupActionHandler: \(identifier) lookup failed - \(error)")
-                self.update(lookupData: LookupState.LookupData(identifier: identifier, state: .failed), in: viewModel)
-                return
-            }
-
-            guard let itemData = data["data"] as? [[String: Any]], let item = itemData.first, let parsedData = self.parse(item, viewModel: viewModel, schemaController: self.schemaController) else {
-                self.update(lookupData: LookupState.LookupData(identifier: identifier, state: .failed), in: viewModel)
-                return
-            }
-
-            identifierLookupController.process(identifier: identifier, response: parsedData.response, attachments: parsedData.attachments)
-        }
-    }
-
     private func update(lookupData: LookupState.LookupData, in viewModel: ViewModel<LookupActionHandler>) {
         switch viewModel.state.lookupState {
         case .lookup(let oldData):
@@ -155,45 +114,8 @@ final class LookupActionHandler: ViewModelActionHandler {
                 state.lookupState = .lookup(newData)
             }
 
-        default: break
-        }
-    }
-
-    private func identifier(from data: [String: String]) -> String {
-        var result = ""
-        for (key, value) in data {
-            result += key + ":" + value
-        }
-        return result
-    }
-
-    /// Tries to parse `ItemResponse` from data returned by translation server. It prioritizes items with attachments if there are multiple items.
-    /// - parameter data: Data to parse
-    /// - parameter schemaController: SchemaController which is used for validating item type and field types
-    /// - returns: `ItemResponse` of parsed item and optional attachment dictionary with title and url.
-    private func parse(_ itemData: [String: Any], viewModel: ViewModel<LookupActionHandler>, schemaController: SchemaController) -> LookupState.TranslatedLookupData? {
-        let collectionKeys = viewModel.state.collectionKeys
-        let libraryId = viewModel.state.libraryId
-
-        do {
-            let item = try ItemResponse(translatorResponse: itemData, schemaController: self.schemaController).copy(libraryId: libraryId, collectionKeys: collectionKeys, tags: [])
-
-            let attachments = ((itemData["attachments"] as? [[String: Any]]) ?? []).compactMap { data -> (Attachment, URL)? in
-                // We can't process snapshots yet, so ignore all text/html attachments
-                guard let mimeType = data["mimeType"] as? String, mimeType != "text/html", let ext = mimeType.extensionFromMimeType,
-                      let urlString = data["url"] as? String, let url = URL(string: urlString) else { return nil }
-
-                let key = KeyGenerator.newKey
-                let filename = FilenameFormatter.filename(from: item, defaultTitle: "Full Text", ext: ext, dateParser: self.dateParser)
-                let attachment = Attachment(type: .file(filename: filename, contentType: mimeType, location: .local, linkType: .importedFile), title: filename, key: key, libraryId: libraryId)
-
-                return (attachment, url)
-            }
-
-            return LookupState.TranslatedLookupData(response: item, attachments: attachments)
-        } catch let error {
-            DDLogError("LookupActionHandler: can't parse data - \(error)")
-            return nil
+        default:
+            break
         }
     }
 }

--- a/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
+++ b/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
@@ -52,17 +52,17 @@ final class LookupActionHandler: ViewModelActionHandler {
                             var lookupData = identifiers.map({ LookupState.LookupData(identifier: $0, state: .enqueued) })
 
                             self.update(viewModel: viewModel) { state in
-                                if !state.multiLookupEnabled {
-                                    state.lookupState = .lookup(lookupData)
-                                } else {
+                                if state.multiLookupEnabled {
                                     switch state.lookupState {
                                     case .lookup(let data):
                                         lookupData.append(contentsOf: data)
-                                    default: break
+                                        
+                                    default:
+                                        break
                                     }
-
-                                    state.lookupState = .lookup(lookupData)
                                 }
+
+                                state.lookupState = .lookup(lookupData)
                             }
                             
                         case .lookupInProgress(let identifier):

--- a/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
+++ b/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
@@ -36,7 +36,7 @@ final class LookupActionHandler: ViewModelActionHandler {
         case .cancelAllLookups:
             identifierLookupController.cancelAllLookups()
             self.update(viewModel: viewModel) { state in
-                state.lookupState = .loadingIdentifiers
+                state.lookupState = .waitingInput
             }
         }
         
@@ -56,50 +56,38 @@ final class LookupActionHandler: ViewModelActionHandler {
                     .observe(on: MainScheduler.instance)
                     .subscribe(with: viewModel) { [weak self] viewModel, update in
                         guard let self else { return }
+                        switch viewModel.state.lookupState {
+                        case .failed, .waitingInput:
+                            // Ignore identifier lookup controller updates if waiting for input
+                            return
+                            
+                        default:
+                            break
+                        }
                         switch update.kind {
                         case .lookupError(let error):
                             self.update(viewModel: viewModel) { state in
                                 state.lookupState = .failed(error)
                             }
 
-                        case .noIdentifiersDetected:
-                            self.update(viewModel: viewModel) { state in
-                                state.lookupState = .failed(LookupState.Error.noIdentifiersDetected)
-                            }
-                            
                         case .identifiersDetected(let identifiers):
-                            var lookupData = identifiers.map({ LookupState.LookupData(identifier: $0, state: .enqueued) })
-
-                            self.update(viewModel: viewModel) { state in
-                                switch state.lookupState {
-                                case .lookup(let data):
-                                    lookupData.append(contentsOf: data)
-                                    
-                                default:
-                                    break
+                            guard !identifiers.isEmpty else {
+                                self.update(viewModel: viewModel) { state in
+                                    state.lookupState = .failed(LookupState.Error.noIdentifiersDetected)
                                 }
-
-                                state.lookupState = .lookup(lookupData)
+                                return
                             }
-                            
-                        case .lookupInProgress(let identifier):
-                            self.update(lookupData: LookupState.LookupData(identifier: identifier, state: .inProgress), in: viewModel)
-                            
-                        case .lookupFailed(let identifier), .parseFailed(let identifier), .itemCreationFailed(let identifier, _, _):
-                            self.update(lookupData: LookupState.LookupData(identifier: identifier, state: .failed), in: viewModel)
-                            
-                        case .itemStored:
-                            break
-                            
-                        case .pendingAttachments(let identifier, let response, let attachments):
-                            let parsedData = LookupState.TranslatedLookupData(response: response, attachments: attachments, libraryId: libraryId, collectionKeys: collectionKeys)
-                            let translatedData = LookupState.LookupData(identifier: identifier, state: .translated(parsedData))
-                            self.update(lookupData: translatedData, in: viewModel)
-                            
-                        case .finishedAllLookups:
                             self.update(viewModel: viewModel) { state in
-                                state.lookupState = .loadingIdentifiers
+                                state.lookupState = .lookup(update.lookupData)
                             }
+                            
+                        case .lookupInProgress, .lookupFailed, .parseFailed, .itemCreationFailed, .itemStored, .pendingAttachments:
+                            self.update(viewModel: viewModel) { state in
+                                state.lookupState = .lookup(update.lookupData)
+                            }
+                                                        
+                        case .finishedAllLookups:
+                            break
                         }
                     }
                     .disposed(by: self.disposeBag)
@@ -115,34 +103,17 @@ final class LookupActionHandler: ViewModelActionHandler {
         guard !newIdentifier.isEmpty else { return }
 
         switch viewModel.state.lookupState {
-        case .loadingIdentifiers, .failed:
-            let data = identifierLookupController.currentLookupData
+        case .waitingInput, .failed:
             self.update(viewModel: viewModel) { state in
-                state.lookupState = .lookup(data)
-                let collectionKeys = viewModel.state.collectionKeys
-                let libraryId = viewModel.state.libraryId
-                self.identifierLookupController.lookUp(libraryId: libraryId, collectionKeys: collectionKeys, identifier: newIdentifier)
+                state.lookupState = .loadingIdentifiers
             }
             
-        case .lookup:
-            let collectionKeys = viewModel.state.collectionKeys
-            let libraryId = viewModel.state.libraryId
-            identifierLookupController.lookUp(libraryId: libraryId, collectionKeys: collectionKeys, identifier: newIdentifier)
-        }
-    }
-
-    private func update(lookupData: LookupState.LookupData, in viewModel: ViewModel<LookupActionHandler>) {
-        switch viewModel.state.lookupState {
-        case .lookup(let oldData):
-            var newData = oldData
-            guard let index = oldData.firstIndex(where: { $0.identifier == lookupData.identifier }) else { return }
-            newData[index] = lookupData
-            self.update(viewModel: viewModel) { state in
-                state.lookupState = .lookup(newData)
-            }
-
-        default:
+        case .loadingIdentifiers, .lookup:
             break
         }
+        
+        let collectionKeys = viewModel.state.collectionKeys
+        let libraryId = viewModel.state.libraryId
+        identifierLookupController.lookUp(libraryId: libraryId, collectionKeys: collectionKeys, identifier: newIdentifier)
     }
 }

--- a/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
+++ b/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
@@ -71,9 +71,15 @@ final class LookupActionHandler: ViewModelActionHandler {
                             }
 
                         case .identifiersDetected(let identifiers):
-                            guard !identifiers.isEmpty else {
-                                self.update(viewModel: viewModel) { state in
-                                    state.lookupState = .failed(LookupState.Error.noIdentifiersDetected)
+                            if identifiers.isEmpty {
+                                if update.lookupData.isEmpty {
+                                    self.update(viewModel: viewModel) { state in
+                                        state.lookupState = .failed(LookupState.Error.noIdentifiersDetectedAndNoLookupData)
+                                    }
+                                } else {
+                                    self.update(viewModel: viewModel) { state in
+                                        state.lookupState = .failed(LookupState.Error.noIdentifiersDetectedWithLookupData)
+                                    }
                                 }
                                 return
                             }

--- a/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
+++ b/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
@@ -28,12 +28,12 @@ final class LookupActionHandler: ViewModelActionHandler {
         case .initialize:
             let collectionKeys = viewModel.state.collectionKeys
             let libraryId = viewModel.state.libraryId
-            identifierLookupController.initialize(libraryId: libraryId, collectionKeys: collectionKeys) { [weak self] observable in
-                guard let self, let observable else {
+            identifierLookupController.initialize(libraryId: libraryId, collectionKeys: collectionKeys) { [weak self] initialized in
+                guard let self, initialized else {
                     DDLogError("LookupActionHandler: can't create observer")
                     return
                 }
-                observable
+                self.identifierLookupController.observable
                     .observe(on: MainScheduler.instance)
                     .subscribe(with: viewModel) { [weak self] viewModel, update in
                         guard let self else { return }

--- a/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
+++ b/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
@@ -24,10 +24,23 @@ final class LookupActionHandler: ViewModelActionHandler {
     }
 
     func process(action: LookupAction, in viewModel: ViewModel<LookupActionHandler>) {
-        let collectionKeys = viewModel.state.collectionKeys
-        let libraryId = viewModel.state.libraryId
         switch action {
         case .initialize:
+            let collectionKeys = viewModel.state.collectionKeys
+            let libraryId = viewModel.state.libraryId
+            initialize(with: collectionKeys, in: libraryId)
+
+        case .lookUp(let identifier):
+            self.lookUp(identifier: identifier, in: viewModel)
+            
+        case .cancelAllLookups:
+            identifierLookupController.cancelAllLookups()
+            self.update(viewModel: viewModel) { state in
+                state.lookupState = .loadingIdentifiers
+            }
+        }
+        
+        func initialize(with collectionKeys: Set<String>, in libraryId: LibraryIdentifier) {
             identifierLookupController.initialize(libraryId: libraryId, collectionKeys: collectionKeys) { [weak self] lookupData in
                 guard let self, let lookupData else {
                     DDLogError("LookupActionHandler: can't create observer")
@@ -90,15 +103,6 @@ final class LookupActionHandler: ViewModelActionHandler {
                         }
                     }
                     .disposed(by: self.disposeBag)
-            }
-
-        case .lookUp(let identifier):
-            self.lookUp(identifier: identifier, in: viewModel)
-            
-        case .cancelAllLookups:
-            identifierLookupController.cancelAllLookups()
-            self.update(viewModel: viewModel) { state in
-                state.lookupState = .loadingIdentifiers
             }
         }
     }

--- a/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
+++ b/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
@@ -48,12 +48,13 @@ final class LookupActionHandler: ViewModelActionHandler {
                         case .itemStored:
                             break
                             
-                        case .pendingAttachments:
-                            let translatedData = LookupState.LookupData(identifier: update.identifier, state: .translated(update.parsedData))
+                        case .pendingAttachments(let identifier, let response, let attachments):
+                            let parsedData = LookupState.TranslatedLookupData(response: response, attachments: attachments)
+                            let translatedData = LookupState.LookupData(identifier: identifier, state: .translated(parsedData))
                             self.update(lookupData: translatedData, in: viewModel)
                             
-                        case .itemCreationFailed:
-                            let failedData = LookupState.LookupData(identifier: update.identifier, state: .failed)
+                        case .itemCreationFailed(let identifier, _, _):
+                            let failedData = LookupState.LookupData(identifier: identifier, state: .failed)
                             self.update(lookupData: failedData, in: viewModel)
                         }
                     }
@@ -194,11 +195,5 @@ final class LookupActionHandler: ViewModelActionHandler {
             DDLogError("LookupActionHandler: can't parse data - \(error)")
             return nil
         }
-    }
-}
-
-extension IdentifierLookupController.Update {
-    var parsedData: LookupState.TranslatedLookupData {
-        .init(response: response, attachments: attachments)
     }
 }

--- a/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
+++ b/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
@@ -116,14 +116,12 @@ final class LookupActionHandler: ViewModelActionHandler {
 
         switch viewModel.state.lookupState {
         case .loadingIdentifiers, .failed:
-            identifierLookupController.getIdentifiersLookupCount { [weak self] _, _, _, data in
-                guard let self else { return }
-                self.update(viewModel: viewModel) { state in
-                    state.lookupState = .lookup(data)
-                    let collectionKeys = viewModel.state.collectionKeys
-                    let libraryId = viewModel.state.libraryId
-                    self.identifierLookupController.lookUp(libraryId: libraryId, collectionKeys: collectionKeys, identifier: newIdentifier)
-                }
+            let data = identifierLookupController.currentLookupData
+            self.update(viewModel: viewModel) { state in
+                state.lookupState = .lookup(data)
+                let collectionKeys = viewModel.state.collectionKeys
+                let libraryId = viewModel.state.libraryId
+                self.identifierLookupController.lookUp(libraryId: libraryId, collectionKeys: collectionKeys, identifier: newIdentifier)
             }
             
         case .lookup:

--- a/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
+++ b/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
@@ -101,7 +101,9 @@ final class LookupActionHandler: ViewModelActionHandler {
             }
         }
 
-        self.identifierLookupController.lookUp(identifier: newIdentifier)
+        let collectionKeys = viewModel.state.collectionKeys
+        let libraryId = viewModel.state.libraryId
+        self.identifierLookupController.lookUp(libraryId: libraryId, collectionKeys: collectionKeys, identifier: newIdentifier)
     }
 
     private func update(lookupData: LookupState.LookupData, in viewModel: ViewModel<LookupActionHandler>) {

--- a/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
@@ -219,7 +219,7 @@ class LookupViewController: UIViewController {
     private func closeAfterUpdateIfNeeded() {
         let itemIdentifiers = dataSource.snapshot().itemIdentifiers
         guard !itemIdentifiers.isEmpty else { return }
-        let activeDownload = itemIdentifiers.first(where: { row in
+        let hasActiveDownload = itemIdentifiers.contains { row in
             switch row {
             case .attachment(_, let update):
                 switch update {
@@ -236,9 +236,8 @@ class LookupViewController: UIViewController {
             case .item:
                 return false
             }
-        })
-
-        if activeDownload == nil {
+        }
+        if !hasActiveDownload {
             self.activeLookupsFinished?()
         }
     }

--- a/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
@@ -216,7 +216,9 @@ class LookupViewController: UIViewController {
     }
 
     private func closeAfterUpdateIfNeeded() {
-        let activeDownload = self.dataSource.snapshot().itemIdentifiers.first(where: { row in
+        let itemIdentifiers = dataSource.snapshot().itemIdentifiers
+        guard !itemIdentifiers.isEmpty else { return }
+        let activeDownload = itemIdentifiers.first(where: { row in
             switch row {
             case .attachment(_, let update):
                 switch update {

--- a/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
@@ -109,10 +109,17 @@ class LookupViewController: UIViewController {
         case .loadingIdentifiers:
             self.tableView.isHidden = true
             self.errorLabel.isHidden = true
-            self.activityIndicator.isHidden = false
-            self.activityIndicator.startAnimating()
+            self.activityIndicator.stopAnimating()
+            self.activityIndicator.isHidden = true
 
         case .lookup(let data):
+            guard !data.isEmpty else {
+                self.tableView.isHidden = true
+                self.errorLabel.isHidden = true
+                self.activityIndicator.isHidden = false
+                self.activityIndicator.startAnimating()
+                return
+            }
             // It takes a little while for the `contentSize` observer notification to come, so all the content is hidden after the notification arrives, so that there is not an empty screen while
             // waiting for it.
             self.show(data: data) { [weak self] in

--- a/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
@@ -99,11 +99,11 @@ class LookupViewController: UIViewController {
 
     private func update(state: LookupState) {
         switch state.lookupState {
-        case .failed:
+        case .failed(let error):
             self.tableView.isHidden = true
             self.activityIndicator.stopAnimating()
             self.activityIndicator.isHidden = true
-            self.errorLabel.text = L10n.Errors.lookup
+            self.errorLabel.text = error.localizedDescription
             self.errorLabel.isHidden = false
 
         case .waitingInput:

--- a/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
@@ -57,7 +57,12 @@ class LookupViewController: UIViewController {
     private unowned let schemaController: SchemaController
     private let disposeBag: DisposeBag
 
-    init(viewModel: ViewModel<LookupActionHandler>, remoteDownloadObserver: PublishSubject<RemoteAttachmentDownloader.Update>, remoteFileDownloader: RemoteAttachmentDownloader, schemaController: SchemaController) {
+    init(
+        viewModel: ViewModel<LookupActionHandler>,
+        remoteDownloadObserver: PublishSubject<RemoteAttachmentDownloader.Update>,
+        remoteFileDownloader: RemoteAttachmentDownloader,
+        schemaController: SchemaController
+    ) {
         self.viewModel = viewModel
         self.remoteFileDownloader = remoteFileDownloader
         self.schemaController = schemaController
@@ -85,9 +90,7 @@ class LookupViewController: UIViewController {
                       })
                       .disposed(by: self.disposeBag)
 
-        if let webView = self.webView {
-            self.viewModel.process(action: .initialize(webView))
-        }
+        self.viewModel.process(action: .initialize)
     }
 
     deinit {

--- a/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import WebKit
 
 import CocoaLumberjackSwift
 import RxSwift
@@ -45,7 +44,6 @@ class LookupViewController: UIViewController {
     @IBOutlet private weak var tableViewHeight: NSLayoutConstraint!
     @IBOutlet private weak var errorLabel: UILabel!
 
-    weak var webView: WKWebView?
     private var dataSource: UITableViewDiffableDataSource<Int, Row>!
     private var contentSizeObserver: NSKeyValueObservation?
     var dataReloaded: (() -> Void)?

--- a/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
@@ -181,7 +181,10 @@ class LookupViewController: UIViewController {
         self.tableView.isHidden = false
         self.dataSource.apply(snapshot, animatingDifferences: false)
 
-        var isFirstCall = true
+        guard self.contentSizeObserver == nil else {
+            completion()
+            return
+        }
         // For some reason, the observer subscription has to be here, doesn't work if it's in `viewDidLoad`.
         self.contentSizeObserver = self.tableView.observe(\.contentSize, options: [.new]) { [weak self] _, change in
             guard let self = self, let value = change.newValue, value.height != self.tableViewHeight.constant else { return }
@@ -190,14 +193,9 @@ class LookupViewController: UIViewController {
 
             if value.height >= self.tableView.frame.height, !self.tableView.isScrollEnabled {
                 self.tableView.isScrollEnabled = true
-                self.contentSizeObserver = nil
             }
 
-            if isFirstCall {
-                completion()
-            } else {
-                isFirstCall = false
-            }
+            completion()
         }
     }
 

--- a/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/LookupViewController.swift
@@ -106,20 +106,19 @@ class LookupViewController: UIViewController {
             self.errorLabel.text = L10n.Errors.lookup
             self.errorLabel.isHidden = false
 
-        case .loadingIdentifiers:
+        case .waitingInput:
             self.tableView.isHidden = true
             self.errorLabel.isHidden = true
             self.activityIndicator.stopAnimating()
             self.activityIndicator.isHidden = true
 
+        case .loadingIdentifiers:
+            self.tableView.isHidden = true
+            self.errorLabel.isHidden = true
+            self.activityIndicator.isHidden = false
+            self.activityIndicator.startAnimating()
+
         case .lookup(let data):
-            guard !data.isEmpty else {
-                self.tableView.isHidden = true
-                self.errorLabel.isHidden = true
-                self.activityIndicator.isHidden = false
-                self.activityIndicator.startAnimating()
-                return
-            }
             // It takes a little while for the `contentSize` observer notification to come, so all the content is hidden after the notification arrives, so that there is not an empty screen while
             // waiting for it.
             self.show(data: data) { [weak self] in

--- a/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
@@ -112,6 +112,9 @@ class ManualLookupViewController: UIViewController {
 
         case .loadingIdentifiers:
             // Initial state for user input, when no lookup state has been restored.
+            self.lookupController?.view.isHidden = true
+            self.topConstraint.constant = 15
+            
             self.titleLabel.isHidden = false
             self.inputContainer.isHidden = false
 
@@ -134,18 +137,24 @@ class ManualLookupViewController: UIViewController {
                 self.textView.resignFirstResponder()
             }
             
-            self.setupCloseBarButton(title: L10n.close)
+            self.setupCloseCancelAllBarButtons()
         }
     }
 
-    private func setupCloseBarButton(title: String) {
-        self.navigationItem.rightBarButtonItem = nil
+    private func setupCloseCancelAllBarButtons() {
+        navigationItem.rightBarButtonItem = nil
 
-        let cancelItem = UIBarButtonItem(title: title, style: .plain, target: nil, action: nil)
-        cancelItem.rx.tap.subscribe(onNext: { [weak self] in
+        let closeItem = UIBarButtonItem(title: L10n.close, style: .plain, target: nil, action: nil)
+        closeItem.rx.tap.subscribe(onNext: { [weak self] in
             self?.close()
         }).disposed(by: self.disposeBag)
-        self.navigationItem.leftBarButtonItem = cancelItem
+        
+        let cancelAllItem = UIBarButtonItem(title: L10n.cancelAll, style: .plain, target: nil, action: nil)
+        cancelAllItem.rx.tap.subscribe(onNext: { [weak self] in
+            self?.lookupController?.viewModel.process(action: .cancelAllLookups)
+        }).disposed(by: self.disposeBag)
+
+        navigationItem.leftBarButtonItems = [closeItem, cancelAllItem]
     }
 
     private func setupCancelDoneBarButtons() {
@@ -159,7 +168,7 @@ class ManualLookupViewController: UIViewController {
         cancelItem.rx.tap.subscribe(onNext: { [weak self] in
             self?.close()
         }).disposed(by: self.disposeBag)
-        self.navigationItem.leftBarButtonItem = cancelItem
+        self.navigationItem.leftBarButtonItems = [cancelItem]
     }
 
     private func updatePreferredContentSize() {

--- a/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
@@ -155,6 +155,7 @@ class ManualLookupViewController: UIViewController {
         let cancelAllItem = UIBarButtonItem(title: L10n.cancelAll, style: .plain, target: nil, action: nil)
         cancelAllItem.rx.tap.subscribe(onNext: { [weak self] in
             self?.lookupController?.viewModel.process(action: .cancelAllLookups)
+            self?.close()
         }).disposed(by: self.disposeBag)
 
         navigationItem.leftBarButtonItems = [closeItem, fixedSpacer, cancelAllItem]

--- a/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
@@ -183,7 +183,7 @@ class ManualLookupViewController: UIViewController {
 
     private func updateKeyboardSize(_ data: KeyboardData) {
         guard UIDevice.current.userInterfaceIdiom == .phone else { return }
-        self.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: data.endFrame.height, right: 0)
+        self.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: data.visibleHeight, right: 0)
     }
 
     // MARK: - Setups

--- a/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
@@ -7,13 +7,11 @@
 //
 
 import UIKit
-import WebKit
 
 import CocoaLumberjackSwift
 import RxSwift
 
 class ManualLookupViewController: UIViewController {
-    @IBOutlet private weak var webView: WKWebView!
     @IBOutlet private weak var container: UIStackView!
     @IBOutlet private weak var roundedContainer: UIView!
     @IBOutlet private weak var titleLabel: UILabel!
@@ -209,7 +207,6 @@ class ManualLookupViewController: UIViewController {
 
     private func setupLookupController() {
         guard let controller = self.coordinatorDelegate?.lookupController(multiLookupEnabled: false, hasDarkBackground: false) else { return }
-        controller.webView = self.webView
         controller.view.isHidden = true
         self.lookupController = controller
 

--- a/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
@@ -254,6 +254,12 @@ class ManualLookupViewController: UIViewController {
     }
 }
 
+extension ManualLookupViewController: IdentifierLookupPresenter {
+    func isPresenting() -> Bool {
+        lookupController?.view.isHidden == false
+    }
+}
+
 private final class LiveTextResponder: UIResponder, UIKeyInput {
     private weak var viewModel: ViewModel<ManualLookupActionHandler>?
 

--- a/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
@@ -98,7 +98,7 @@ class ManualLookupViewController: UIViewController {
     private func update(state: LookupState) {
         switch state.lookupState {
         case .failed:
-            // Similar to state for user input, but with error message displayed.
+            // Similar to initial state for user input, but with error message displayed.
             self.lookupController?.view.isHidden = false
             
             self.titleLabel.isHidden = false
@@ -110,7 +110,7 @@ class ManualLookupViewController: UIViewController {
             
             self.setupCancelDoneBarButtons()
 
-        case .loadingIdentifiers:
+        case .waitingInput:
             // Initial state for user input, when no lookup state has been restored.
             self.lookupController?.view.isHidden = true
             self.topConstraint.constant = 15
@@ -124,7 +124,7 @@ class ManualLookupViewController: UIViewController {
             
             self.setupCancelDoneBarButtons()
 
-        case .lookup:
+        case .loadingIdentifiers, .lookup:
             self.lookupController?.view.isHidden = false
             
             self.titleLabel.isHidden = true
@@ -144,6 +144,9 @@ class ManualLookupViewController: UIViewController {
     private func setupCloseCancelAllBarButtons() {
         navigationItem.rightBarButtonItem = nil
 
+        let fixedSpacer = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
+        fixedSpacer.width = 16
+
         let closeItem = UIBarButtonItem(title: L10n.close, style: .plain, target: nil, action: nil)
         closeItem.rx.tap.subscribe(onNext: { [weak self] in
             self?.close()
@@ -154,7 +157,7 @@ class ManualLookupViewController: UIViewController {
             self?.lookupController?.viewModel.process(action: .cancelAllLookups)
         }).disposed(by: self.disposeBag)
 
-        navigationItem.leftBarButtonItems = [closeItem, cancelAllItem]
+        navigationItem.leftBarButtonItems = [closeItem, fixedSpacer, cancelAllItem]
     }
 
     private func setupCancelDoneBarButtons() {

--- a/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
@@ -121,7 +121,7 @@ class ManualLookupViewController: UIViewController {
             
             self.setupCancelDoneBarButtons()
 
-        case .lookup(let data):
+        case .lookup:
             self.lookupController?.view.isHidden = false
             
             self.titleLabel.isHidden = true
@@ -134,13 +134,7 @@ class ManualLookupViewController: UIViewController {
                 self.textView.resignFirstResponder()
             }
             
-            let didTranslateAll = !data.contains(where: { data in
-                switch data.state {
-                case .enqueued, .inProgress: return true
-                case .failed, .translated: return false
-                }
-            })
-            self.setupCloseBarButton(title: didTranslateAll ? L10n.close : L10n.cancel)
+            self.setupCloseBarButton(title: L10n.close)
         }
     }
 

--- a/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.xib
+++ b/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.xib
@@ -22,7 +22,6 @@
                 <outlet property="titleLabel" destination="4ev-98-hhW" id="Kf6-ey-mRe"/>
                 <outlet property="topConstraint" destination="dMJ-41-9SJ" id="UKJ-i8-2JE"/>
                 <outlet property="view" destination="5Zg-jR-lrP" id="ZRe-Ca-sVd"/>
-                <outlet property="webView" destination="ehk-5k-KTu" id="xXa-HA-LzF"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -30,14 +29,6 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <wkWebView hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ehk-5k-KTu">
-                    <rect key="frame" x="0.0" y="48" width="414" height="814"/>
-                    <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <wkWebViewConfiguration key="configuration">
-                        <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
-                        <wkPreferences key="preferences"/>
-                    </wkWebViewConfiguration>
-                </wkWebView>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="CBC-9R-ZFy">
                     <rect key="frame" x="15" y="63" width="384" height="784"/>
                     <subviews>
@@ -86,11 +77,7 @@
             <viewLayoutGuide key="safeArea" id="c30-ta-gNc"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="c30-ta-gNc" firstAttribute="trailing" secondItem="ehk-5k-KTu" secondAttribute="trailing" id="Aas-Tb-DLu"/>
-                <constraint firstItem="ehk-5k-KTu" firstAttribute="leading" secondItem="c30-ta-gNc" secondAttribute="leading" id="B6i-Lc-49E"/>
-                <constraint firstItem="c30-ta-gNc" firstAttribute="bottom" secondItem="ehk-5k-KTu" secondAttribute="bottom" id="EsW-Pp-MuX"/>
                 <constraint firstItem="c30-ta-gNc" firstAttribute="trailing" secondItem="CBC-9R-ZFy" secondAttribute="trailing" constant="15" id="GND-9B-MuT"/>
-                <constraint firstItem="ehk-5k-KTu" firstAttribute="top" secondItem="c30-ta-gNc" secondAttribute="top" id="IFs-ev-qY1"/>
                 <constraint firstItem="c30-ta-gNc" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="CBC-9R-ZFy" secondAttribute="bottom" constant="15" id="JTA-yk-KBy"/>
                 <constraint firstItem="CBC-9R-ZFy" firstAttribute="leading" secondItem="c30-ta-gNc" secondAttribute="leading" constant="15" id="Vbv-dG-rKZ"/>
                 <constraint firstItem="CBC-9R-ZFy" firstAttribute="top" secondItem="c30-ta-gNc" secondAttribute="top" constant="15" id="dMJ-41-9SJ"/>

--- a/Zotero/Scenes/Detail/Lookup/Views/ScannerViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/ScannerViewController.swift
@@ -8,7 +8,6 @@
 
 import AVFoundation
 import UIKit
-import WebKit
 
 import CocoaLumberjackSwift
 import RxSwift
@@ -18,7 +17,6 @@ final class ScannerViewController: UIViewController {
     private let sessionQueue: DispatchQueue
     private let disposeBag: DisposeBag
 
-    @IBOutlet private weak var webView: WKWebView!
     @IBOutlet private weak var barcodeContainer: UIView!
     @IBOutlet private weak var barcodeStackContainer: UIStackView!
     @IBOutlet private weak var barcodeTitleLabel: UILabel!
@@ -116,7 +114,6 @@ final class ScannerViewController: UIViewController {
 
     private func setupLookupController() {
         guard let controller = self.coordinatorDelegate?.lookupController(multiLookupEnabled: true, hasDarkBackground: true) else { return }
-        controller.webView = self.webView
         controller.view.backgroundColor = .clear
         controller.view.isHidden = true
         self.lookupController = controller

--- a/Zotero/Scenes/Detail/Lookup/Views/ScannerViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/ScannerViewController.swift
@@ -195,3 +195,9 @@ extension ScannerViewController: AVCaptureMetadataOutputObjectsDelegate {
         self.lookupController?.view.isHidden = false
     }
 }
+
+extension ScannerViewController: IdentifierLookupPresenter {
+    func isPresenting() -> Bool {
+        lookupController?.view.isHidden == false
+    }
+}

--- a/Zotero/Scenes/Detail/Lookup/Views/ScannerViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/ScannerViewController.swift
@@ -113,7 +113,7 @@ final class ScannerViewController: UIViewController {
     // MARK: - Setups
 
     private func setupLookupController() {
-        guard let controller = self.coordinatorDelegate?.lookupController(multiLookupEnabled: true, hasDarkBackground: true) else { return }
+        guard let controller = self.coordinatorDelegate?.lookupController(restoreLookupState: true, hasDarkBackground: true) else { return }
         controller.view.backgroundColor = .clear
         controller.view.isHidden = true
         self.lookupController = controller

--- a/Zotero/Scenes/Detail/Lookup/Views/ScannerViewController.xib
+++ b/Zotero/Scenes/Detail/Lookup/Views/ScannerViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -15,7 +15,6 @@
                 <outlet property="barcodeStackContainer" destination="RKp-Fw-EE9" id="7sk-70-7qO"/>
                 <outlet property="barcodeTitleLabel" destination="CLK-8r-yoH" id="vae-oh-2mq"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
-                <outlet property="webView" destination="Wnj-84-CMH" id="WjH-dM-cZZ"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -23,22 +22,14 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <wkWebView hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wnj-84-CMH">
-                    <rect key="frame" x="0.0" y="44" width="414" height="771.5"/>
-                    <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <wkWebViewConfiguration key="configuration">
-                        <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
-                        <wkPreferences key="preferences"/>
-                    </wkWebViewConfiguration>
-                </wkWebView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ju0-oz-eDG">
-                    <rect key="frame" x="0.0" y="815.5" width="414" height="46.5"/>
+                    <rect key="frame" x="0.0" y="812" width="414" height="50"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RKp-Fw-EE9">
-                            <rect key="frame" x="16" y="16" width="382" height="14.5"/>
+                            <rect key="frame" x="16" y="16" width="382" height="18"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scan one or more barcodes" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CLK-8r-yoH">
-                                    <rect key="frame" x="0.0" y="0.0" width="382" height="14.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="382" height="18"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <nil key="highlightedColor"/>
@@ -60,11 +51,7 @@
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="ju0-oz-eDG" secondAttribute="trailing" id="067-pn-qWP"/>
-                <constraint firstItem="Wnj-84-CMH" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="210-Tf-UXB"/>
-                <constraint firstItem="Wnj-84-CMH" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="DPZ-3Z-YSV"/>
                 <constraint firstItem="ju0-oz-eDG" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="DjQ-Fj-hbJ"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Wnj-84-CMH" secondAttribute="trailing" id="KnE-cr-ddM"/>
-                <constraint firstItem="ju0-oz-eDG" firstAttribute="top" secondItem="Wnj-84-CMH" secondAttribute="bottom" id="PEa-9k-akH"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="ju0-oz-eDG" secondAttribute="bottom" id="Tpn-MT-gyG"/>
             </constraints>
             <point key="canvasLocation" x="131.8840579710145" y="122.54464285714285"/>

--- a/Zotero/Scenes/Master/Libraries/Views/LibrariesViewController.swift
+++ b/Zotero/Scenes/Master/Libraries/Views/LibrariesViewController.swift
@@ -222,10 +222,4 @@ extension LibrariesViewController: IdentifierLookupWebViewProvider {
         view.insertSubview(webView, at: 0)
         return webView
     }
-    
-    func removeWebView(_ webView: WKWebView) {
-        if view.subviews.contains(where: { $0 == webView }) {
-            webView.removeFromSuperview()
-        }
-    }
 }

--- a/Zotero/Scenes/Master/Libraries/Views/LibrariesViewController.swift
+++ b/Zotero/Scenes/Master/Libraries/Views/LibrariesViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import WebKit
 
 import RxSwift
 
@@ -17,16 +18,20 @@ final class LibrariesViewController: UIViewController {
     private static let customLibrariesSection = 0
     private static let groupLibrariesSection = 1
     private let viewModel: ViewModel<LibrariesActionHandler>
+    private unowned let identifierLookupController: IdentifierLookupController
     private let disposeBag: DisposeBag
 
     weak var coordinatorDelegate: MasterLibrariesCoordinatorDelegate?
 
     // MARK: - Lifecycle
 
-    init(viewModel: ViewModel<LibrariesActionHandler>) {
+    init(viewModel: ViewModel<LibrariesActionHandler>, identifierLookupController: IdentifierLookupController) {
         self.viewModel = viewModel
+        self.identifierLookupController = identifierLookupController
         self.disposeBag = DisposeBag()
         super.init(nibName: "LibrariesViewController", bundle: nil)
+        
+        identifierLookupController.webViewProvider = self
     }
 
     required init?(coder: NSCoder) {
@@ -209,3 +214,18 @@ extension LibrariesViewController: UITableViewDataSource, UITableViewDelegate {
 }
 
 extension LibrariesViewController: BottomSheetObserver { }
+
+extension LibrariesViewController: IdentifierLookupWebViewProvider {
+    func addWebView() -> WKWebView {
+        let webView = WKWebView()
+        webView.isHidden = true
+        view.insertSubview(webView, at: 0)
+        return webView
+    }
+    
+    func removeWebView(_ webView: WKWebView) {
+        if view.subviews.contains(where: { $0 == webView }) {
+            webView.removeFromSuperview()
+        }
+    }
+}

--- a/Zotero/Scenes/Master/MasterCoordinator.swift
+++ b/Zotero/Scenes/Master/MasterCoordinator.swift
@@ -56,7 +56,7 @@ final class MasterCoordinator: NSObject, Coordinator {
 
     func start(animated: Bool) {
         guard let userControllers = self.controllers.userControllers else { return }
-        let librariesController = self.createLibrariesViewController(dbStorage: userControllers.dbStorage)
+        let librariesController = self.createLibrariesViewController(dbStorage: userControllers.dbStorage, identifierLookupController: userControllers.identifierLookupController)
         let collectionsController = self.createCollectionsViewController(
             libraryId: self.visibleLibraryId,
             selectedCollectionId: Defaults.shared.selectedCollectionId,
@@ -66,9 +66,9 @@ final class MasterCoordinator: NSObject, Coordinator {
         self.navigationController?.setViewControllers([librariesController, collectionsController], animated: animated)
     }
 
-    private func createLibrariesViewController(dbStorage: DbStorage) -> UIViewController {
+    private func createLibrariesViewController(dbStorage: DbStorage, identifierLookupController: IdentifierLookupController) -> UIViewController {
         let viewModel = ViewModel(initialState: LibrariesState(), handler: LibrariesActionHandler(dbStorage: dbStorage))
-        let controller = LibrariesViewController(viewModel: viewModel)
+        let controller = LibrariesViewController(viewModel: viewModel, identifierLookupController: identifierLookupController)
         controller.coordinatorDelegate = self
         return controller
     }


### PR DESCRIPTION
closes https://github.com/zotero/zotero-ios/issues/683

Moves item & attachment creation from identifier lookup to a separate user controller, that is guarranted to fulfill ongoing lookups, if lookup window is closed.

With this change, perhaps we should label the button as `Close`, instead of `Cancel`. Furthermore, the items added for this identifier, perhaps should indicate that they might have pending downloads.

-- 

TODO:
- [x] Keep track of separate lookup window initializations, if selected library & collections are different.
- [x] Include downloaded attachments from translated identifiers, in items toolbar label `Downloaded x/y`.
- [x] Show progress of identifier lookup in items toolbar label as `Saved x/y`.
- [x] Add button in items toolbar, that will restore lookup window, when there are identifier lookups in the background.
- [x] Add `Cancel all` button in lookup window, that will cancel all downloads and trash items/attachments already fetched.
- [x] Rename current `Cancel` button in lookup window to `Close`, that dismisses window and continues lookup in the background.
- [ ] Add a cancel button in each lookup item row, for individual cancellation. Cancelling an item, will also remove its attachments. Use an X or trash icon.
- [ ] Add a cancel button in each attachment row, that cancels/removes this attachment.
- [x] Cleanup of finished lookup items from controller, when lookup window is closed, and all operations are finished/cancelled.
- [x] When new identifiers are added for lookup, with previous ones queued, show a list of all items.
