### PR TITLE
Fix AnnotationCell setup crash

### DIFF
--- a/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationViewController.swift
@@ -101,7 +101,6 @@ final class AnnotationViewController: UIViewController {
             },
             isEditable: (editability == .editable),
             showsLock: (editability != .editable),
-            showDoneButton: false,
             accessibilityType: .view,
             displayName: state.displayName,
             username: state.username
@@ -191,7 +190,6 @@ final class AnnotationViewController: UIViewController {
             },
             isEditable: (editability == .editable),
             showsLock: (editability != .editable),
-            showDoneButton: false,
             accessibilityType: .view,
             displayName: self.viewModel.state.displayName,
             username: self.viewModel.state.username

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
@@ -113,7 +113,6 @@ final class AnnotationView: UIView {
             },
             isEditable: (editability != .notEditable && selected),
             showsLock: editability != .editable,
-            showDoneButton: self.layout.showDoneButton,
             accessibilityType: .cell,
             displayName: displayName,
             username: username

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHeader.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHeader.swift
@@ -82,7 +82,6 @@ final class AnnotationViewHeader: UIView {
         author: String,
         shareMenu: UIMenu?,
         showsMenuButton: Bool,
-        showsDoneButton: Bool,
         showsLock: Bool,
         accessibilityType: AnnotationView.AccessibilityType
     ) {
@@ -116,7 +115,6 @@ final class AnnotationViewHeader: UIView {
         shareMenuProvider: @escaping ((UIButton) -> UIMenu?),
         isEditable: Bool,
         showsLock: Bool,
-        showDoneButton: Bool,
         accessibilityType: AnnotationView.AccessibilityType,
         displayName: String,
         username: String
@@ -130,7 +128,6 @@ final class AnnotationViewHeader: UIView {
             author: author,
             shareMenu: shareMenuProvider(shareButton),
             showsMenuButton: isEditable,
-            showsDoneButton: showDoneButton,
             showsLock: showsLock,
             accessibilityType: accessibilityType
         )

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
@@ -302,23 +302,22 @@ final class AnnotationsViewController: UIViewController {
             preview = nil
         }
 
-        if let boundingBoxConverter = self.boundingBoxConverter, let pdfAnnotationsCoordinatorDelegate = coordinatorDelegate {
-            cell.setup(
-                with: annotation,
-                comment: comment,
-                preview: preview,
-                selected: selected,
-                availableWidth: PDFReaderLayout.sidebarWidth,
-                library: state.library,
-                isEditing: state.sidebarEditingEnabled,
-                currentUserId: self.viewModel.state.userId,
-                displayName: self.viewModel.state.displayName,
-                username: self.viewModel.state.username,
-                boundingBoxConverter: boundingBoxConverter,
-                pdfAnnotationsCoordinatorDelegate: pdfAnnotationsCoordinatorDelegate,
-                state: state
-            )
-        }
+        guard let boundingBoxConverter = self.boundingBoxConverter, let pdfAnnotationsCoordinatorDelegate = coordinatorDelegate else { return }
+        cell.setup(
+            with: annotation,
+            comment: comment,
+            preview: preview,
+            selected: selected,
+            availableWidth: PDFReaderLayout.sidebarWidth,
+            library: state.library,
+            isEditing: state.sidebarEditingEnabled,
+            currentUserId: self.viewModel.state.userId,
+            displayName: self.viewModel.state.displayName,
+            username: self.viewModel.state.username,
+            boundingBoxConverter: boundingBoxConverter,
+            pdfAnnotationsCoordinatorDelegate: pdfAnnotationsCoordinatorDelegate,
+            state: state
+        )
         let actionSubscription = cell.actionPublisher.subscribe(onNext: { [weak self] action in
             self?.perform(action: action, annotation: annotation)
         })


### PR DESCRIPTION
* Fixes `AnnotationCell` setup crash, reported via AppStoreConnect analytics. Happens in an edge case, where `AnnotationsViewController` finds `nil` values in `weak` properties.
* Remove unused parameters to simplify code.