### PR TITLE
Fix size class transition issues

### DIFF
--- a/Zotero/Scenes/Detail/Annotation Filter Popover/Views/AnnotationsFilterViewController.swift
+++ b/Zotero/Scenes/Detail/Annotation Filter Popover/Views/AnnotationsFilterViewController.swift
@@ -71,10 +71,8 @@ class AnnotationsFilterViewController: UIViewController {
             self.setupClearButton(visible: (!state.colors.isEmpty || !state.tags.isEmpty))
         }
 
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            self.updateFilter()
-            self.updatePreferredContentSize()
-        }
+        self.updateFilter()
+        self.updatePreferredContentSize()
     }
 
     private func updatePreferredContentSize() {
@@ -104,9 +102,7 @@ class AnnotationsFilterViewController: UIViewController {
     }
 
     private func close() {
-        if UIDevice.current.userInterfaceIdiom == .phone {
-            self.updateFilter()
-        }
+        self.updateFilter()
         self.navigationController?.presentingViewController?.dismiss(animated: true)
     }
 
@@ -149,14 +145,12 @@ class AnnotationsFilterViewController: UIViewController {
     }
 
     private func setupNavigationBar() {
-        if UIDevice.current.userInterfaceIdiom == .phone {
-            let close = UIBarButtonItem(title: L10n.close, style: .plain, target: nil, action: nil)
-            close.rx.tap.subscribe(onNext: { [weak self] _ in
-                self?.close()
-            })
-            .disposed(by: self.disposeBag)
-            self.navigationItem.leftBarButtonItem = close
-        }
+        let close = UIBarButtonItem(title: L10n.close, style: .plain, target: nil, action: nil)
+        close.rx.tap.subscribe(onNext: { [weak self] _ in
+            self?.close()
+        })
+        .disposed(by: self.disposeBag)
+        self.navigationItem.leftBarButtonItem = close
 
         self.setupClearButton(visible: (!self.viewModel.state.colors.isEmpty || !self.viewModel.state.tags.isEmpty))
     }

--- a/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailCollectionViewHandler.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailCollectionViewHandler.swift
@@ -811,6 +811,7 @@ final class ItemDetailCollectionViewHandler: NSObject {
     private func setupCollectionView() {
         self.collectionView.collectionViewLayout = self.createCollectionViewLayout()
         self.collectionView.delegate = self
+        // keyboardDismissMode is device based, regardless of horizontal size class.
         self.collectionView.keyboardDismissMode = UIDevice.current.userInterfaceIdiom == .phone ? .interactive : .none
         self.collectionView.register(UINib(nibName: "ItemDetailSectionView", bundle: nil), forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "Header")
         self.collectionView.isEditing = true

--- a/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailTitleContentView.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailTitleContentView.swift
@@ -33,10 +33,8 @@ final class ItemDetailTitleContentView: UIView {
 
         let font = self.textView.font!
         self.topConstraint.constant = font.capHeight - font.ascender
-        switch UIDevice.current.userInterfaceIdiom {
-        case .pad:
+        if traitCollection.horizontalSizeClass == .regular && UIDevice.current.userInterfaceIdiom == .pad {
             self.bottomConstraint.constant = -font.descender
-        default: break
         }
     }
 

--- a/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailTitleContentView.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailTitleContentView.swift
@@ -33,9 +33,11 @@ final class ItemDetailTitleContentView: UIView {
 
         let font = self.textView.font!
         self.topConstraint.constant = font.capHeight - font.ascender
-        if traitCollection.horizontalSizeClass == .regular && UIDevice.current.userInterfaceIdiom == .pad {
-            self.bottomConstraint.constant = -font.descender
-        }
+        setupBottomConstraint()
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        setupBottomConstraint()
     }
 
     override func layoutSubviews() {
@@ -46,5 +48,14 @@ final class ItemDetailTitleContentView: UIView {
     func setup(with title: String, isEditing: Bool) {
         self.textView.isEditable = isEditing
         self.delegate.set(text: title, to: self.textView)
+    }
+    
+    private func setupBottomConstraint() {
+        if traitCollection.horizontalSizeClass == .regular && UIDevice.current.userInterfaceIdiom == .pad {
+            let font = textView.font!
+            bottomConstraint.constant = -font.descender
+        } else {
+            bottomConstraint.constant = 0
+        }
     }
 }

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
@@ -11,7 +11,7 @@ import UIKit
 import RealmSwift
 import RxSwift
 
-protocol ItemsToolbarControllerDelegate: AnyObject {
+protocol ItemsToolbarControllerDelegate: UITraitEnvironment {
     func process(action: ItemAction.Kind, button: UIBarButtonItem)
 }
 
@@ -78,19 +78,17 @@ final class ItemsToolbarController {
     }
 
     private func deviceSpecificFilters(from filters: [ItemsFilter]) -> [ItemsFilter] {
-        // There is different functionality on iPad and iPhone. iPhone shows tag filters in filter popup in items screen while iPad shows tag filters in master controller.
-        // So filter icon and description should always show up on iPhone, while it should not show up on iPad for tag filters.
-        // Therefore we ignore `.tag` filter on iPad and keep it on iPhone.
-        switch UIDevice.current.userInterfaceIdiom {
-        case .pad:
+        // There is different functionality based on horizontal size class. iPhone and compact iPad show tag filters in filter popup in items screen while iPad shows tag filters in master controller.
+        // So filter icon and description should always show up on iPhone and compact iPad, while it should not show up on regular iPad for tag filters.
+        // Therefore we ignore `.tag` filter on iPhone and compact iPad, and keep it on regular iPad.
+        if delegate?.traitCollection.horizontalSizeClass == .regular && UIDevice.current.userInterfaceIdiom == .pad {
             return filters.filter({
                 switch $0 {
                 case .tags: return false
                 case .downloadedFiles: return true
                 }
             })
-
-        default:
+        } else {
             return filters
         }
     }

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
@@ -63,7 +63,7 @@ final class ItemsToolbarController {
             self.viewController.toolbarItems = self.createEditingToolbarItems(from: self.editingActions)
             self.updateEditingToolbarItems(for: state.selectedItems, results: state.results)
         } else {
-            let filters = self.deviceSpecificFilters(from: state.filters)
+            let filters = self.sizeClassSpecificFilters(from: state.filters)
             self.viewController.toolbarItems = self.createNormalToolbarItems(for: filters)
             self.updateNormalToolbarItems(for: filters, downloadBatchData: state.downloadBatchData, results: state.results)
         }
@@ -73,24 +73,26 @@ final class ItemsToolbarController {
         if state.isEditing {
             self.updateEditingToolbarItems(for: state.selectedItems, results: state.results)
         } else {
-            self.updateNormalToolbarItems(for: self.deviceSpecificFilters(from: state.filters), downloadBatchData: state.downloadBatchData, results: state.results)
+            self.updateNormalToolbarItems(for: self.sizeClassSpecificFilters(from: state.filters), downloadBatchData: state.downloadBatchData, results: state.results)
         }
     }
 
-    private func deviceSpecificFilters(from filters: [ItemsFilter]) -> [ItemsFilter] {
+    private func sizeClassSpecificFilters(from filters: [ItemsFilter]) -> [ItemsFilter] {
         // There is different functionality based on horizontal size class. iPhone and compact iPad show tag filters in filter popup in items screen while iPad shows tag filters in master controller.
         // So filter icon and description should always show up on iPhone and compact iPad, while it should not show up on regular iPad for tag filters.
         // Therefore we ignore `.tag` filter on iPhone and compact iPad, and keep it on regular iPad.
-        if delegate?.traitCollection.horizontalSizeClass == .regular && UIDevice.current.userInterfaceIdiom == .pad {
-            return filters.filter({
-                switch $0 {
-                case .tags: return false
-                case .downloadedFiles: return true
-                }
-            })
-        } else {
+        if delegate?.traitCollection.horizontalSizeClass == .compact || UIDevice.current.userInterfaceIdiom == .phone {
             return filters
         }
+        return filters.filter({
+            switch $0 {
+            case .tags:
+                return false
+                
+            case .downloadedFiles:
+                return true
+            }
+        })
     }
 
     // MARK: - Helpers

--- a/Zotero/Scenes/Detail/Items/Views/ItemsFilterViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsFilterViewController.swift
@@ -56,6 +56,8 @@ class ItemsFilterViewController: UIViewController {
                           self.update(state: state)
                       })
                       .disposed(by: self.disposeBag)
+        
+        parent?.presentationController?.delegate = self
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -65,13 +67,6 @@ class ItemsFilterViewController: UIViewController {
         preferredSize.width = ItemsFilterViewController.width
         self.preferredContentSize = preferredSize
         self.navigationController?.preferredContentSize = preferredSize
-    }
-    
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        UIView.animate(withDuration: 0.1) {
-            self.showHideTagFilter()
-        }
     }
 
     // MARK: - Actions
@@ -129,6 +124,24 @@ class ItemsFilterViewController: UIViewController {
             tagFilterControllerContainer.isHidden = true
             separator.isHidden = true
             containerTop.constant = 15
+        }
+    }
+}
+
+extension ItemsFilterViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationController(
+        _ presentationController: UIPresentationController,
+        willPresentWithAdaptiveStyle style: UIModalPresentationStyle,
+        transitionCoordinator: UIViewControllerTransitionCoordinator?
+    ) {
+        if let transitionCoordinator {
+            transitionCoordinator.animate { _ in
+                self.showHideTagFilter()
+            }
+        } else {
+            UIView.animate(withDuration: 0.1) {
+                self.showHideTagFilter()
+            }
         }
     }
 }

--- a/Zotero/Scenes/Detail/Items/Views/ItemsFilterViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsFilterViewController.swift
@@ -61,12 +61,17 @@ class ItemsFilterViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        guard traitCollection.horizontalSizeClass == .regular && UIDevice.current.userInterfaceIdiom == .pad else { return }
-
         var preferredSize = self.container.systemLayoutSizeFitting(CGSize(width: ItemsFilterViewController.width, height: .greatestFiniteMagnitude))
         preferredSize.width = ItemsFilterViewController.width
         self.preferredContentSize = preferredSize
         self.navigationController?.preferredContentSize = preferredSize
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        UIView.animate(withDuration: 0.1) {
+            self.showHideTagFilter()
+        }
     }
 
     // MARK: - Actions
@@ -98,13 +103,6 @@ class ItemsFilterViewController: UIViewController {
         self.downloadsTitleLabel.text = L10n.Items.Filters.downloads
         self.downloadsSwitch.isOn = self.downloadsFilterEnabled
 
-        guard traitCollection.horizontalSizeClass == .compact || UIDevice.current.userInterfaceIdiom == .phone else {
-            self.tagFilterControllerContainer.isHidden = true
-            self.separator.isHidden = true
-            return
-        }
-
-        self.containerTop.constant = 4
         self.tagFilterController.willMove(toParent: self)
         self.tagFilterControllerContainer.addSubview(self.tagFilterController.view)
         self.addChild(self.tagFilterController)
@@ -117,5 +115,20 @@ class ItemsFilterViewController: UIViewController {
             self.tagFilterControllerContainer.bottomAnchor.constraint(equalTo: self.tagFilterController.view.bottomAnchor),
             self.separator.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale)
         ])
+        
+        showHideTagFilter()
+    }
+    
+    func showHideTagFilter() {
+        let isCollapsed = (presentingViewController as? MainViewController)?.isCollapsed
+        if UIDevice.current.userInterfaceIdiom == .phone || isCollapsed == true {
+            tagFilterControllerContainer.isHidden = false
+            separator.isHidden = false
+            containerTop.constant = 4
+        } else {
+            tagFilterControllerContainer.isHidden = true
+            separator.isHidden = true
+            containerTop.constant = 15
+        }
     }
 }

