### PR TITLE
Fixed dynamic type issue with items list title

### DIFF
--- a/Zotero/Scenes/Detail/Items/Models/ItemsAction.swift
+++ b/Zotero/Scenes/Detail/Items/Models/ItemsAction.swift
@@ -15,6 +15,7 @@ enum ItemsAction {
     case addAttachments([URL])
     case assignItemsToCollections(items: Set<String>, collections: Set<String>)
     case cacheItemTitle(key: String, title: String)
+    case clearTitleCache
     case deleteItemsFromCollection(Set<String>)
     case deleteItems(Set<String>)
     case deselectItem(String)

--- a/Zotero/Scenes/Detail/Items/Models/ItemsState.swift
+++ b/Zotero/Scenes/Detail/Items/Models/ItemsState.swift
@@ -41,7 +41,6 @@ struct ItemsState: ViewModelState {
 
     let collection: Collection
     let library: Library
-    let itemTitleFont: UIFont
 
     var sortType: ItemsSortType
     var searchTerm: String?
@@ -64,6 +63,9 @@ struct ItemsState: ViewModelState {
     var bibliographyError: Error?
     var attachmentToOpen: String?
     var downloadBatchData: DownloadBatchData?
+    var itemTitleFont: UIFont {
+        return UIFont.preferredFont(for: .headline, weight: .regular)
+    }
 
     var tagsFilter: Set<String>? {
         let tagFilter = self.filters.first(where: { filter in
@@ -92,7 +94,6 @@ struct ItemsState: ViewModelState {
         self.searchTerm = searchTerm
         self.processingBibliography = false
         self.itemTitles = [:]
-        self.itemTitleFont = UIFont.preferredFont(for: .headline, weight: .regular)
     }
 
     mutating func cleanup() {

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
@@ -192,6 +192,11 @@ struct ItemsActionHandler: ViewModelActionHandler, BackgroundDbProcessingActionH
             self.update(viewModel: viewModel) { state in
                 state.itemTitles[key] = self.htmlAttributedStringConverter.convert(text: title, baseAttributes: [.font: state.itemTitleFont])
             }
+
+        case .clearTitleCache:
+            self.update(viewModel: viewModel) { state in
+                state.itemTitles = [:]
+            }
         }
     }
 

--- a/Zotero/Scenes/Detail/Items/Views/ItemsTableViewHandler.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsTableViewHandler.swift
@@ -207,8 +207,10 @@ final class ItemsTableViewHandler: NSObject {
         cell.set(accessory: self.cellAccessory(from: accessory))
     }
 
-    func reloadAll(snapshot: Results<RItem>) {
-        self.snapshot = snapshot
+    func reloadAll(snapshot: Results<RItem>? = nil) {
+        if let snapshot {
+            self.snapshot = snapshot
+        }
         self.tableView.reloadData()
     }
 

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -521,10 +521,20 @@ final class ItemsViewController: UIViewController {
             .rx
             .notification(.willEnterForeground)
             .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] _ in
-                guard let self = self, self.searchBarNeedsReset else { return }
+            .subscribe(with: self, onNext: { `self`, _ in
+                guard self.searchBarNeedsReset else { return }
                 self.resetSearchBar()
                 self.searchBarNeedsReset = false
+            })
+            .disposed(by: self.disposeBag)
+
+        NotificationCenter.default
+            .rx
+            .notification(UIContentSizeCategory.didChangeNotification)
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self, onNext: { `self`, _ in
+                self.viewModel.process(action: .clearTitleCache)
+                self.tableViewHandler.reloadAll()
             })
             .disposed(by: self.disposeBag)
     }


### PR DESCRIPTION
There is some weird (possibly Apple) bug, where caching a `NSAttributedString` with a `.font` attribute causes the label to ignore the dynamic type change.

Fixes #768