### PR TITLE
Improve Xcode Cloud CI

### DIFF
--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -1197,6 +1197,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		611486502A9CD511002EEBEF /* ci_post_xcodebuild.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_xcodebuild.sh; sourceTree = "<group>"; };
 		614D65812A79C9AC007CF449 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		614D65842A7BCC22007CF449 /* ci_post_clone.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_clone.sh; sourceTree = "<group>"; };
 		61ABA7502A6137D1002A4219 /* ShareableImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableImage.swift; sourceTree = "<group>"; };
@@ -3966,8 +3967,9 @@
 		B3F6415E2A28B1EF00A78CB0 /* ci_scripts */ = {
 			isa = PBXGroup;
 			children = (
-				B3F6415F2A28B21E00A78CB0 /* ci_pre_xcodebuild.sh */,
 				614D65842A7BCC22007CF449 /* ci_post_clone.sh */,
+				B3F6415F2A28B21E00A78CB0 /* ci_pre_xcodebuild.sh */,
+				611486502A9CD511002EEBEF /* ci_post_xcodebuild.sh */,
 			);
 			path = ci_scripts;
 			sourceTree = "<group>";

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -60,13 +60,13 @@ bump_version() {
 
 # Bump version string according to trigger tag
 case "$CI_TAG" in
-    "trigger-build-bump-patch")
+    "trigger-build-bump-patch-"*)
         newVersionString=$(bump_version "$versionString" "patch")
         ;;
-    "trigger-build-bump-minor")
+    "trigger-build-bump-minor-"*)
         newVersionString=$(bump_version "$versionString" "minor")
         ;;
-    "trigger-build-bump-major")
+    "trigger-build-bump-major-"*)
         newVersionString=$(bump_version "$versionString" "major")
         ;;
     *)
@@ -74,10 +74,6 @@ case "$CI_TAG" in
         exit 1
         ;;
 esac
-
-# Cleanup trigger tag from origin
-echo "Removing trigger tag $CI_TAG from origin"
-git push $github_pat_repo_url --delete $CI_TAG
 
 # Update Info.plist files
 echo "Setting version to $newVersionString"

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #  ci_post_clone.sh
 #  Zotero
@@ -6,5 +6,29 @@
 #  Created by Miltiadis Vasilakis on 3/8/23.
 #  Copyright © 2023 Corporation for Digital Scholarship. All rights reserved.
 
+set -euo pipefail
+
 which swiftgen || HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install swiftgen
 which swiftlint || HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install swiftlint
+which openssl || HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install openssl
+which python3 || HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install python3
+which jq || HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install jq
+pip3 install joserfc
+
+# Generate JWT token
+jwt_token=$(./generate_jtw_token.py)
+
+# App Store Connect API request
+response=$(curl -s --header "Authorization: Bearer $jwt_token" "https://api.appstoreconnect.apple.com/v1/apps/$zotero_app_id/appStoreVersions?filter%5BappStoreState%5D=READY_FOR_SALE&fields%5BappStoreVersions%5D=versionString")
+versionString=$(echo "$response" | jq -r '.data[0].attributes.versionString')
+if [[ "$versionString" == "null" ]]; then
+    echo "Error: versionString is null"
+    exit 1
+fi
+
+# Increment version string
+newVersionString=$(awk -F. -v OFS=. '{$NF = $NF + 1; print}' <<< "$versionString")
+
+# Update Info.plist files
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $newVersionString" ../Zotero/Info.plist
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $newVersionString" ../ZShare/Info.plist

--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -12,7 +12,19 @@ if [[ -d "$CI_APP_STORE_SIGNED_APP_PATH" ]]; then
   TESTFLIGHT_DIR_PATH=../TestFlight
   mkdir -p $TESTFLIGHT_DIR_PATH
   cat <<EOF > "$TESTFLIGHT_DIR_PATH/WhatToTest.en-US.txt"
-branch: $CI_BRANCH
+(To unsubscribe from TestFlight emails, open the TestFlight app, tap on Zotero, and disable Email Notifications. We’re not able to unsubscribe you from TestFlight emails on our end.)
+
+You’re using the beta version of Zotero for iOS. You can reinstall the production version of the app from the App Store at any time.
+
+New in this version:
+
+- Miscellaneous bug fixes
+
+Please post to the Zotero Forums with all bug reports and feature requests.
+
+Thanks for helping to test Zotero for iOS.
+
+branch: ${CI_BRANCH:-$(git symbolic-ref --short HEAD)}
 commit: $(git log -n 1 --pretty=format:"%h")
 message: $(git log -n 1 --pretty=format:"%s")
 EOF