--- a/Zotero/Scenes/Detail/Items/Views/ItemsFilterViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsFilterViewController.swift
@@ -61,7 +61,7 @@ class ItemsFilterViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        guard UIDevice.current.userInterfaceIdiom == .pad else { return }
+        guard traitCollection.horizontalSizeClass == .regular && UIDevice.current.userInterfaceIdiom == .pad else { return }
 
         var preferredSize = self.container.systemLayoutSizeFitting(CGSize(width: ItemsFilterViewController.width, height: .greatestFiniteMagnitude))
         preferredSize.width = ItemsFilterViewController.width
@@ -98,7 +98,7 @@ class ItemsFilterViewController: UIViewController {
         self.downloadsTitleLabel.text = L10n.Items.Filters.downloads
         self.downloadsSwitch.isOn = self.downloadsFilterEnabled
 
-        guard UIDevice.current.userInterfaceIdiom == .phone else {
+        guard traitCollection.horizontalSizeClass == .compact || UIDevice.current.userInterfaceIdiom == .phone else {
             self.tagFilterControllerContainer.isHidden = true
             self.separator.isHidden = true
             return

--- a/Zotero/Scenes/Detail/Items/Views/ItemsTableViewHandler.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsTableViewHandler.swift
@@ -289,6 +289,7 @@ final class ItemsTableViewHandler: NSObject {
         self.tableView.rowHeight = UITableView.automaticDimension
         self.tableView.estimatedRowHeight = 60
         self.tableView.allowsMultipleSelectionDuringEditing = true
+        // keyboardDismissMode is device based, regardless of horizontal size class.
         self.tableView.keyboardDismissMode = UIDevice.current.userInterfaceIdiom == .phone ? .interactive : .none
         self.tableView.shouldGroupAccessibilityChildren = true
 

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -146,6 +146,7 @@ final class ItemsViewController: UIViewController {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
+        // TODO: Modify this to use trait transitions
         if UIDevice.current.userInterfaceIdiom == .pad {
             let position = self.setupSearchBar(for: size)
             if position == .navigationItem {
@@ -569,7 +570,8 @@ final class ItemsViewController: UIViewController {
     }
 
     private func setupTitle() {
-        guard UIDevice.current.userInterfaceIdiom == .phone else { return }
+        guard traitCollection.horizontalSizeClass == .compact || UIDevice.current.userInterfaceIdiom == .phone else { return }
+        // TODO: Check why it is ignored in compact iPad
         self.title = self.viewModel.state.collection.name
     }
 

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -146,7 +146,7 @@ final class ItemsViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         
-        // willTransition(to:with:) seems to not be not called for all transitions, so instead we traitCollectionDidChange(_:) is used w/ a short animation block.
+        // willTransition(to:with:) seems to not be not called for all transitions, so instead traitCollectionDidChange(_:) is used w/ a short animation block.
         guard UIDevice.current.userInterfaceIdiom == .pad, traitCollection.horizontalSizeClass != previousTraitCollection?.horizontalSizeClass else { return }
         UIView.animate(withDuration: 0.1) {
             self.toolbarController.reloadToolbarItems(for: self.viewModel.state)

--- a/Zotero/Scenes/Main/Views/MainViewController.swift
+++ b/Zotero/Scenes/Main/Views/MainViewController.swift
@@ -119,16 +119,6 @@ final class MainViewController: UISplitViewController {
 }
 
 extension MainViewController: UISplitViewControllerDelegate {
-    func splitViewController(_ splitViewController: UISplitViewController,
-                             collapseSecondary secondaryViewController: UIViewController,
-                             onto primaryViewController: UIViewController) -> Bool {
-        // The search bar is hidden when the app goes to background for unknown reason. This is a workaround to reset it if needed when
-        // the app returns to active state.
-        if let controller = (secondaryViewController as? UINavigationController)?.topViewController as? ItemsViewController {
-            controller.setSearchBarNeedsReset()
-        }
-        return false
-    }
 }
 
 extension MainViewController: MainCoordinatorDelegate {

--- a/Zotero/Scenes/Master/MasterContainerViewController.swift
+++ b/Zotero/Scenes/Master/MasterContainerViewController.swift
@@ -53,8 +53,11 @@ final class MasterContainerViewController: UINavigationController {
     private var initialBottomMinY: CGFloat?
     private var keyboardHeight: CGFloat = 0
 
-    init(bottomController: DraggableViewController) {
+    private weak var coordinatorDelegate: MasterContainerCoordinatorDelegate?
+    
+    init(bottomController: DraggableViewController, coordinatorDelegate: MasterContainerCoordinatorDelegate) {
         self.bottomController = bottomController
+        self.coordinatorDelegate = coordinatorDelegate
         self.bottomPosition = .default
         self.didAppear = false
         self.disposeBag = DisposeBag()
@@ -337,9 +340,8 @@ final class MasterContainerViewController: UINavigationController {
     override func separateSecondaryViewController(for splitViewController: UISplitViewController) -> UIViewController? {
         showBottomSheet(true)
         guard topViewController?.isKind(of: UINavigationController.self) == true else {
-            // TODO: Resolve nil detail view controller if needed.
             // When separating from an initially collapsed split view controller, the detail view controller is not yet set.
-            // Detect this here or in the split view controller delegate and set a default, e.g. all items
+            coordinatorDelegate?.showDefaultCollection()
             return nil
         }
         return super.separateSecondaryViewController(for: splitViewController)

--- a/Zotero/Scenes/Master/MasterContainerViewController.swift
+++ b/Zotero/Scenes/Master/MasterContainerViewController.swift
@@ -16,7 +16,7 @@ protocol DraggableViewController: UIViewController {
     func disablePanning()
 }
 
-final class MasterContainerViewController: UIViewController {
+final class MasterContainerViewController: UINavigationController {
     enum BottomPosition {
         case mostlyVisible
         case `default`
@@ -38,13 +38,12 @@ final class MasterContainerViewController: UIViewController {
     private static let bottomContainerTappableHeight: CGFloat = 35
     private static let bottomContainerDraggableHeight: CGFloat = 55
     private static let minVisibleBottomHeight: CGFloat = 200
-    let upperController: UIViewController
     let bottomController: DraggableViewController
     private let disposeBag: DisposeBag
 
-    private weak var bottomContainer: UIView!
-    private weak var bottomYConstraint: NSLayoutConstraint!
-    private weak var bottomContainerBottomConstraint: NSLayoutConstraint!
+    private var bottomContainer: UIView!
+    private var bottomYConstraint: NSLayoutConstraint!
+    private var bottomContainerBottomConstraint: NSLayoutConstraint!
     // Current position of bottom container
     private var bottomPosition: BottomPosition
     // Previous position of bottom container. Used to return to previous position when drag handle is tapped.
@@ -54,8 +53,7 @@ final class MasterContainerViewController: UIViewController {
     private var initialBottomMinY: CGFloat?
     private var keyboardHeight: CGFloat = 0
 
-    init(topController: UIViewController, bottomController: DraggableViewController) {
-        self.upperController = topController
+    init(bottomController: DraggableViewController) {
         self.bottomController = bottomController
         self.bottomPosition = .default
         self.didAppear = false
@@ -71,278 +69,318 @@ final class MasterContainerViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .clear
-        self.setupView()
-        self.setupKeyboardObserving()
+        view.backgroundColor = .clear
+        setupView()
+        setupKeyboardObserving()
+        showBottomSheet(false)
+        
+        func setupView() {
+            bottomController.view.translatesAutoresizingMaskIntoConstraints = false
+
+            let bottomPanRecognizer = UIPanGestureRecognizer()
+            bottomPanRecognizer.delegate = self
+            bottomPanRecognizer.rx.event
+                .subscribe(with: self, onNext: { _, recognizer in
+                    toolbarDidPan(recognizer: recognizer)
+                })
+                .disposed(by: disposeBag)
+
+            let tapRecognizer = UITapGestureRecognizer()
+            tapRecognizer.delegate = self
+            tapRecognizer.require(toFail: bottomPanRecognizer)
+            tapRecognizer.rx.event
+                .subscribe(with: self, onNext: { _, _ in
+                    toggleBottomPosition()
+                })
+                .disposed(by: disposeBag)
+
+            let bottomContainer = UIView()
+            bottomContainer.translatesAutoresizingMaskIntoConstraints = false
+            bottomContainer.layer.masksToBounds = true
+            bottomContainer.backgroundColor = .systemBackground
+            bottomContainer.addGestureRecognizer(bottomPanRecognizer)
+            bottomContainer.addGestureRecognizer(tapRecognizer)
+            view.addSubview(bottomContainer)
+            self.bottomContainer = bottomContainer
+
+            // Since the instance keeps a strong reference to the bottomController, its view is simply added as a subview.
+            // Adding bottomController as a child view controller, would mess up the navigation stack.
+            bottomContainer.addSubview(bottomController.view)
+
+            let handleBackground = UIView()
+            handleBackground.translatesAutoresizingMaskIntoConstraints = false
+            handleBackground.backgroundColor = .systemBackground
+            bottomContainer.addSubview(handleBackground)
+
+            let dragIcon = UIImageView(image: Asset.Images.dragHandle.image.withRenderingMode(.alwaysTemplate))
+            dragIcon.translatesAutoresizingMaskIntoConstraints = false
+            dragIcon.tintColor = .gray.withAlphaComponent(0.6)
+            bottomContainer.addSubview(dragIcon)
+
+            let separator = UIView()
+            separator.translatesAutoresizingMaskIntoConstraints = false
+            separator.backgroundColor = .opaqueSeparator
+            bottomContainer.addSubview(separator)
+
+            let bottomYConstraint = bottomContainer.topAnchor.constraint(equalTo: view.topAnchor)
+            let bottomControllerHeight = bottomController.view.heightAnchor.constraint(greaterThanOrEqualToConstant: 100)
+            bottomControllerHeight.priority = .required
+            let bottomControllerBottom = bottomController.view.bottomAnchor.constraint(equalTo: bottomContainer.bottomAnchor)
+            bottomControllerBottom.priority = UILayoutPriority(999)
+            let bottomContainerBottomConstraint = view.bottomAnchor.constraint(equalTo: bottomContainer.bottomAnchor)
+
+            // bottom container contains from top to bottom:
+            // --- handle background (drag icon) - bottom controller view
+            //  \- separator
+            NSLayoutConstraint.activate([
+                bottomYConstraint,
+                view.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor),
+                view.trailingAnchor.constraint(equalTo: bottomContainer.trailingAnchor),
+                bottomContainerBottomConstraint,
+                // handle background
+                handleBackground.topAnchor.constraint(equalTo: bottomContainer.topAnchor),
+                handleBackground.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor),
+                handleBackground.trailingAnchor.constraint(equalTo: bottomContainer.trailingAnchor),
+                handleBackground.heightAnchor.constraint(equalToConstant: Self.bottomControllerHandleHeight),
+                // drag icon
+                dragIcon.centerXAnchor.constraint(equalTo: bottomContainer.centerXAnchor),
+                dragIcon.topAnchor.constraint(equalTo: bottomContainer.topAnchor, constant: Self.dragHandleTopOffset),
+                // bottom controller view
+                bottomController.view.topAnchor.constraint(equalTo: bottomContainer.topAnchor, constant: Self.bottomControllerHandleHeight),
+                bottomController.view.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor),
+                bottomController.view.trailingAnchor.constraint(equalTo: bottomContainer.trailingAnchor),
+                bottomControllerHeight,
+                bottomControllerBottom,
+                // separator
+                separator.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale),
+                separator.topAnchor.constraint(equalTo: bottomContainer.topAnchor),
+                separator.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor),
+                separator.trailingAnchor.constraint(equalTo: bottomContainer.trailingAnchor)
+            ])
+
+            self.bottomYConstraint = bottomYConstraint
+            self.bottomContainerBottomConstraint = bottomContainerBottomConstraint
+            
+            func toolbarDidPan(recognizer: UIPanGestureRecognizer) {
+                switch recognizer.state {
+                case .began:
+                    initialBottomMinY = self.bottomContainer.frame.minY
+                    bottomController.disablePanning()
+
+                case .changed:
+                    guard let initialBottomMinY else { return }
+
+                    let translation = recognizer.translation(in: self.view)
+                    let availableHeight = view.frame.height
+                    var minY = initialBottomMinY + translation.y
+                    let mostlyVisibleTopOffset = BottomPosition.mostlyVisible.topOffset(availableHeight: availableHeight)
+                    let hiddenTopOffset = BottomPosition.hidden.topOffset(availableHeight: availableHeight)
+                    if minY < mostlyVisibleTopOffset {
+                        minY = mostlyVisibleTopOffset
+                    } else if minY > hiddenTopOffset {
+                        minY = hiddenTopOffset
+                    }
+
+                    self.bottomYConstraint.constant = minY
+                    view.layoutIfNeeded()
+
+                case .ended, .failed:
+                    let availableHeight = view.frame.height - keyboardHeight
+                    let dragVelocity = recognizer.velocity(in: view)
+                    let newPosition = position(fromYPos: self.bottomYConstraint.constant, containerHeight: availableHeight, velocity: dragVelocity)
+                    let velocity = velocity(from: dragVelocity, currentYPos: self.bottomYConstraint.constant, position: newPosition, availableHeight: availableHeight)
+
+                    set(bottomPosition: newPosition, containerHeight: availableHeight)
+
+                    switch newPosition {
+                    case .custom:
+                        view.layoutIfNeeded()
+
+                    case .mostlyVisible, .default, .hidden:
+                        UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: velocity, options: [.curveEaseOut], animations: {
+                            self.view.layoutIfNeeded()
+                        })
+                    }
+
+                    initialBottomMinY = nil
+                    bottomController.enablePanning()
+
+                case .cancelled, .possible:
+                    break
+                    
+                @unknown default:
+                    break
+                }
+                
+                /// Return new position for given center and velocity of handle. If velocity > 1500, it's considered a swipe and the handle
+                /// is moved in swipe direction. Otherwise the handle stays in place.
+                func position(fromYPos yPos: CGFloat, containerHeight: CGFloat, velocity: CGPoint) -> BottomPosition {
+                    if abs(velocity.y) > 1000 {
+                        // Swipe in direction of velocity
+                        if yPos > BottomPosition.default.topOffset(availableHeight: containerHeight) {
+                            return velocity.y > 0 ? .hidden : .default
+                        } else {
+                            return velocity.y > 0 ? .default : .mostlyVisible
+                        }
+                    }
+
+                    if yPos > (containerHeight - MasterContainerViewController.minVisibleBottomHeight) {
+                        return velocity.y > 0 ? .hidden : .default
+                    }
+
+                    return .custom(yPos)
+                }
+                
+                func velocity(from dragVelocity: CGPoint, currentYPos: CGFloat, position: BottomPosition, availableHeight: CGFloat) -> CGFloat {
+                    return abs(dragVelocity.y / (position.topOffset(availableHeight: availableHeight) - currentYPos))
+                }
+            }
+            
+            func toggleBottomPosition() {
+                switch bottomPosition {
+                case .hidden:
+                    set(bottomPosition: previousBottomPosition ?? .default)
+                    previousBottomPosition = nil
+
+                default:
+                    previousBottomPosition = bottomPosition
+
+                    if let controller = bottomController as? TagFilterViewController, controller.searchBar.isFirstResponder {
+                        // If tag picker search bar is first responder and tag picker was toggled to hide, we should deselect the search bar
+                        bottomPosition = .hidden
+                        // Don't need to `set(bottomPosition:containerHeight:)` manually here, resigning search bar will send keyboard notifications and the UI will update there.
+                        controller.searchBar.resignFirstResponder()
+                        return
+                    }
+
+                    set(bottomPosition: .hidden)
+                }
+
+                UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseOut, animations: {
+                    self.view.layoutIfNeeded()
+                })
+            }
+        }
+        
+        func setupKeyboardObserving() {
+            NotificationCenter.default
+                              .keyboardWillShow
+                              .observe(on: MainScheduler.instance)
+                              .subscribe(onNext: { notification in
+                                  if let data = notification.keyboardData {
+                                      setupKeyboard(with: data)
+                                  }
+                              })
+                              .disposed(by: disposeBag)
+
+            NotificationCenter.default
+                              .keyboardWillHide
+                              .observe(on: MainScheduler.instance)
+                              .subscribe(onNext: { notification in
+                                  if let data = notification.keyboardData {
+                                      setupKeyboard(with: data)
+                                  }
+                              })
+                              .disposed(by: disposeBag)
+            
+            func setupKeyboard(with keyboardData: KeyboardData) {
+                keyboardHeight = keyboardData.visibleHeight
+
+                updateBottomPosition()
+                bottomContainerBottomConstraint.constant = keyboardData.visibleHeight
+                UIView.animate(withDuration: 0.5, delay: 0, options: .curveEaseOut, animations: {
+                    self.view.layoutIfNeeded()
+                })
+            }
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        self.didAppear = true
+        guard !didAppear else { return }
+        didAppear = true
+        if let splitViewController {
+            // Split view controller collapsed status when the app launches is correct here, so it's used to show/hide bottom sheet for the first appearance.
+            // The app may be launched in collapsed mode, if it was in such mode the last time it was moved to background.
+            showBottomSheet(!splitViewController.isCollapsed)
+        }
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        guard !self.didAppear else { return }
-        let visibleHeight = self.view.frame.height - self.keyboardHeight
-        self.set(bottomPosition: self.bottomPosition, containerHeight: visibleHeight)
+        guard !didAppear else { return }
+        updateBottomPosition()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
-        let visibleHeight = size.height - self.keyboardHeight
-        self.set(bottomPosition: self.bottomPosition, containerHeight: visibleHeight)
+        let visibleHeight = size.height - keyboardHeight
+        set(bottomPosition: bottomPosition, containerHeight: visibleHeight)
 
         coordinator.animate(alongsideTransition: { _ in
             self.view.layoutIfNeeded()
         }, completion: nil)
     }
-
-    // MARK: - Actions
-
-    private func toggleBottomPosition() {
-        let visibleHeight = self.view.frame.height - self.keyboardHeight
-        switch self.bottomPosition {
-        case .hidden:
-            self.set(bottomPosition: (self.previousBottomPosition ?? .default), containerHeight: visibleHeight)
-            self.previousBottomPosition = nil
-
-        default:
-            self.previousBottomPosition = self.bottomPosition
-
-            if let controller = self.bottomController as? TagFilterViewController, controller.searchBar.isFirstResponder {
-                // If tag picker search bar is first responder and tag picker was toggled to hide, we should deselect the search bar
-                self.bottomPosition = .hidden
-                // Don't need to `set(bottomPosition:containerHeight:)` manually here, resigning search bar will send keyboard notifications and the UI will update there.
-                controller.searchBar.resignFirstResponder()
-                return
-            }
-
-            self.set(bottomPosition: .hidden, containerHeight: visibleHeight)
+        
+    override func collapseSecondaryViewController(_ secondaryViewController: UIViewController, for splitViewController: UISplitViewController) {
+        showBottomSheet(false)
+        super.collapseSecondaryViewController(secondaryViewController, for: splitViewController)
+        // The search bar is hidden when the app goes to background for unknown reason. This is a workaround to reset it if needed when
+        // the app returns to active state.
+        if let controller = (secondaryViewController as? UINavigationController)?.topViewController as? ItemsViewController {
+            controller.setSearchBarNeedsReset()
         }
-
-        UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseOut, animations: {
-            self.view.layoutIfNeeded()
-        })
     }
 
-    private func setupKeyboard(with keyboardData: KeyboardData) {
-        self.keyboardHeight = keyboardData.visibleHeight
-
-        let visibleHeight = self.view.frame.height - keyboardData.visibleHeight
-        self.set(bottomPosition: self.bottomPosition, containerHeight: visibleHeight)
-        self.bottomContainerBottomConstraint.constant = keyboardData.visibleHeight
-        UIView.animate(withDuration: 0.5, delay: 0, options: .curveEaseOut, animations: {
-            self.view.layoutIfNeeded()
-        })
+    override func separateSecondaryViewController(for splitViewController: UISplitViewController) -> UIViewController? {
+        showBottomSheet(true)
+        guard topViewController?.isKind(of: UINavigationController.self) == true else {
+            // TODO: Resolve nil detail view controller if needed.
+            // When separating from an initially collapsed split view controller, the detail view controller is not yet set.
+            // Detect this here or in the split view controller delegate and set a default, e.g. all items
+            return nil
+        }
+        return super.separateSecondaryViewController(for: splitViewController)
     }
 
     // MARK: - Bottom panning
+    private func showBottomSheet(_ show: Bool) {
+        if show {
+            bottomContainer.isHidden = false
+            additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0)
+        } else {
+            bottomContainer.isHidden = true
+            additionalSafeAreaInsets = .zero
+        }
+    }
 
     private func set(bottomPosition: BottomPosition, containerHeight: CGFloat) {
-        self.bottomYConstraint?.constant = bottomPosition.topOffset(availableHeight: containerHeight)
+        bottomYConstraint.constant = bottomPosition.topOffset(availableHeight: containerHeight)
         self.bottomPosition = bottomPosition
     }
-
-    private func toolbarDidPan(recognizer: UIPanGestureRecognizer) {
-        switch recognizer.state {
-        case .began:
-            self.initialBottomMinY = self.bottomContainer.frame.minY
-            self.bottomController.disablePanning()
-
-        case .changed:
-            guard let initialMinY = self.initialBottomMinY else { return }
-
-            let translation = recognizer.translation(in: self.view)
-            var minY = initialMinY + translation.y
-            if minY < BottomPosition.mostlyVisible.topOffset(availableHeight: self.view.frame.height) {
-                minY = BottomPosition.mostlyVisible.topOffset(availableHeight: self.view.frame.height)
-            } else if minY > BottomPosition.hidden.topOffset(availableHeight: self.view.frame.height) {
-                minY = BottomPosition.hidden.topOffset(availableHeight: self.view.frame.height)
-            }
-
-            self.bottomYConstraint.constant = minY
-            self.view.layoutIfNeeded()
-
-        case .ended, .failed:
-            let availableHeight = self.view.frame.height - self.keyboardHeight
-            let dragVelocity = recognizer.velocity(in: self.view)
-            let newPosition = self.position(fromYPos: self.bottomYConstraint.constant, containerHeight: availableHeight, velocity: dragVelocity)
-            let velocity = self.velocity(from: dragVelocity, currentYPos: self.bottomYConstraint.constant, position: newPosition, availableHeight: availableHeight)
-
-            self.set(bottomPosition: newPosition, containerHeight: availableHeight)
-
-            switch newPosition {
-            case .custom:
-                self.view.layoutIfNeeded()
-
-            case .mostlyVisible, .default, .hidden:
-                UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: velocity, options: [.curveEaseOut], animations: {
-                    self.view.layoutIfNeeded()
-                })
-            }
-
-            self.initialBottomMinY = nil
-            self.bottomController.enablePanning()
-
-        case .cancelled, .possible: break
-        @unknown default: break
-        }
+    
+    private func set(bottomPosition: BottomPosition) {
+        let availableHeight = view.frame.height - keyboardHeight
+        set(bottomPosition: bottomPosition, containerHeight: availableHeight)
     }
-
-    /// Return new position for given center and velocity of handle. If velocity > 1500, it's considered a swipe and the handle
-    /// is moved in swipe direction. Otherwise the handle stays in place.
-    private func position(fromYPos yPos: CGFloat, containerHeight: CGFloat, velocity: CGPoint) -> BottomPosition {
-        if abs(velocity.y) > 1000 {
-            // Swipe in direction of velocity
-            if yPos > BottomPosition.default.topOffset(availableHeight: containerHeight) {
-                return velocity.y > 0 ? .hidden : .default
-            } else {
-                return velocity.y > 0 ? .default : .mostlyVisible
-            }
-        }
-
-        if yPos > (containerHeight - MasterContainerViewController.minVisibleBottomHeight) {
-            return velocity.y > 0 ? .hidden : .default
-        }
-
-        return .custom(yPos)
-    }
-
-    private func velocity(from dragVelocity: CGPoint, currentYPos: CGFloat, position: BottomPosition, availableHeight: CGFloat) -> CGFloat {
-        return abs(dragVelocity.y / (position.topOffset(availableHeight: availableHeight) - currentYPos))
-    }
-
-    // MARK: - Setups
-
-    private func setupView() {
-        self.upperController.view.translatesAutoresizingMaskIntoConstraints = false
-        self.bottomController.view.translatesAutoresizingMaskIntoConstraints = false
-
-        self.upperController.willMove(toParent: self)
-        self.view.addSubview(self.upperController.view)
-        self.addChild(self.upperController)
-        self.upperController.didMove(toParent: self)
-        self.upperController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0)
-
-        let bottomPanRecognizer = UIPanGestureRecognizer()
-        bottomPanRecognizer.delegate = self
-        bottomPanRecognizer.rx.event
-                     .subscribe(with: self, onNext: { `self`, recognizer in
-                         self.toolbarDidPan(recognizer: recognizer)
-                     })
-                    .disposed(by: self.disposeBag)
-
-        let tapRecognizer = UITapGestureRecognizer()
-        tapRecognizer.delegate = self
-        tapRecognizer.require(toFail: bottomPanRecognizer)
-        tapRecognizer.rx.event
-                     .subscribe(with: self, onNext: { `self`, _ in
-                         self.toggleBottomPosition()
-                     })
-                    .disposed(by: self.disposeBag)
-
-        let bottomContainer = UIView()
-        bottomContainer.translatesAutoresizingMaskIntoConstraints = false
-        bottomContainer.layer.masksToBounds = true
-        bottomContainer.backgroundColor = .systemBackground
-        bottomContainer.addGestureRecognizer(bottomPanRecognizer)
-        bottomContainer.addGestureRecognizer(tapRecognizer)
-        self.view.addSubview(bottomContainer)
-        self.bottomContainer = bottomContainer
-
-        self.bottomController.willMove(toParent: self)
-        bottomContainer.addSubview(self.bottomController.view)
-        self.addChild(self.bottomController)
-        self.bottomController.didMove(toParent: self)
-
-        let handleBackground = UIView()
-        handleBackground.translatesAutoresizingMaskIntoConstraints = false
-        handleBackground.backgroundColor = .systemBackground
-        bottomContainer.addSubview(handleBackground)
-
-        let dragIcon = UIImageView(image: Asset.Images.dragHandle.image.withRenderingMode(.alwaysTemplate))
-        dragIcon.translatesAutoresizingMaskIntoConstraints = false
-        dragIcon.tintColor = .gray.withAlphaComponent(0.6)
-        bottomContainer.addSubview(dragIcon)
-
-        let separator = UIView()
-        separator.translatesAutoresizingMaskIntoConstraints = false
-        separator.backgroundColor = .opaqueSeparator
-        bottomContainer.addSubview(separator)
-
-        let bottomYConstraint = bottomContainer.topAnchor.constraint(equalTo: self.view.topAnchor)
-        let bottomControllerHeight = self.bottomController.view.heightAnchor.constraint(greaterThanOrEqualToConstant: 100)
-        bottomControllerHeight.priority = .required
-        let bottomControllerBottom = self.bottomController.view.bottomAnchor.constraint(equalTo: bottomContainer.bottomAnchor)
-        bottomControllerBottom.priority = UILayoutPriority(999)
-        let bottomContainerBottomConstraint = self.view.bottomAnchor.constraint(equalTo: bottomContainer.bottomAnchor)
-
-        NSLayoutConstraint.activate([
-            self.view.topAnchor.constraint(equalTo: self.upperController.view.topAnchor),
-            self.view.leadingAnchor.constraint(equalTo: self.upperController.view.leadingAnchor),
-            self.view.trailingAnchor.constraint(equalTo: self.upperController.view.trailingAnchor),
-            bottomContainer.topAnchor.constraint(equalTo: self.upperController.view.bottomAnchor, constant: -16),
-            bottomYConstraint,
-            self.view.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor),
-            self.view.trailingAnchor.constraint(equalTo: bottomContainer.trailingAnchor),
-            bottomContainerBottomConstraint,
-            self.bottomController.view.topAnchor.constraint(equalTo: bottomContainer.topAnchor, constant: MasterContainerViewController.bottomControllerHandleHeight),
-            self.bottomController.view.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor),
-            self.bottomController.view.trailingAnchor.constraint(equalTo: bottomContainer.trailingAnchor),
-            bottomControllerHeight,
-            bottomControllerBottom,
-            handleBackground.topAnchor.constraint(equalTo: bottomContainer.topAnchor),
-            handleBackground.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor),
-            handleBackground.trailingAnchor.constraint(equalTo: bottomContainer.trailingAnchor),
-            handleBackground.heightAnchor.constraint(equalToConstant: MasterContainerViewController.bottomControllerHandleHeight),
-            dragIcon.centerXAnchor.constraint(equalTo: bottomContainer.centerXAnchor),
-            dragIcon.topAnchor.constraint(equalTo: bottomContainer.topAnchor, constant: MasterContainerViewController.dragHandleTopOffset),
-            separator.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale),
-            separator.topAnchor.constraint(equalTo: bottomContainer.topAnchor),
-            separator.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor),
-            separator.trailingAnchor.constraint(equalTo: bottomContainer.trailingAnchor)
-        ])
-
-        self.bottomYConstraint = bottomYConstraint
-        self.bottomContainerBottomConstraint = bottomContainerBottomConstraint
-    }
-
-    private func setupKeyboardObserving() {
-        NotificationCenter.default
-                          .keyboardWillShow
-                          .observe(on: MainScheduler.instance)
-                          .subscribe(onNext: { [weak self] notification in
-                              if let data = notification.keyboardData {
-                                  self?.setupKeyboard(with: data)
-                              }
-                          })
-                          .disposed(by: self.disposeBag)
-
-        NotificationCenter.default
-                          .keyboardWillHide
-                          .observe(on: MainScheduler.instance)
-                          .subscribe(onNext: { [weak self] notification in
-                              if let data = notification.keyboardData {
-                                  self?.setupKeyboard(with: data)
-                              }
-                          })
-                          .disposed(by: self.disposeBag)
+    
+    private func updateBottomPosition() {
+        set(bottomPosition: bottomPosition)
     }
 }
 
 extension MasterContainerViewController: UIGestureRecognizerDelegate {
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        let location = gestureRecognizer.location(in: self.bottomContainer)
+        let location = gestureRecognizer.location(in: bottomContainer)
 
         if gestureRecognizer is UITapGestureRecognizer {
-            return location.y <= MasterContainerViewController.bottomContainerTappableHeight
+            return location.y <= Self.bottomContainerTappableHeight
         }
 
         if gestureRecognizer is UIPanGestureRecognizer {
-            return location.y <= MasterContainerViewController.bottomContainerDraggableHeight
+            return location.y <= Self.bottomContainerDraggableHeight
         }
 
         return false

--- a/Zotero/Scenes/Master/MasterCoordinator.swift
+++ b/Zotero/Scenes/Master/MasterCoordinator.swift
@@ -10,6 +10,10 @@ import UIKit
 
 import CocoaLumberjackSwift
 
+protocol MasterContainerCoordinatorDelegate: AnyObject {
+    func showDefaultCollection()
+}
+
 final class MasterCoordinator {
     private let controllers: Controllers
     private unowned let mainController: MainViewController
@@ -42,9 +46,8 @@ final class MasterCoordinator {
         let handler = TagFilterActionHandler(dbStorage: dbStorage)
         let viewModel = ViewModel(initialState: state, handler: handler)
         let tagController = TagFilterViewController(viewModel: viewModel, dragDropController: self.controllers.dragDropController)
-        tagController.view.backgroundColor = .systemGreen
 
-        let containerController = MasterContainerViewController(bottomController: tagController)
+        let containerController = MasterContainerViewController(bottomController: tagController, coordinatorDelegate: self)
         let masterController = containerController
         let masterCoordinator = MasterTopCoordinator(navigationController: masterController, mainCoordinatorDelegate: self.mainController, controllers: self.controllers)
         masterCoordinator.start(animated: false)
@@ -60,5 +63,11 @@ final class MasterCoordinator {
         self.topCoordinator = masterCoordinator
 
         self.mainController.viewControllers = [masterController]
+    }
+}
+
+extension MasterCoordinator: MasterContainerCoordinatorDelegate {
+    func showDefaultCollection() {
+        topCoordinator?.showDefaultCollection()
     }
 }

--- a/Zotero/Scenes/Master/MasterCoordinator.swift
+++ b/Zotero/Scenes/Master/MasterCoordinator.swift
@@ -12,6 +12,7 @@ import CocoaLumberjackSwift
 
 protocol MasterContainerCoordinatorDelegate: AnyObject {
     func showDefaultCollection()
+    func bottomController() -> DraggableViewController?
 }
 
 final class MasterCoordinator {
@@ -30,38 +31,10 @@ final class MasterCoordinator {
     }
 
     func start() {
-        switch UIDevice.current.userInterfaceIdiom {
-        case .pad:
-            self.startPad()
-
-        default:
-            self.startPhone()
-        }
-    }
-
-    private func startPad() {
-        guard let dbStorage = self.controllers.userControllers?.dbStorage else { return }
-        
-        let state = TagFilterState(selectedTags: [], showAutomatic: Defaults.shared.tagPickerShowAutomaticTags, displayAll: Defaults.shared.tagPickerDisplayAllTags)
-        let handler = TagFilterActionHandler(dbStorage: dbStorage)
-        let viewModel = ViewModel(initialState: state, handler: handler)
-        let tagController = TagFilterViewController(viewModel: viewModel, dragDropController: self.controllers.dragDropController)
-
-        let containerController = MasterContainerViewController(bottomController: tagController, coordinatorDelegate: self)
-        let masterController = containerController
+        let masterController = MasterContainerViewController(coordinatorDelegate: self)
         let masterCoordinator = MasterTopCoordinator(navigationController: masterController, mainCoordinatorDelegate: self.mainController, controllers: self.controllers)
         masterCoordinator.start(animated: false)
         self.topCoordinator = masterCoordinator
-        self.mainController.viewControllers = [containerController]
-    }
-
-    // TODO: Merge startPad() and startPhone() methods to one adaptive workflow
-    private func startPhone() {
-        let masterController = UINavigationController()
-        let masterCoordinator = MasterTopCoordinator(navigationController: masterController, mainCoordinatorDelegate: self.mainController, controllers: self.controllers)
-        masterCoordinator.start(animated: false)
-        self.topCoordinator = masterCoordinator
-
         self.mainController.viewControllers = [masterController]
     }
 }
@@ -69,5 +42,14 @@ final class MasterCoordinator {
 extension MasterCoordinator: MasterContainerCoordinatorDelegate {
     func showDefaultCollection() {
         topCoordinator?.showDefaultCollection()
+    }
+    
+    func bottomController() -> DraggableViewController? {
+        guard UIDevice.current.userInterfaceIdiom == .pad else { return nil }
+        guard let dbStorage = controllers.userControllers?.dbStorage else { return nil }
+        let state = TagFilterState(selectedTags: [], showAutomatic: Defaults.shared.tagPickerShowAutomaticTags, displayAll: Defaults.shared.tagPickerDisplayAllTags)
+        let handler = TagFilterActionHandler(dbStorage: dbStorage)
+        let viewModel = ViewModel(initialState: state, handler: handler)
+        return TagFilterViewController(viewModel: viewModel, dragDropController: controllers.dragDropController)
     }
 }

--- a/Zotero/Scenes/Master/MasterCoordinator.swift
+++ b/Zotero/Scenes/Master/MasterCoordinator.swift
@@ -38,20 +38,21 @@ final class MasterCoordinator {
     private func startPad() {
         guard let dbStorage = self.controllers.userControllers?.dbStorage else { return }
         
-        let masterController = UINavigationController()
-        let masterCoordinator = MasterTopCoordinator(navigationController: masterController, mainCoordinatorDelegate: self.mainController, controllers: self.controllers)
-        masterCoordinator.start(animated: false)
-        self.topCoordinator = masterCoordinator
-
         let state = TagFilterState(selectedTags: [], showAutomatic: Defaults.shared.tagPickerShowAutomaticTags, displayAll: Defaults.shared.tagPickerDisplayAllTags)
         let handler = TagFilterActionHandler(dbStorage: dbStorage)
         let viewModel = ViewModel(initialState: state, handler: handler)
         let tagController = TagFilterViewController(viewModel: viewModel, dragDropController: self.controllers.dragDropController)
+        tagController.view.backgroundColor = .systemGreen
 
-        let containerController = MasterContainerViewController(topController: masterController, bottomController: tagController)
+        let containerController = MasterContainerViewController(bottomController: tagController)
+        let masterController = containerController
+        let masterCoordinator = MasterTopCoordinator(navigationController: masterController, mainCoordinatorDelegate: self.mainController, controllers: self.controllers)
+        masterCoordinator.start(animated: false)
+        self.topCoordinator = masterCoordinator
         self.mainController.viewControllers = [containerController]
     }
 
+    // TODO: Merge startPad() and startPhone() methods to one adaptive workflow
     private func startPhone() {
         let masterController = UINavigationController()
         let masterCoordinator = MasterTopCoordinator(navigationController: masterController, mainCoordinatorDelegate: self.mainController, controllers: self.controllers)

--- a/Zotero/Scenes/Master/MasterTopCoordinator.swift
+++ b/Zotero/Scenes/Master/MasterTopCoordinator.swift
@@ -27,6 +27,7 @@ protocol MasterCollectionsCoordinatorDelegate: MainCoordinatorDelegate {
     func showCiteExport(for itemIds: Set<String>, libraryId: LibraryIdentifier)
     func showCiteExportError()
     func showSearch(for state: CollectionsState, in controller: UIViewController, selectAction: @escaping (Collection) -> Void)
+    func showDefaultCollection()
 }
 
 final class MasterTopCoordinator: NSObject, Coordinator {
@@ -259,5 +260,11 @@ extension MasterTopCoordinator: MasterCollectionsCoordinatorDelegate {
         searchController.isModalInPresentation = true
 
         controller.present(searchController, animated: true, completion: nil)
+    }
+    
+    func showDefaultCollection() {
+        let library = Library(identifier: visibleLibraryId, name: "", metadataEditable: true, filesEditable: true)
+        let collection = Collection(custom: .all)
+        showItems(for: collection, in: library, saveCollectionToDefaults: false)
     }
 }

--- a/Zotero/Scenes/Master/TagFiltering/Views/TagFilterViewController.swift
+++ b/Zotero/Scenes/Master/TagFiltering/Views/TagFilterViewController.swift
@@ -66,11 +66,9 @@ class TagFilterViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        switch UIDevice.current.userInterfaceIdiom {
-        case .phone:
-        // Trigger initial load on phone.
-        self.delegate?.tagOptionsDidChange()
-        default: break
+        if traitCollection.horizontalSizeClass == .compact || UIDevice.current.userInterfaceIdiom == .phone {
+            // Trigger initial load on iPhone and compact iPad.
+            self.delegate?.tagOptionsDidChange()
         }
     }
 
@@ -82,7 +80,7 @@ class TagFilterViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        guard UIDevice.current.userInterfaceIdiom == .pad && !self.didAppear else { return }
+        guard traitCollection.horizontalSizeClass == .regular && UIDevice.current.userInterfaceIdiom == .pad && !self.didAppear else { return }
 
         let height = TagFilterViewController.searchBarHeight + TagFilterViewController.searchBarTopOffset
         self.collectionView.setContentOffset(CGPoint(x: 0, y: height), animated: false)
@@ -168,7 +166,7 @@ class TagFilterViewController: UIViewController {
             self.viewModel.process(action: .setShowAutomatic(!self.viewModel.state.showAutomatic))
         })
         var options: [UIAction] = [showAutomatic]
-        if UIDevice.current.userInterfaceIdiom != .phone {
+        if traitCollection.horizontalSizeClass == .regular && UIDevice.current.userInterfaceIdiom == .pad {
             let displayAll = UIAction(title: L10n.TagPicker.showAll, state: (state.displayAll ? .on : .off), handler: { [weak self] _ in
                 guard let self = self else { return }
                 self.viewModel.process(action: .setDisplayAll(!self.viewModel.state.displayAll))
@@ -228,13 +226,10 @@ class TagFilterViewController: UIViewController {
         self.collectionView = collectionView
         self.view.insertSubview(collectionView, belowSubview: searchContainer)
 
-        switch UIDevice.current.userInterfaceIdiom {
-        case .phone:
-            collectionView.keyboardDismissMode = .onDrag
-
-        case .pad:
+        if traitCollection.horizontalSizeClass == .regular && UIDevice.current.userInterfaceIdiom == .pad {
             collectionView.dropDelegate = self
-        default: break
+        } else {
+            collectionView.keyboardDismissMode = .onDrag
         }
 
         let searchBarTop = searchContainer.topAnchor.constraint(equalTo: self.view.topAnchor, constant: TagFilterViewController.searchBarTopOffset)


### PR DESCRIPTION
Modifies `MasterContainerViewController` to inherit from `UINavigationController`. This allows split view controller to merge/separate navigation stacks when it collapses/expands. 

`MasterContainerViewController` is used for both iPhone and iPad, with these differences:
* in iPhone the bottom controller is not created
* for iPhones Pro Max and Plus, the default behavior of showing a split view controller in landscape is kept, but without the bottom controller

So the case that was previously
`UIDevice.current.userInterfaceIdiom == .pad`
becomes (in most cases)
`traitCollection.horizontalSizeClass == .regular && UIDevice.current.userInterfaceIdiom == .pad`

and the case that was previously
`UIDevice.current.userInterfaceIdiom == .phone`
becomes (in most cases)
`traitCollection.horizontalSizeClass == .compact || UIDevice.current.userInterfaceIdiom == .phone`

Trait transition logic has been updated in most common cases. Other existing cases should work as is, but we can update them as well, if we get relevant feedback.