### PR TITLE
Remove view model state observer skips

### DIFF
--- a/ZShare/View Controllers/AllCollectionPickerViewController.swift
+++ b/ZShare/View Controllers/AllCollectionPickerViewController.swift
@@ -42,7 +42,6 @@ final class AllCollectionPickerViewController: UICollectionViewController {
         self.updateDataSource(with: self.viewModel.state, includeSelection: true)
 
         self.viewModel.stateObservable
-                      .skip(1)
                       .observe(on: MainScheduler.instance)
                       .subscribe(onNext: { [weak self] state in
                           self?.update(to: state)

--- a/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
@@ -228,7 +228,6 @@ class ManualLookupViewController: UIViewController {
             self?.updatePreferredContentSize()
         }
         controller.viewModel.stateObservable
-                  .skip(1)
                   .subscribe(with: self, onNext: { `self`, state in
                       self.update(state: state)
                   })

--- a/Zotero/Scenes/General/Views/CollectionsPickerViewController.swift
+++ b/Zotero/Scenes/General/Views/CollectionsPickerViewController.swift
@@ -83,7 +83,6 @@ class CollectionsPickerViewController: UICollectionViewController {
         self.updateDataSource(with: self.viewModel.state, animated: false)
 
         self.viewModel.stateObservable
-                      .skip(1)
                       .observe(on: MainScheduler.instance)
                       .subscribe(onNext: { [weak self] state in
                           self?.update(to: state)

--- a/Zotero/Scenes/Master/Collections/Views/CollectionsSearchViewController.swift
+++ b/Zotero/Scenes/Master/Collections/Views/CollectionsSearchViewController.swift
@@ -43,7 +43,6 @@ final class CollectionsSearchViewController: UIViewController {
         self.setupDataSource()
 
         self.viewModel.stateObservable
-                      .skip(1)
                       .observe(on: MainScheduler.instance)
                       .subscribe(onNext: { [weak self] state in
                           self?.update(to: state)


### PR DESCRIPTION
Since https://github.com/zotero/zotero-ios/pull/763 changed `ViewModel`'s `stateObservable` from `BehaviorRelay` to `PublishSubject`, there is no initial state that may need to be skipped in certain cases.