--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+#  ci_post_xcodebuild.sh
+#  Zotero
+#
+#  Created by Miltiadis Vasilakis on 28/8/23.
+#  Copyright © 2023 Corporation for Digital Scholarship. All rights reserved.
+
+set -eo pipefail
+
+if [[ -d "$CI_APP_STORE_SIGNED_APP_PATH" ]]; then
+  TESTFLIGHT_DIR_PATH=../TestFlight
+  mkdir -p $TESTFLIGHT_DIR_PATH
+  cat <<EOF > "$TESTFLIGHT_DIR_PATH/WhatToTest.en-US.txt"
+branch: $CI_BRANCH
+commit: $(git log -n 1 --pretty=format:"%h")
+message: $(git log -n 1 --pretty=format:"%s")
+EOF
+fi

--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -11,7 +11,9 @@ set -eo pipefail
 if [[ -d "$CI_APP_STORE_SIGNED_APP_PATH" ]]; then
   TESTFLIGHT_DIR_PATH=../TestFlight
   mkdir -p $TESTFLIGHT_DIR_PATH
-  cat <<EOF > "$TESTFLIGHT_DIR_PATH/WhatToTest.en-US.txt"
+  TESTFLIGHT_FILE_PATH=$TESTFLIGHT_DIR_PATH/WhatToTest.en-US.txt
+
+  cat <<EOF > "$TESTFLIGHT_FILE_PATH"
 (To unsubscribe from TestFlight emails, open the TestFlight app, tap on Zotero, and disable Email Notifications. We’re not able to unsubscribe you from TestFlight emails on our end.)
 
 You’re using the beta version of Zotero for iOS. You can reinstall the production version of the app from the App Store at any time.
@@ -24,10 +26,13 @@ Please post to the Zotero Forums with all bug reports and feature requests.
 
 Thanks for helping to test Zotero for iOS.
 
-branch: ${CI_BRANCH:-$(git symbolic-ref --short HEAD)}
-commit: $(git log -n 1 --pretty=format:"%h")
-message: $(git log -n 1 --pretty=format:"%s")
 EOF
+
+  if [[ -n "$CI_BRANCH" ]]; then
+    echo "branch: $CI_BRANCH" >> "$TESTFLIGHT_FILE_PATH"
+  fi
+  echo "commit: $(git log -n 1 --pretty=format:"%h")" >> "$TESTFLIGHT_FILE_PATH"
+  echo "message: $(git log -n 1 --pretty=format:"%s")" >> "$TESTFLIGHT_FILE_PATH"
 
   # Push version-build tag to origin
   VERSION=$(cat ../${CI_PRODUCT}.xcodeproj/project.pbxproj | grep -m1 'MARKETING_VERSION' | cut -d'=' -f2 | tr -d ';' | tr -d ' ')

--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -16,4 +16,10 @@ branch: $CI_BRANCH
 commit: $(git log -n 1 --pretty=format:"%h")
 message: $(git log -n 1 --pretty=format:"%s")
 EOF
+
+  # Push version-build tag to origin
+  VERSION=$(cat ../${CI_PRODUCT}.xcodeproj/project.pbxproj | grep -m1 'MARKETING_VERSION' | cut -d'=' -f2 | tr -d ';' | tr -d ' ')
+  TAG="${VERSION}-${CI_BUILD_NUMBER}"
+  git tag -a ${TAG} -m "$TAG"
+  git push $github_pat_repo_url $TAG
 fi

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-#  pre-xcodebuild.sh
+#  ci_pre_xcodebuild.sh
 #  Zotero
 #
 #  Created by Michal Rentka on 01.06.2023.

--- a/ci_scripts/generate_jtw_token.py
+++ b/ci_scripts/generate_jtw_token.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import os, sys, time
+from joserfc import jwt
+from joserfc.jwk import ECKey
+
+def generate_jwt_token(key_id, issuer_id, secret):
+	header = {"alg": "ES256", "kid": key_id, "typ": "JWT"}
+	issued_at_time = int(time.time())
+	expiration_time = issued_at_time + 2*600
+	payload = {"iss": issuer_id, "iat": issued_at_time, "exp": expiration_time, "aud": "appstoreconnect-v1"}
+	secret = secret[:27] + secret[27:-25].replace(" ", "\n") + secret[-25:]
+	key = ECKey.import_key(secret)
+	token = jwt.encode(header, payload, key)
+	return f"{token}"
+
+if __name__ == "__main__":
+    key_id = os.environ.get("app_store_connect_key_id")
+    issuer_id = os.environ.get("app_store_connect_issuer_id")
+    secret = os.environ.get("app_store_connect_api_key")
+    if key_id is None or issuer_id is None or secret is None:
+        print("Error: One or more arguments are missing", file=sys.stderr)
+        sys.exit(1)
+    elif secret[:27] != "-----BEGIN PRIVATE KEY-----" or secret[-25:] != "-----END PRIVATE KEY-----":    	
+        print("Error: secret not in PEM format", file=sys.stderr)
+        sys.exit(2)
+
+    result = generate_jwt_token(key_id, issuer_id, secret)
+    print(result)

