### PR TITLE
Show proper hierarchy when there is restored state

### DIFF
--- a/ZShare/ViewModels/ExtensionViewModel.swift
+++ b/ZShare/ViewModels/ExtensionViewModel.swift
@@ -1457,7 +1457,13 @@ final class ExtensionViewModel {
 
                 recents = recentCollections
                 library = _library
-                collection = _collection
+                switch self.state.selectedCollectionId {
+                case .collection:
+                    collection = _collection
+                    
+                default:
+                    break
+                }
             })
 
             guard let library = library else { return }

--- a/Zotero/Controllers/Database/Requests/ReadCollectionAndLibraryDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/ReadCollectionAndLibraryDbRequest.swift
@@ -26,7 +26,11 @@ struct ReadCollectionAndLibraryDbRequest: DbResponseRequest {
             let rCollection = try ReadCollectionDbRequest(libraryId: self.libraryId, key: key).process(in: database)
             let collection = Collection(object: rCollection, itemCount: 0)
             return (collection, library)
-            
+
+        case .custom(let type):
+            let collection = Collection(custom: type)
+            return (collection, library)
+
         default:
             return (nil, library)
         }

--- a/Zotero/Extensions/NSUserActivity+Activities.swift
+++ b/Zotero/Extensions/NSUserActivity+Activities.swift
@@ -11,6 +11,7 @@ import Foundation
 struct RestoredStateData {
     let key: String
     let libraryId: LibraryIdentifier
+    let collectionId: CollectionIdentifier?
 }
 
 extension NSUserActivity {
@@ -21,9 +22,13 @@ extension NSUserActivity {
         return NSUserActivity(activityType: self.mainId)
     }
 
-    static func pdfActivity(for key: String, libraryId: LibraryIdentifier) -> NSUserActivity {
+    static func pdfActivity(for key: String, libraryId: LibraryIdentifier, collectionId: CollectionIdentifier) -> NSUserActivity {
         let activity = NSUserActivity(activityType: self.pdfId)
-        activity.addUserInfoEntries(from: ["key": key, "libraryId": self.libraryIdToString(libraryId)])
+        var pdfUserInfo: [AnyHashable: Any] = ["key": key, "libraryId": libraryIdToString(libraryId)]
+        if let collectionIdData = try? JSONEncoder().encode(collectionId) {
+            pdfUserInfo["collectionId"] = collectionIdData
+        }
+        activity.addUserInfoEntries(from: pdfUserInfo)
         return activity
     }
 
@@ -54,7 +59,15 @@ extension NSUserActivity {
 
     var restoredStateData: RestoredStateData? {
         guard self.activityType == NSUserActivity.pdfId,
-              let key = self.userInfo?["key"] as? String, let libraryString = self.userInfo?["libraryId"] as? String, let libraryId = self.stringToLibraryId(libraryString) else { return nil }
-        return RestoredStateData(key: key, libraryId: libraryId)
+              let userInfo,
+              let key = userInfo["key"] as? String,
+              let libraryString = userInfo["libraryId"] as? String,
+              let libraryId = stringToLibraryId(libraryString)
+        else { return nil }
+        var collectionId: CollectionIdentifier?
+        if let collectionIdData = userInfo["collectionId"] as? Data {
+            collectionId = try? JSONDecoder().decode(CollectionIdentifier.self, from: collectionIdData)
+        }
+        return RestoredStateData(key: key, libraryId: libraryId, collectionId: collectionId)
     }
 }

--- a/Zotero/Extensions/NSUserActivity+Activities.swift
+++ b/Zotero/Extensions/NSUserActivity+Activities.swift
@@ -11,7 +11,7 @@ import Foundation
 struct RestoredStateData {
     let key: String
     let libraryId: LibraryIdentifier
-    let collectionId: CollectionIdentifier?
+    let collectionId: CollectionIdentifier
 }
 
 extension NSUserActivity {
@@ -64,9 +64,12 @@ extension NSUserActivity {
               let libraryString = userInfo["libraryId"] as? String,
               let libraryId = stringToLibraryId(libraryString)
         else { return nil }
-        var collectionId: CollectionIdentifier?
-        if let collectionIdData = userInfo["collectionId"] as? Data {
-            collectionId = try? JSONDecoder().decode(CollectionIdentifier.self, from: collectionIdData)
+        var collectionId: CollectionIdentifier
+        if let collectionIdData = userInfo["collectionId"] as? Data,
+           let decodedCollectionId = try? JSONDecoder().decode(CollectionIdentifier.self, from: collectionIdData) {
+            collectionId = decodedCollectionId
+        } else {
+            collectionId = Defaults.shared.selectedCollectionId
         }
         return RestoredStateData(key: key, libraryId: libraryId, collectionId: collectionId)
     }

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -239,6 +239,9 @@ final class AppCoordinator: NSObject {
             mainController.showItems(for: collection, in: library, isInitial: false)
         } else {
             DDLogInfo("AppCoordinator: show restored state - \(data.key); \(data.libraryId); \(url.relativePath)")
+            // Collection is missing, show all items instead
+            let collection = Collection(custom: .all)
+            mainController.showItems(for: collection, in: library, isInitial: true)
         }
             
         mainController.getDetailCoordinator { [weak self] coordinator in

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -238,7 +238,7 @@ final class AppCoordinator: NSObject {
             DDLogInfo("AppCoordinator: show restored state - \(data.key); \(data.libraryId); \(data.collectionId); \(url.relativePath)")
             mainController.showItems(for: collection, in: library, isInitial: false)
         } else {
-            DDLogInfo("AppCoordinator: show restored state - \(data.key); \(data.libraryId); \(url.relativePath)")
+            DDLogWarn("AppCoordinator: show restored state using all items collection - \(data.key); \(data.libraryId); \(url.relativePath)")
             // Collection is missing, show all items instead
             let collection = Collection(custom: .all)
             mainController.showItems(for: collection, in: library, isInitial: true)

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -127,9 +127,7 @@ final class AppCoordinator: NSObject {
         // If scene had state stored, check if defaults need to be updated first
         DDLogInfo("AppCoordinator: Preprocessing restored state - \(data)")
         Defaults.shared.selectedLibrary = data.libraryId
-        if let collectionId = data.collectionId {
-            Defaults.shared.selectedCollectionId = collectionId
-        }
+        Defaults.shared.selectedCollectionId = data.collectionId
     }
     
     private func process(connectionOptions: UIScene.ConnectionOptions, session: UISceneSession) {
@@ -230,8 +228,8 @@ final class AppCoordinator: NSObject {
     private func showRestoredState(for data: RestoredStateData) {
         guard let mainController = self.window?.rootViewController as? MainViewController,
               let (url, library, collection) = self.loadRestoredStateData(forKey: data.key, libraryId: data.libraryId, collectionId: data.collectionId) else { return }
-        if let collectionId = data.collectionId, let collection {
-            DDLogInfo("AppCoordinator: show restored state - \(data.key); \(data.libraryId); \(collectionId); \(url.relativePath)")
+        if let collection {
+            DDLogInfo("AppCoordinator: show restored state - \(data.key); \(data.libraryId); \(data.collectionId); \(url.relativePath)")
             mainController.showItems(for: collection, in: library, isInitial: false)
         } else {
             DDLogInfo("AppCoordinator: show restored state - \(data.key); \(data.libraryId); \(url.relativePath)")
@@ -256,7 +254,7 @@ final class AppCoordinator: NSObject {
         return navigationController
     }
 
-    private func loadRestoredStateData(forKey key: String, libraryId: LibraryIdentifier, collectionId: CollectionIdentifier?) -> (URL, Library, Collection?)? {
+    private func loadRestoredStateData(forKey key: String, libraryId: LibraryIdentifier, collectionId: CollectionIdentifier) -> (URL, Library, Collection?)? {
         guard let dbStorage = self.controllers.userControllers?.dbStorage else { return nil }
 
         var url: URL?
@@ -275,13 +273,9 @@ final class AppCoordinator: NSObject {
                     case .local, .localAndChangedRemotely:
                         let file = Files.attachmentFile(in: libraryId, key: key, filename: filename, contentType: contentType)
                         url = file.createUrl()
-                        if let collectionId {
-                            let (_collection, _library) = try coordinator.perform(request: ReadCollectionAndLibraryDbRequest(collectionId: collectionId, libraryId: libraryId))
-                            collection = _collection
-                            library = _library
-                        } else {
-                            library = try coordinator.perform(request: ReadLibraryDbRequest(libraryId: libraryId))
-                        }
+                        let (_collection, _library) = try coordinator.perform(request: ReadCollectionAndLibraryDbRequest(collectionId: collectionId, libraryId: libraryId))
+                        collection = _collection
+                        library = _library
 
                     case .remote, .remoteMissing: break
                     }

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -236,12 +236,12 @@ final class AppCoordinator: NSObject {
               let (url, library, collection) = self.loadRestoredStateData(forKey: data.key, libraryId: data.libraryId, collectionId: data.collectionId) else { return }
         if let collection {
             DDLogInfo("AppCoordinator: show restored state - \(data.key); \(data.libraryId); \(data.collectionId); \(url.relativePath)")
-            mainController.showItems(for: collection, in: library, isInitial: false)
+            mainController.showItems(for: collection, in: library, saveCollectionToDefaults: true)
         } else {
             DDLogWarn("AppCoordinator: show restored state using all items collection - \(data.key); \(data.libraryId); \(url.relativePath)")
             // Collection is missing, show all items instead
             let collection = Collection(custom: .all)
-            mainController.showItems(for: collection, in: library, isInitial: true)
+            mainController.showItems(for: collection, in: library, saveCollectionToDefaults: false)
         }
             
         mainController.getDetailCoordinator { [weak self] coordinator in

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -206,7 +206,7 @@ class PDFReaderViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.set(userActivity: .pdfActivity(for: self.viewModel.state.key, libraryId: self.viewModel.state.library.identifier))
+        self.set(userActivity: .pdfActivity(for: self.viewModel.state.key, libraryId: self.viewModel.state.library.identifier, collectionId: Defaults.shared.selectedCollectionId))
 
         self.view.backgroundColor = .systemGray6
         self.setupViews()

--- a/Zotero/Scenes/Main/Views/MainViewController.swift
+++ b/Zotero/Scenes/Main/Views/MainViewController.swift
@@ -15,7 +15,7 @@ import CocoaLumberjackSwift
 import RxSwift
 
 protocol MainCoordinatorDelegate: SplitControllerDelegate {
-    func showItems(for collection: Collection, in library: Library, isInitial: Bool)
+    func showItems(for collection: Collection, in library: Library, saveCollectionToDefaults: Bool)
 }
 
 protocol SplitControllerDelegate: AnyObject {
@@ -132,8 +132,8 @@ extension MainViewController: UISplitViewControllerDelegate {
 }
 
 extension MainViewController: MainCoordinatorDelegate {
-    func showItems(for collection: Collection, in library: Library, isInitial: Bool) {
-        if !isInitial {
+    func showItems(for collection: Collection, in library: Library, saveCollectionToDefaults: Bool) {
+        if saveCollectionToDefaults {
             Defaults.shared.selectedCollectionId = collection.identifier
         }
         guard !self.isSplit || self.detailCoordinator?.library != library || self.detailCoordinator?.collection.identifier != collection.identifier else { return }

--- a/Zotero/Scenes/Main/Views/MainViewController.swift
+++ b/Zotero/Scenes/Main/Views/MainViewController.swift
@@ -27,14 +27,8 @@ protocol MainCoordinatorSyncToolbarDelegate: AnyObject {
 }
 
 final class MainViewController: UISplitViewController {
-    private struct InitialLoadData {
-        let collection: Collection
-        let library: Library
-    }
-
     // Constants
     private let controllers: Controllers
-    private let defaultCollection: Collection
     private let disposeBag: DisposeBag
     // Variables
     private var didAppear: Bool = false
@@ -54,7 +48,6 @@ final class MainViewController: UISplitViewController {
 
     init(controllers: Controllers) {
         self.controllers = controllers
-        self.defaultCollection = Collection(custom: .all)
         self.disposeBag = DisposeBag()
 
         super.init(nibName: nil, bundle: nil)
@@ -107,44 +100,6 @@ final class MainViewController: UISplitViewController {
         self.detailCoordinator = coordinator
 
         self.showDetailViewController(navigationController, sender: nil)
-    }
-
-    private func loadInitialDetailData(collectionId: CollectionIdentifier, libraryId: LibraryIdentifier) -> InitialLoadData? {
-        guard let dbStorage = self.controllers.userControllers?.dbStorage else { return nil }
-
-        DDLogInfo("MainViewController: load initial detail data collectionId=\(collectionId); libraryId=\(libraryId)")
-
-        var collection: Collection?
-        var library: Library?
-
-        do {
-            try dbStorage.perform(on: .main, with: { coordinator in
-                switch collectionId {
-                case .collection(let key):
-                    let rCollection = try coordinator.perform(request: ReadCollectionDbRequest(libraryId: libraryId, key: key))
-                    collection = Collection(object: rCollection, itemCount: 0)
-
-                case .search(let key):
-                    let rSearch = try coordinator.perform(request: ReadSearchDbRequest(libraryId: libraryId, key: key))
-                    collection = Collection(object: rSearch)
-
-                case .custom(let type):
-                    collection = Collection(custom: type)
-                }
-                library = try coordinator.perform(request: ReadLibraryDbRequest(libraryId: libraryId))
-            })
-        } catch let error {
-            DDLogError("MainViewController: can't load initial data - \(error)")
-            return nil
-        }
-
-        if let collection = collection, let library = library {
-            return InitialLoadData(collection: collection, library: library)
-        }
-
-        DDLogWarn("MainViewController: returning default library and collection")
-        return InitialLoadData(collection: Collection(custom: .all),
-                               library: Library(identifier: .custom(.myLibrary), name: "My Library", metadataEditable: true, filesEditable: true))
     }
 
     // MARK: - Setups

--- a/Zotero/Scenes/Main/Views/MainViewController.swift
+++ b/Zotero/Scenes/Main/Views/MainViewController.swift
@@ -178,6 +178,9 @@ extension MainViewController: UISplitViewControllerDelegate {
 
 extension MainViewController: MainCoordinatorDelegate {
     func showItems(for collection: Collection, in library: Library, isInitial: Bool) {
+        if !isInitial {
+            Defaults.shared.selectedCollectionId = collection.identifier
+        }
         guard !self.isSplit || self.detailCoordinator?.library != library || self.detailCoordinator?.collection.identifier != collection.identifier else { return }
         self.showItems(for: collection, in: library, searchItemKeys: nil)
     }

--- a/Zotero/Scenes/Master/Collections/Views/CollectionsViewController.swift
+++ b/Zotero/Scenes/Master/Collections/Views/CollectionsViewController.swift
@@ -44,7 +44,7 @@ final class CollectionsViewController: UICollectionViewController {
 
         if self.coordinatorDelegate?.isSplit == true {
             if let collection = self.viewModel.state.collectionTree.collection(for: self.viewModel.state.selectedCollectionId) {
-                self.coordinatorDelegate?.showItems(for: collection, in: self.viewModel.state.library, isInitial: true)
+                self.coordinatorDelegate?.showItems(for: collection, in: self.viewModel.state.library, saveCollectionToDefaults: false)
             } else {
                 self.viewModel.process(action: .select(.custom(.all)))
             }
@@ -86,7 +86,7 @@ final class CollectionsViewController: UICollectionViewController {
         }
 
         if state.changes.contains(.selection), let collection = state.collectionTree.collection(for: state.selectedCollectionId) {
-            self.coordinatorDelegate?.showItems(for: collection, in: state.library, isInitial: false)
+            self.coordinatorDelegate?.showItems(for: collection, in: state.library, saveCollectionToDefaults: true)
 
             if !requiresUpdate {
                 self.selectIfNeeded(collectionId: state.selectedCollectionId, tree: state.collectionTree, scrollToPosition: false)

--- a/Zotero/Scenes/Master/MasterTopCoordinator.swift
+++ b/Zotero/Scenes/Master/MasterTopCoordinator.swift
@@ -195,9 +195,9 @@ extension MasterTopCoordinator: MasterCollectionsCoordinatorDelegate {
         self.navigationController?.present(navigationController, animated: true, completion: nil)
     }
 
-    func showItems(for collection: Collection, in library: Library, isInitial: Bool) {
+    func showItems(for collection: Collection, in library: Library, saveCollectionToDefaults: Bool) {
         self.visibleLibraryId = library.identifier
-        self.mainCoordinatorDelegate.showItems(for: collection, in: library, isInitial: isInitial)
+        self.mainCoordinatorDelegate.showItems(for: collection, in: library, saveCollectionToDefaults: saveCollectionToDefaults)
     }
 
     var isSplit: Bool {

--- a/Zotero/Scenes/Master/MasterTopCoordinator.swift
+++ b/Zotero/Scenes/Master/MasterTopCoordinator.swift
@@ -197,9 +197,6 @@ extension MasterTopCoordinator: MasterCollectionsCoordinatorDelegate {
 
     func showItems(for collection: Collection, in library: Library, isInitial: Bool) {
         self.visibleLibraryId = library.identifier
-        if !isInitial {
-            Defaults.shared.selectedCollectionId = collection.identifier
-        }
         self.mainCoordinatorDelegate.showItems(for: collection, in: library, isInitial: isInitial)
     }
 


### PR DESCRIPTION
closes https://github.com/zotero/zotero-ios/issues/703

Restores proper hierarchy for both iPhone & iPad.
Updates Defaults.shared.selectedLibrary & Defaults.shared.selectedCollectionId accordingly.

Tested cases, for both devices:
* open pdf, close app, launch app with restored state, pdf is shown, and selected collection should be the same
* open pdf, close app, share with extension to a different collection, launch app with restored state, pdf is shown, and selected collection should be the same

Easiest way to be certain that you get restoration of your previous state, is to close normally the app, restart simulator/device, launch the app again.