### PR TITLE
Refactored Coordinator.navigationController to be weak instead of unowned

### DIFF
--- a/Zotero/Controllers/Architecture/Coordinator.swift
+++ b/Zotero/Controllers/Architecture/Coordinator.swift
@@ -16,7 +16,7 @@ enum SourceView {
 protocol Coordinator: AnyObject {
     var parentCoordinator: Coordinator? { get }
     var childCoordinators: [Coordinator] { get set }
-    var navigationController: UINavigationController { get }
+    var navigationController: UINavigationController? { get }
 
     func start(animated: Bool)
     func childDidFinish(_ child: Coordinator)
@@ -30,9 +30,9 @@ extension Coordinator {
         }
 
         // Take navigation controller delegate back from child if needed
-        if self.navigationController.delegate === child,
+        if self.navigationController?.delegate === child,
            let delegate = self as? UINavigationControllerDelegate {
-            self.navigationController.delegate = delegate
+            self.navigationController?.delegate = delegate
         }
     }
 
@@ -52,6 +52,6 @@ extension Coordinator {
             }
         }
 
-        (presenter ?? navigationController).present(controller, animated: true, completion: nil)
+        (presenter ?? navigationController)?.present(controller, animated: true, completion: nil)
     }
 }

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -180,13 +180,13 @@ final class AppCoordinator: NSObject {
 
         // Show "All" collection in given library/group
         if mainController.masterCoordinator?.topCoordinator.visibleLibraryId != library.identifier ||
-           (mainController.masterCoordinator?.topCoordinator.navigationController.visibleViewController as? CollectionsViewController)?.selectedIdentifier != .custom(.all) {
+           (mainController.masterCoordinator?.topCoordinator.navigationController?.visibleViewController as? CollectionsViewController)?.selectedIdentifier != .custom(.all) {
             mainController.masterCoordinator?.topCoordinator.showCollections(for: library.identifier, preselectedCollection: .custom(.all), animated: animated)
         }
 
         // Show item detail of given key
         mainController.getDetailCoordinator { coordinator in
-            if (coordinator.navigationController.visibleViewController as? ItemDetailViewController)?.key != key {
+            if (coordinator.navigationController?.visibleViewController as? ItemDetailViewController)?.key != key {
                 coordinator.showItemDetail(for: .preview(key: key), library: library, scrolledToKey: childKey, animated: animated)
             }
         }
@@ -196,7 +196,7 @@ final class AppCoordinator: NSObject {
         guard let window = self.window, let mainController = window.rootViewController as? MainViewController else { return }
 
         mainController.getDetailCoordinator { [weak self] coordinator in
-            guard let self = self, (coordinator.navigationController.presentedViewController as? PDFReaderViewController)?.key != attachment.key else { return }
+            guard let self = self, (coordinator.navigationController?.presentedViewController as? PDFReaderViewController)?.key != attachment.key else { return }
             self._open(attachment: attachment, library: library, on: page, annotation: annotation, window: window, detailCoordinator: coordinator, animated: animated) {
                 self._showItemDetail(key: (parentKey ?? attachment.key), library: library, selectChildKey: attachment.key, animated: animated)
             }

--- a/Zotero/Scenes/Detail/Annotation Filter Popover/AnnotationsFilterPopoverCoordinator.swift
+++ b/Zotero/Scenes/Detail/Annotation Filter Popover/AnnotationsFilterPopoverCoordinator.swift
@@ -15,12 +15,11 @@ protocol AnnotationsFilterPopoverToAnnotationsFilterCoordinatorDelegate: AnyObje
 final class AnnotationsFilterPopoverCoordinator: NSObject, Coordinator {
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator]
+    weak var navigationController: UINavigationController?
 
     private let initialFilter: AnnotationsFilter?
     private let availableColors: [String]
     private let availableTags: [Tag]
-
-    unowned let navigationController: UINavigationController
     private unowned let controllers: Controllers
     private let completionHandler: (AnnotationsFilter?) -> Void
 
@@ -48,7 +47,7 @@ final class AnnotationsFilterPopoverCoordinator: NSObject, Coordinator {
         let viewModel = ViewModel(initialState: state, handler: handler)
         let controller = AnnotationsFilterViewController(viewModel: viewModel, completion: self.completionHandler)
         controller.coordinatorDelegate = self
-        self.navigationController.setViewControllers([controller], animated: animated)
+        self.navigationController?.setViewControllers([controller], animated: animated)
     }
 }
 
@@ -65,7 +64,7 @@ extension AnnotationsFilterPopoverCoordinator: AnnotationsFilterPopoverToAnnotat
             completed(tagNames)
         })
         controller.preferredContentSize = CGSize(width: 300, height: 500)
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 }
 

--- a/Zotero/Scenes/Detail/Annotation Popover/AnnotationPopoverCoordinator.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/AnnotationPopoverCoordinator.swift
@@ -28,8 +28,8 @@ protocol AnnotationEditCoordinatorDelegate: AnyObject {
 final class AnnotationPopoverCoordinator: NSObject, Coordinator {
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator]
+    weak var navigationController: UINavigationController?
 
-    unowned let navigationController: UINavigationController
     private unowned let viewModel: ViewModel<PDFReaderActionHandler>
     private unowned let controllers: Controllers
     private let disposeBag: DisposeBag
@@ -52,8 +52,8 @@ final class AnnotationPopoverCoordinator: NSObject, Coordinator {
     func start(animated: Bool) {
         let controller = AnnotationViewController(viewModel: self.viewModel, attributedStringConverter: self.controllers.htmlAttributedStringConverter)
         controller.coordinatorDelegate = self
-        self.navigationController.isNavigationBarHidden = true
-        self.navigationController.setViewControllers([controller], animated: animated)
+        self.navigationController?.isNavigationBarHidden = true
+        self.navigationController?.setViewControllers([controller], animated: animated)
     }
 }
 
@@ -75,7 +75,7 @@ extension AnnotationPopoverCoordinator: AnnotationPopoverAnnotationCoordinatorDe
         let viewModel = ViewModel(initialState: state, handler: handler)
         let controller = AnnotationEditViewController(viewModel: viewModel, includeColorPicker: false, saveAction: saveAction, deleteAction: deleteAction)
         controller.coordinatorDelegate = self
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 
     func showTagPicker(libraryId: LibraryIdentifier, selected: Set<String>, picked: @escaping ([Tag]) -> Void) {
@@ -86,8 +86,8 @@ extension AnnotationPopoverCoordinator: AnnotationPopoverAnnotationCoordinatorDe
         let viewModel = ViewModel(initialState: state, handler: handler)
         let controller = TagPickerViewController(viewModel: viewModel, saveAction: picked)
         controller.preferredContentSize = AnnotationPopoverLayout.tagPickerPreferredSize
-        self.navigationController.preferredContentSize = controller.preferredContentSize
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.preferredContentSize = controller.preferredContentSize
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 
     func didFinish() {
@@ -101,7 +101,7 @@ extension AnnotationPopoverCoordinator: AnnotationEditCoordinatorDelegate {
         let handler = AnnotationPageLabelActionHandler()
         let viewModel = ViewModel(initialState: state, handler: handler)
         let controller = AnnotationPageLabelViewController(viewModel: viewModel, saveAction: saveAction)
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 }
 

--- a/Zotero/Scenes/Detail/CitationBibliographyExport/CitationBibliographyExportCoordinator.swift
+++ b/Zotero/Scenes/Detail/CitationBibliographyExport/CitationBibliographyExportCoordinator.swift
@@ -22,11 +22,11 @@ protocol CitationBibliographyExportCoordinatorDelegate: AnyObject {
 final class CitationBibliographyExportCoordinator: NSObject, Coordinator {
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator]
+    weak var navigationController: UINavigationController?
 
     private static let defaultSize: CGSize = CGSize(width: 600, height: 504)
     private let itemIds: Set<String>
     private let libraryId: LibraryIdentifier
-    unowned let navigationController: UINavigationController
     private unowned let controllers: Controllers
     private let disposeBag: DisposeBag
 
@@ -89,20 +89,21 @@ final class CitationBibliographyExportCoordinator: NSObject, Coordinator {
         let controller = UIHostingController(rootView: view.environmentObject(viewModel))
         controller.preferredContentSize = CitationBibliographyExportCoordinator.defaultSize
 
-        self.navigationController.setViewControllers([controller], animated: animated)
-        self.navigationController.view.insertSubview(webView, at: 0)
+        self.navigationController?.setViewControllers([controller], animated: animated)
+        self.navigationController?.view.insertSubview(webView, at: 0)
     }
 
     private func share(file: File) {
+        guard let navigationController else { return }
         let controller = UIActivityViewController(activityItems: [file.createUrl()], applicationActivities: nil)
         controller.modalPresentationStyle = .pageSheet
-        controller.popoverPresentationController?.sourceView = self.navigationController.viewControllers.first?.view
+        controller.popoverPresentationController?.sourceView = navigationController.viewControllers.first?.view
         controller.completionWithItemsHandler = { [weak self] _, finished, _, _ in
             if finished {
                 self?.cancel()
             }
         }
-        self.navigationController.present(controller, animated: true, completion: nil)
+        navigationController.present(controller, animated: true, completion: nil)
     }
 }
 
@@ -115,7 +116,7 @@ extension CitationBibliographyExportCoordinator: CitationBibliographyExportCoord
         let view = StylePickerView(picked: picked)
         let controller = UIHostingController(rootView: view.environmentObject(viewModel))
         controller.preferredContentSize = CGSize(width: CitationBibliographyExportCoordinator.defaultSize.width, height: UIScreen.main.bounds.size.height)
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 
     func showLanguagePicker(picked: @escaping (ExportLocale) -> Void) {
@@ -126,11 +127,11 @@ extension CitationBibliographyExportCoordinator: CitationBibliographyExportCoord
         let view = ExportLocalePickerView(picked: picked)
         let controller = UIHostingController(rootView: view.environmentObject(viewModel))
         controller.preferredContentSize = CGSize(width: CitationBibliographyExportCoordinator.defaultSize.width, height: UIScreen.main.bounds.size.height)
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 
     func cancel() {
-        self.navigationController.parent?.presentingViewController?.dismiss(animated: true, completion: nil)
+        self.navigationController?.parent?.presentingViewController?.dismiss(animated: true, completion: nil)
     }
 }
 

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -253,10 +253,11 @@ final class DetailCoordinator: Coordinator {
     }
 
     private func showWebView(for url: URL) {
+        guard let currentNavigationController = self.navigationController else { return }
         let controller = WebViewController(url: url)
         let navigationController = UINavigationController(rootViewController: controller)
         navigationController.modalPresentationStyle = .fullScreen
-        self.navigationController?.present(navigationController, animated: true, completion: nil)
+        currentNavigationController.present(navigationController, animated: true, completion: nil)
     }
 
     func show(doi: String) {

--- a/Zotero/Scenes/Detail/Items/ItemsFilterCoordinator.swift
+++ b/Zotero/Scenes/Detail/Items/ItemsFilterCoordinator.swift
@@ -15,9 +15,9 @@ protocol ItemsFilterCoordinatorDelegate: AnyObject {
 final class ItemsFilterCoordinator: NSObject, Coordinator {
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator]
+    weak var navigationController: UINavigationController?
 
     private unowned let viewModel: ViewModel<ItemsActionHandler>
-    unowned let navigationController: UINavigationController
     private unowned let controllers: Controllers
     private weak var itemsController: ItemsViewController?
 
@@ -49,7 +49,7 @@ final class ItemsFilterCoordinator: NSObject, Coordinator {
 
         let controller = ItemsFilterViewController(viewModel: self.viewModel, tagFilterController: tagController)
         controller.coordinatorDelegate = self
-        self.navigationController.setViewControllers([controller], animated: animated)
+        self.navigationController?.setViewControllers([controller], animated: animated)
     }
 }
 
@@ -61,6 +61,6 @@ extension ItemsFilterCoordinator: ItemsFilterCoordinatorDelegate {
         let handler = TagPickerActionHandler(dbStorage: dbStorage)
         let viewModel = ViewModel(initialState: state, handler: handler)
         let controller = TagPickerViewController(viewModel: viewModel, saveAction: picked)
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 }

--- a/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
+++ b/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
@@ -22,9 +22,9 @@ protocol LookupCoordinatorDelegate: AnyObject {
 final class LookupCoordinator: NSObject, Coordinator {
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator]
+    weak var navigationController: UINavigationController?
 
     private let startingView: LookupStartingView
-    unowned let navigationController: UINavigationController
     private unowned let controllers: Controllers
     private let disposeBag: DisposeBag
 
@@ -44,7 +44,7 @@ final class LookupCoordinator: NSObject, Coordinator {
 
     func start(animated: Bool) {
         let controller = self.startingView == .manual ? self.manualController : self.scannerController
-        self.navigationController.setViewControllers([controller], animated: animated)
+        self.navigationController?.setViewControllers([controller], animated: animated)
     }
 
     private func lookupController(multiLookupEnabled: Bool, hasDarkBackground: Bool, userControllers: UserControllers) -> LookupViewController {

--- a/Zotero/Scenes/Detail/PDF/AnnotationEditCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/AnnotationEditCoordinator.swift
@@ -14,6 +14,7 @@ import RxSwift
 final class AnnotationEditCoordinator: Coordinator {
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator]
+    weak var navigationController: UINavigationController?
 
     private let annotation: Annotation
     private let userId: Int
@@ -21,7 +22,6 @@ final class AnnotationEditCoordinator: Coordinator {
     private let saveAction: AnnotationEditSaveAction
     private let deleteAction: AnnotationEditDeleteAction
     private unowned let controllers: Controllers
-    unowned let navigationController: UINavigationController
     private let disposeBag: DisposeBag
 
     init(annotation: Annotation, userId: Int, library: Library, saveAction: @escaping AnnotationEditSaveAction, deleteAction: @escaping AnnotationEditDeleteAction,
@@ -51,7 +51,7 @@ final class AnnotationEditCoordinator: Coordinator {
         let viewModel = ViewModel(initialState: state, handler: handler)
         let controller = AnnotationEditViewController(viewModel: viewModel, includeColorPicker: true, saveAction: self.saveAction, deleteAction: self.deleteAction)
         controller.coordinatorDelegate = self
-        self.navigationController.setViewControllers([controller], animated: false)
+        self.navigationController?.setViewControllers([controller], animated: false)
     }
 }
 
@@ -61,6 +61,6 @@ extension AnnotationEditCoordinator: AnnotationEditCoordinatorDelegate {
         let handler = AnnotationPageLabelActionHandler()
         let viewModel = ViewModel(initialState: state, handler: handler)
         let controller = AnnotationPageLabelViewController(viewModel: viewModel, saveAction: saveAction)
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 }

--- a/Zotero/Scenes/Detail/PDF/CreatorEditCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/CreatorEditCoordinator.swift
@@ -19,13 +19,13 @@ protocol CreatorEditCoordinatorDelegate: AnyObject {
 final class CreatorEditCoordinator: Coordinator {
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator]
+    weak var navigationController: UINavigationController?
 
     let creator: ItemDetailState.Creator
     let itemType: String
     let saved: CreatorEditSaveAction
     let deleted: CreatorEditDeleteAction?
     private unowned let controllers: Controllers
-    unowned let navigationController: UINavigationController
     private let disposeBag: DisposeBag
 
     init(creator: ItemDetailState.Creator, itemType: String, saved: @escaping CreatorEditSaveAction, deleted: CreatorEditDeleteAction?,
@@ -58,7 +58,7 @@ final class CreatorEditCoordinator: Coordinator {
         let navigationController = UINavigationController(rootViewController: controller)
         navigationController.isModalInPresentation = true
         navigationController.modalPresentationStyle = .formSheet
-        self.navigationController.setViewControllers([controller], animated: animated)
+        self.navigationController?.setViewControllers([controller], animated: animated)
     }
 }
 
@@ -73,6 +73,6 @@ extension CreatorEditCoordinator: CreatorEditCoordinatorDelegate {
         .environmentObject(viewModel)
 
         let controller = UIHostingController(rootView: view)
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 }

--- a/Zotero/Scenes/General/NoteEditorCoordinator.swift
+++ b/Zotero/Scenes/General/NoteEditorCoordinator.swift
@@ -19,6 +19,7 @@ final class NoteEditorCoordinator: NSObject, Coordinator {
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator]
     private var transitionDelegate: EmptyTransitioningDelegate?
+    weak var navigationController: UINavigationController?
 
     private let initialText: String
     private let initialTags: [Tag]
@@ -26,7 +27,6 @@ final class NoteEditorCoordinator: NSObject, Coordinator {
     private let libraryId: LibraryIdentifier
     private let readOnly: Bool
     private let saveAction: (String, [Tag]) -> Void
-    unowned let navigationController: UINavigationController
     private unowned let controllers: Controllers
 
     init(text: String, tags: [Tag], title: NoteEditorState.TitleData?, libraryId: LibraryIdentifier, readOnly: Bool, save: @escaping (String, [Tag]) -> Void, navigationController: NavigationViewController, controllers: Controllers) {
@@ -54,7 +54,7 @@ final class NoteEditorCoordinator: NSObject, Coordinator {
         let viewModel = ViewModel(initialState: state, handler: handler)
         let controller = NoteEditorViewController(viewModel: viewModel)
         controller.coordinatorDelegate = self
-        self.navigationController.setViewControllers([controller], animated: animated)
+        self.navigationController?.setViewControllers([controller], animated: animated)
     }
 }
 
@@ -67,7 +67,7 @@ extension NoteEditorCoordinator: NoteEditorCoordinatorDelegate {
         let viewModel = ViewModel(initialState: state, handler: handler)
         let controller = TagPickerViewController(viewModel: viewModel, saveAction: picked)
 
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 
     func show(url: URL) {
@@ -85,6 +85,6 @@ extension NoteEditorCoordinator: NoteEditorCoordinatorDelegate {
         self.transitionDelegate = EmptyTransitioningDelegate()
         controller.transitioningDelegate = self.transitionDelegate
         self.transitionDelegate = nil
-        self.navigationController.present(controller, animated: true, completion: nil)
+        self.navigationController?.present(controller, animated: true, completion: nil)
     }
 }

--- a/Zotero/Scenes/Main/Views/MainViewController.swift
+++ b/Zotero/Scenes/Main/Views/MainViewController.swift
@@ -155,8 +155,9 @@ final class MainViewController: UISplitViewController {
         self.masterCoordinator = masterCoordinator
 
         if let progressObservable = self.controllers.userControllers?.syncScheduler.syncController.progressObservable,
-           let dbStorage = self.controllers.userControllers?.dbStorage {
-            self.syncToolbarController = SyncToolbarController(parent: masterCoordinator.topCoordinator.navigationController, progressObservable: progressObservable, dbStorage: dbStorage)
+           let dbStorage = self.controllers.userControllers?.dbStorage,
+           let navigationController = masterCoordinator.topCoordinator.navigationController {
+            self.syncToolbarController = SyncToolbarController(parent: navigationController, progressObservable: progressObservable, dbStorage: dbStorage)
             self.syncToolbarController?.coordinatorDelegate = self
         }
     }

--- a/Zotero/Scenes/Master/Collection Editing/CollectionEditingCoordinator.swift
+++ b/Zotero/Scenes/Master/Collection Editing/CollectionEditingCoordinator.swift
@@ -18,11 +18,11 @@ protocol CollectionEditingCoordinatorDelegate: AnyObject {
 final class CollectionEditingCoordinator: Coordinator {
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator]
+    weak var navigationController: UINavigationController?
 
     private let library: Library
     private let data: CollectionStateEditingData
     private unowned let controllers: Controllers
-    unowned let navigationController: UINavigationController
 
     init(data: CollectionStateEditingData, library: Library, navigationController: UINavigationController, controllers: Controllers) {
         self.data = data
@@ -36,7 +36,7 @@ final class CollectionEditingCoordinator: Coordinator {
         guard let dbStorage = self.controllers.userControllers?.dbStorage else { return }
 
         let controller = self.createEditViewController(dbStorage: dbStorage)
-        self.navigationController.setViewControllers([controller], animated: false)
+        self.navigationController?.setViewControllers([controller], animated: false)
     }
 
     private func createEditViewController(dbStorage: DbStorage) -> UIViewController {
@@ -59,9 +59,9 @@ extension CollectionEditingCoordinator: CollectionEditingCoordinatorDelegate {
         }))
         controller.addAction(UIAlertAction(title: L10n.delete, style: .destructive, handler: { _ in
             completion(true)
-            self.navigationController.dismiss(animated: true, completion: nil)
+            self.navigationController?.dismiss(animated: true, completion: nil)
         }))
-        self.navigationController.present(controller, animated: true, completion: nil)
+        self.navigationController?.present(controller, animated: true, completion: nil)
     }
 
     func showCollectionPicker(viewModel: ViewModel<CollectionEditActionHandler>) {
@@ -76,7 +76,7 @@ extension CollectionEditingCoordinator: CollectionEditingCoordinatorDelegate {
                                                                    excludedKeys: excludedKeys,
                                                                    dbStorage: dbStorage,
                                                                    collectionEditViewModel: viewModel)
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 
     private func createCollectionPickerViewController(library: Library, selected: String, excludedKeys: Set<String>, dbStorage: DbStorage,
@@ -91,7 +91,7 @@ extension CollectionEditingCoordinator: CollectionEditingCoordinatorDelegate {
     }
 
     func dismiss() {
-        self.navigationController.dismiss(animated: true, completion: { [weak self] in
+        self.navigationController?.dismiss(animated: true, completion: { [weak self] in
             guard let self = self else { return }
             self.parentCoordinator?.childDidFinish(self)
         })

--- a/Zotero/Scenes/Master/Settings/SettingsCoordinator.swift
+++ b/Zotero/Scenes/Master/Settings/SettingsCoordinator.swift
@@ -54,8 +54,8 @@ protocol DebuggingSettingsSettingsCoordinatorDelegate: AnyObject {
 final class SettingsCoordinator: NSObject, Coordinator {
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator]
+    weak var navigationController: UINavigationController?
 
-    unowned let navigationController: UINavigationController
     private unowned let controllers: Controllers
     private let startsWithExport: Bool
     private let disposeBag: DisposeBag
@@ -87,7 +87,7 @@ final class SettingsCoordinator: NSObject, Coordinator {
         if self.startsWithExport {
             controllers.append(self.createExportController())
         }
-        self.navigationController.setViewControllers(controllers, animated: animated)
+        self.navigationController?.setViewControllers(controllers, animated: animated)
     }
 
     private func createListController() -> UIViewController? {
@@ -149,7 +149,7 @@ extension SettingsCoordinator: StorageSettingsSettingsCoordinatorDelegate {
         controller.addAction(UIAlertAction(title: L10n.cancel, style: .cancel, handler: nil))
 
         // Settings are already presented, so present over them
-        self.navigationController.present(controller, animated: true, completion: nil)
+        self.navigationController?.present(controller, animated: true, completion: nil)
     }
 }
 
@@ -181,7 +181,7 @@ extension SettingsCoordinator: SettingsCoordinatorDelegate {
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }
         controller.preferredContentSize = SettingsCoordinator.defaultSize
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 
     func showSupport() {
@@ -194,7 +194,7 @@ extension SettingsCoordinator: SettingsCoordinatorDelegate {
 
     private func showSafari(with url: URL) {
         let controller = SFSafariViewController(url: url)
-        self.navigationController.present(controller, animated: true, completion: nil)
+        self.navigationController?.present(controller, animated: true, completion: nil)
     }
 
     func showCitationSettings() {
@@ -227,7 +227,7 @@ extension SettingsCoordinator: SettingsCoordinatorDelegate {
 
         let controller = UIAlertController(title: L10n.error, message: message, preferredStyle: .alert)
         controller.addAction(UIAlertAction(title: L10n.ok, style: .cancel, handler: nil))
-        self.navigationController.present(controller, animated: true, completion: nil)
+        self.navigationController?.present(controller, animated: true, completion: nil)
     }
 
     func showCitationStyleManagement(viewModel: ViewModel<CiteActionHandler>) {
@@ -245,12 +245,12 @@ extension SettingsCoordinator: SettingsCoordinatorDelegate {
         }
         controller.coordinatorDelegate = self
         controller.preferredContentSize = UIScreen.main.bounds.size
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 
     func showExportSettings() {
         let controller = self.createExportController()
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 
     func showStorageSettings() {
@@ -285,7 +285,7 @@ extension SettingsCoordinator: SettingsCoordinatorDelegate {
             viewModel?.process(action: .logout)
         }))
         controller.addAction(UIAlertAction(title: L10n.no, style: .cancel, handler: nil))
-        self.navigationController.present(controller, animated: true, completion: nil)
+        self.navigationController?.present(controller, animated: true, completion: nil)
     }
 
     func showGeneralSettings() {
@@ -295,13 +295,13 @@ extension SettingsCoordinator: SettingsCoordinatorDelegate {
     }
 
     func dismiss() {
-        self.navigationController.dismiss(animated: true, completion: nil)
+        self.navigationController?.dismiss(animated: true, completion: nil)
     }
 
     private func pushDefaultSize<V: View>(view: V) {
         let controller = UIHostingController(rootView: view)
         controller.preferredContentSize = SettingsCoordinator.defaultSize
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 
     func showSchemePicker(viewModel: ViewModel<SyncSettingsActionHandler>) {
@@ -314,19 +314,19 @@ extension SettingsCoordinator: SettingsCoordinatorDelegate {
             guard let scheme = WebDavScheme(rawValue: value) else { return }
             viewModel?.process(action: .setScheme(scheme))
         }, closeAction: { [weak self] completion in
-            self?.navigationController.popViewController(animated: true)
+            self?.navigationController?.popViewController(animated: true)
             completion?()
         })
 
         let controller = UIHostingController(rootView: view.environmentObject(ViewModel(initialState: state, handler: handler)))
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 
     func promptZoteroDirCreation(url: String, create: @escaping () -> Void, cancel: @escaping () -> Void) {
         let controller = UIAlertController(title: L10n.Settings.Sync.DirectoryNotFound.title, message: L10n.Settings.Sync.DirectoryNotFound.message(url), preferredStyle: .alert)
         controller.addAction(UIAlertAction(title: L10n.cancel, style: .cancel, handler: { _ in cancel() }))
         controller.addAction(UIAlertAction(title: L10n.create, style: .default, handler: { _ in create() }))
-        self.navigationController.present(controller, animated: true, completion: nil)
+        self.navigationController?.present(controller, animated: true, completion: nil)
     }
 
     func showWeb(url: URL, completion: @escaping () -> Void) {
@@ -338,7 +338,7 @@ extension SettingsCoordinator: SettingsCoordinatorDelegate {
         self.transitionDelegate = EmptyTransitioningDelegate()
         controller.transitioningDelegate = self.transitionDelegate
         self.transitionDelegate = nil
-        self.navigationController.present(controller, animated: true, completion: nil)
+        self.navigationController?.present(controller, animated: true, completion: nil)
     }
 }
 
@@ -358,7 +358,7 @@ extension SettingsCoordinator: CitationStyleSearchSettingsCoordinatorDelegate {
         controller.addAction(UIAlertAction(title: L10n.cancel, style: .cancel, handler: { _ in
             cancelAction()
         }))
-        self.navigationController.present(controller, animated: true, completion: nil)
+        self.navigationController?.present(controller, animated: true, completion: nil)
     }
 }
 
@@ -371,7 +371,7 @@ extension SettingsCoordinator: ExportSettingsCoordinatorDelegate {
         let view = StylePickerView(picked: picked)
         let controller = UIHostingController(rootView: view.environmentObject(viewModel))
         controller.preferredContentSize = SettingsCoordinator.defaultSize
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 
     func showLocalePicker(picked: @escaping (ExportLocale) -> Void) {
@@ -382,26 +382,26 @@ extension SettingsCoordinator: ExportSettingsCoordinatorDelegate {
         let view = ExportLocalePickerView(picked: picked)
         let controller = UIHostingController(rootView: view.environmentObject(viewModel))
         controller.preferredContentSize = SettingsCoordinator.defaultSize
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 }
 
 extension SettingsCoordinator: DebuggingSettingsSettingsCoordinatorDelegate {
     func exportDb() {
-        guard let userId = self.controllers.sessionController.sessionData?.userId else { return }
+        guard let navigationController, let userId = self.controllers.sessionController.sessionData?.userId else { return }
 
         let mainUrl = Files.dbFile(for: userId).createUrl()
         let bundledUrl = Files.bundledDataDbFile.createUrl()
 
         let controller = UIActivityViewController(activityItems: [mainUrl, bundledUrl], applicationActivities: nil)
         controller.modalPresentationStyle = .pageSheet
-        controller.popoverPresentationController?.sourceView = self.navigationController.view
-        self.navigationController.present(controller, animated: true, completion: nil)
+        controller.popoverPresentationController?.sourceView = navigationController.view
+        navigationController.present(controller, animated: true, completion: nil)
     }
 
     func showLogs(string: BehaviorRelay<String>) {
         let controller = LogsViewController(logs: self.controllers.debugLogging.logString, lines: self.controllers.debugLogging.logLines)
-        self.navigationController.pushViewController(controller, animated: true)
+        self.navigationController?.pushViewController(controller, animated: true)
     }
 }
 


### PR DESCRIPTION
I couldn't reproduce the crash myself, but obviously it happened that `navigationController` was deinitialized while `PDFCoordinator` instance was presented and when going back from PDF to previous screen the app would crash. Making `navigationController` in `Coordinator` protocol weak will solve this and potentially there may be user reports of UI issues which will point us in right direction.