--- a/scripts/push_build
+++ b/scripts/push_build
@@ -1,16 +1,38 @@
 #!/bin/bash
 set -euo pipefail
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+push_tag() {
+    TAG=$1
+    git tag $TAG -m "$TAG"
+    git push origin $TAG
+    git tag -d $TAG
+    CURRENT_BRANCH=$(git symbolic-ref --short HEAD)
+    COMMIT=$(git log -n 1 --pretty=format:"%h")
+    echo "Pushed tag '$TAG' to branch '$CURRENT_BRANCH' at commit '$COMMIT'."
+}
 
-LAST_TAG=`git describe --tags $(git rev-list --tags --max-count=1)`
-PARTS=(${LAST_TAG//-/ })
-NEW_VERSION=$(cat "$ROOT_DIR/Zotero.xcodeproj/project.pbxproj" | grep MARKETING_VERSION | head -n 1 | sed -E 's/.+([0-9]+\.[0-9]+\.[0-9]+).+/\1/')
-NEW_BUILD=$((${PARTS[1]}+1))
+DEFAULT_TAG="trigger-build-bump-patch"
 
-TAG="$NEW_VERSION-$NEW_BUILD"
+if [ $# -eq 0 ]; then
+    TAG=$DEFAULT_TAG
+else
+    case $1 in
+        "minor"|"major"|"patch")
+            TAG="trigger-build-bump-$1"
+            ;;
+        *)
+            echo "Invalid tag argument. Usage: $0 [patch (default)|minor|major]"
+            exit 1
+            ;;
+    esac
+fi
 
-echo "Pushing tag: $TAG"
-git tag -a ${TAG} -m "$TAG"
-git push origin ${TAG}
+if [ "$TAG" != "$DEFAULT_TAG" ]; then
+    read -p "Are you sure you want to push tag '$TAG'? (y/n): " choice
+    if [ "$choice" != "y" ]; then
+        echo "Operation canceled."
+        exit 0
+    fi
+fi
+
+push_tag $TAG

--- a/scripts/push_build
+++ b/scripts/push_build
@@ -3,6 +3,7 @@ set -euo pipefail
 
 push_tag() {
     TAG=$1
+    TAG=$1-$(date "+%Y%m%d%H%M%S")-$(echo $((RANDOM%10000)))
     git tag $TAG -m "$TAG"
     git push origin $TAG
     git tag -d $TAG


### PR DESCRIPTION
* Uses App Store Connect API to set version in post clone script. It uses current released version, and increments it according to version bump type.
* Tags the commit used for the build with an annotated version tag `<version>-<build>`. (Reminder, the build numbers themselves are handled by Xcode Cloud.
* Adds TestFlight message in post build script. Uses standard text, and then logs branch (if available), commit hash, and commit message.

A workflow using these script needs to have these environment variables set:
* app_store_connect_key_id
* zotero_app_id
* app_store_connect_api_key
* app_store_connect_issuer_id

`scripts/push_build` can be called to trigger an Xcode Cloud build by setting a trigger tag (not annotated, but we can change it), that decides the version bump type.
Those have the format `trigger-build-bump-[patch (default)|minor|major]-<timestamp>-<random value>`. 
For `minor` & `major` version bumps a confirmation prompt is shown.

The tag is set locally, pushed to origin, and then the local tag is deleted.
The remote tag will trigger the workflow. To avoid triggering the workflow by other tags, it's configured to do so only with those that start with `trigger-build`.
The remote tags are kept in the repo so that Xcode Cloud also keep the build page around. When not needed anymore, they can be delte manually or via a cleanup GitHub action, that e.g. deletes those trigger tags with timestamp older than 1 month.

In the post clone script:
-  New version is determined.

In the post build script:
- `<version>-<build>` annotated tag is pushed to origin. It uses an environment secret that contains a GitHub Personal Access Token (PAT) URL for the repo. That limits each workflow in one repo, e.g. main org repo, or a developer fork. The reason is that it doesn't seem possible to read the primary repo URL used by the workflow. (We can probably use `git remote` to get the value, but I'll have to check if it works as expected, e.g. if there are multiple remotes.) 
    PAT should be created by a user that has access to each repo, with the minimum allowed permissions (`public_repo`, `repo:status` should be enough), but even those might be a lot. There is a newer fine-grained GitHub tokens feature, that we can try to limit it only to specific repositories, but in this case the repo owner should be the one to create each respective token.