### PR TITLE
WIP Support multiple open items

### DIFF
--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		61C817F22A49B5D30085B1E6 /* CollectionResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1EDEE250242E700D8BC1E /* CollectionResponseSpec.swift */; };
 		61FA14CE2B05081D00E7D423 /* TextConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FA14CD2B05081D00E7D423 /* TextConverter.swift */; };
 		61FA14D02B08E24A00E7D423 /* ColorPickerStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FA14CF2B08E24A00E7D423 /* ColorPickerStackView.swift */; };
+		61E24DCC2ABB385E00D75F50 /* OpenItemsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E24DCB2ABB385E00D75F50 /* OpenItemsController.swift */; };
 		B300B33324291C8D00C1FE1E /* RTranslatorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = B300B33224291C8D00C1FE1E /* RTranslatorMetadata.swift */; };
 		B300B3352429222B00C1FE1E /* TranslatorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = B300B3342429222B00C1FE1E /* TranslatorMetadata.swift */; };
 		B300B3362429234C00C1FE1E /* TranslatorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = B300B3342429222B00C1FE1E /* TranslatorMetadata.swift */; };
@@ -1211,6 +1212,7 @@
 		61BD13942A5831EF008A0704 /* TextKit1TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextKit1TextView.swift; sourceTree = "<group>"; };
 		61FA14CD2B05081D00E7D423 /* TextConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextConverter.swift; sourceTree = "<group>"; };
 		61FA14CF2B08E24A00E7D423 /* ColorPickerStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerStackView.swift; sourceTree = "<group>"; };
+		61E24DCB2ABB385E00D75F50 /* OpenItemsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenItemsController.swift; sourceTree = "<group>"; };
 		B300B33224291C8D00C1FE1E /* RTranslatorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTranslatorMetadata.swift; sourceTree = "<group>"; };
 		B300B3342429222B00C1FE1E /* TranslatorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslatorMetadata.swift; sourceTree = "<group>"; };
 		B300B3372429254900C1FE1E /* SyncTranslatorsDbRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTranslatorsDbRequest.swift; sourceTree = "<group>"; };
@@ -2162,6 +2164,7 @@
 				B3A17D1827FC33B800322CAD /* LowPowerModeController.swift */,
 				B3C43C1F28589F300007076D /* NotePreviewGenerator.swift */,
 				B305646C23FC051E003304F2 /* ObjectUserChangeObserver.swift */,
+				61E24DCB2ABB385E00D75F50 /* OpenItemsController.swift */,
 				B34A9F6325BF1ABB007C9A4A /* PdfDocumentExporter.swift */,
 				B3C6D551261C9F2E0068B9FE /* PlaceholderTextViewDelegate.swift */,
 				B378F4CC242CD45700B88A05 /* RepoParserDelegate.swift */,
@@ -4832,6 +4835,7 @@
 				B36181EC24C96B0500B30D56 /* SearchableCollection.swift in Sources */,
 				B3830CDB255451AB00910FE0 /* TagPickerAction.swift in Sources */,
 				B3593F40241A61C700760E20 /* ItemCell.swift in Sources */,
+				61E24DCC2ABB385E00D75F50 /* OpenItemsController.swift in Sources */,
 				B305679023FC1D9B003304F2 /* CollectionDifference+Separated.swift in Sources */,
 				B34ACC7A2514EAAB00040C17 /* AnnotationColorGenerator.swift in Sources */,
 				B3ADAE4F2833BEDC00D46271 /* LookupState.swift in Sources */,

--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		614D65832A79C9B0007CF449 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 614D65802A79C9AC007CF449 /* Localizable.stringsdict */; };
 		614D65872A8030C9007CF449 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 614D65862A8030C9007CF449 /* OrderedCollections */; };
 		618404262A4456A9005AAF22 /* IdentifierLookupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618404252A4456A9005AAF22 /* IdentifierLookupController.swift */; };
+		61639F852AE03B8500026003 /* InstantPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61639F842AE03B8500026003 /* InstantPresenter.swift */; };
 		61ABA7512A6137D1002A4219 /* ShareableImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61ABA7502A6137D1002A4219 /* ShareableImage.swift */; };
 		61BD13952A5831EF008A0704 /* TextKit1TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BD13942A5831EF008A0704 /* TextKit1TextView.swift */; };
 		61C817F22A49B5D30085B1E6 /* CollectionResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1EDEE250242E700D8BC1E /* CollectionResponseSpec.swift */; };
@@ -1208,6 +1209,7 @@
 		614D65812A79C9AC007CF449 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		614D65842A7BCC22007CF449 /* ci_post_clone.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_clone.sh; sourceTree = "<group>"; };
 		618404252A4456A9005AAF22 /* IdentifierLookupController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierLookupController.swift; sourceTree = "<group>"; };
+		61639F842AE03B8500026003 /* InstantPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantPresenter.swift; sourceTree = "<group>"; };
 		61ABA7502A6137D1002A4219 /* ShareableImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableImage.swift; sourceTree = "<group>"; };
 		61BD13942A5831EF008A0704 /* TextKit1TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextKit1TextView.swift; sourceTree = "<group>"; };
 		61FA14CD2B05081D00E7D423 /* TextConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextConverter.swift; sourceTree = "<group>"; };
@@ -2156,6 +2158,7 @@
 				B305648123FC051E003304F2 /* Formatter.swift */,
 				B367330C24ACB63300E0CDA8 /* HtmlAttributedStringConverter.swift */,
 				B307A2722704A87D005986B3 /* IdleTimerController.swift */,
+				61639F842AE03B8500026003 /* InstantPresenter.swift */,
 				B30564B923FC051E003304F2 /* ItemTitleFormatter.swift */,
 				B39649172869B0D0000BCB6C /* ISBNParser.swift */,
 				B305648023FC051E003304F2 /* KeyGenerator.swift */,
@@ -5105,6 +5108,7 @@
 				B357A292285B786E00E73CA1 /* LookupCoordinator.swift in Sources */,
 				B34A9F6425BF1ABB007C9A4A /* PdfDocumentExporter.swift in Sources */,
 				B377F2A5249373F300022943 /* AttachmentFileCleanupController.swift in Sources */,
+				61639F852AE03B8500026003 /* InstantPresenter.swift in Sources */,
 				B3E8FE3E27142AA300F51458 /* StylePickerActionHandler.swift in Sources */,
 				B305661823FC051E003304F2 /* LoadPermissionsSyncAction.swift in Sources */,
 				B3593F3E241A61C700760E20 /* ItemsTableViewHandler.swift in Sources */,

--- a/Zotero/AppDelegate.swift
+++ b/Zotero/AppDelegate.swift
@@ -301,7 +301,6 @@ extension AppDelegate: UIApplicationDelegate {
 
     func applicationWillEnterForeground(_ application: UIApplication) {
         self.controllers.willEnterForeground()
-        NotificationCenter.default.post(name: .willEnterForeground, object: nil)
     }
 
     func applicationWillTerminate(_ application: UIApplication) {

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -140,6 +140,7 @@
 "items.generating_bib" = "Generating Bibliography";
 "items.creator_summary.and" = "%@ and %@";
 "items.creator_summary.etal" = "%@ et al.";
+"items.restore_open" = "Restore Open Items";
 
 "lookup.title" = "Enter ISBNs, DOls, PMIDs, arXiv IDs, or ADS Bibcodes to add to your library:";
 

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -537,3 +537,4 @@
 "accessibility.pdf.undo" = "Undo";
 "accessibility.pdf.toggle_annotation_toolbar" = "Toggle annotation toolbar";
 "accessibility.pdf.show_more_tools" = "Show more";
+"accessibility.pdf.open_items" = "Open Items";

--- a/Zotero/Controllers/Controllers.swift
+++ b/Zotero/Controllers/Controllers.swift
@@ -383,7 +383,7 @@ final class UserControllers {
         self.translatorsAndStylesController = controllers.translatorsAndStylesController
         self.idleTimerController = controllers.idleTimerController
         self.customUrlController = CustomURLController(dbStorage: dbStorage, fileStorage: controllers.fileStorage)
-        openItemsController = OpenItemsController()
+        openItemsController = OpenItemsController(dbStorage: dbStorage, fileStorage: controllers.fileStorage)
         self.lastBuildNumber = controllers.lastBuildNumber
         self.disposeBag = DisposeBag()
     }

--- a/Zotero/Controllers/Controllers.swift
+++ b/Zotero/Controllers/Controllers.swift
@@ -306,6 +306,7 @@ final class UserControllers {
     let citationController: CitationController
     let webDavController: WebDavController
     let customUrlController: CustomURLController
+    let openItemsController: OpenItemsController
     private let isFirstLaunch: Bool
     private let lastBuildNumber: Int?
     private unowned let translatorsAndStylesController: TranslatorsAndStylesController
@@ -382,6 +383,7 @@ final class UserControllers {
         self.translatorsAndStylesController = controllers.translatorsAndStylesController
         self.idleTimerController = controllers.idleTimerController
         self.customUrlController = CustomURLController(dbStorage: dbStorage, fileStorage: controllers.fileStorage)
+        openItemsController = OpenItemsController()
         self.lastBuildNumber = controllers.lastBuildNumber
         self.disposeBag = DisposeBag()
     }

--- a/Zotero/Controllers/Database/Requests/ReadItemDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/ReadItemDbRequest.swift
@@ -25,18 +25,3 @@ struct ReadItemDbRequest: DbResponseRequest {
         return item
     }
 }
-
-struct ReadItemGloballyDbRequest: DbResponseRequest {
-    typealias Response = RItem
-
-    let key: String
-
-    var needsWrite: Bool { return false }
-
-    func process(in database: Realm) throws -> RItem {
-        guard let item = database.objects(RItem.self).filter(.key(key)).first else {
-            throw DbError.objectNotFound
-        }
-        return item
-    }
-}

--- a/Zotero/Controllers/Database/Requests/ReadItemDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/ReadItemDbRequest.swift
@@ -25,3 +25,18 @@ struct ReadItemDbRequest: DbResponseRequest {
         return item
     }
 }
+
+struct ReadItemGloballyDbRequest: DbResponseRequest {
+    typealias Response = RItem
+
+    let key: String
+
+    var needsWrite: Bool { return false }
+
+    func process(in database: Realm) throws -> RItem {
+        guard let item = database.objects(RItem.self).filter(.key(key)).first else {
+            throw DbError.objectNotFound
+        }
+        return item
+    }
+}

--- a/Zotero/Controllers/Database/Requests/ReadItemsDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/ReadItemsDbRequest.swift
@@ -86,3 +86,15 @@ struct ReadItemsWithKeysDbRequest: DbResponseRequest {
         return database.objects(RItem.self).filter(.keys(self.keys, in: self.libraryId))
     }
 }
+
+struct ReadItemsWithKeysFromMultipleLibrariesDbRequest: DbResponseRequest {
+    typealias Response = Results<RItem>
+
+    let keysByLibraryIdentifier: [LibraryIdentifier: Set<String>]
+
+    var needsWrite: Bool { return false }
+
+    func process(in database: Realm) throws -> Results<RItem> {
+        database.objects(RItem.self).filter(.keysByLibraryIdentifier(keysByLibraryIdentifier))
+    }
+}

--- a/Zotero/Controllers/InstantPresenter.swift
+++ b/Zotero/Controllers/InstantPresenter.swift
@@ -1,0 +1,94 @@
+//
+//  InstantPresenter.swift
+//  Zotero
+//
+//  Created by Miltiadis Vasilakis on 18/10/23.
+//  Copyright © 2023 Corporation for Digital Scholarship. All rights reserved.
+//
+
+import UIKit
+
+import CocoaLumberjackSwift
+
+protocol InstantPresenter: AnyObject {
+    var presentedRestoredControllerWindow: UIWindow? { get set }
+    
+    func show(controller: UIViewController, by presenter: UIViewController, in window: UIWindow, animated: Bool, completion: (() -> Void)?)
+}
+
+extension InstantPresenter {
+    func show(controller: UIViewController, by presenter: UIViewController, in window: UIWindow, animated: Bool, completion: (() -> Void)? = nil) {
+        DDLogInfo("InstantPresenter: show controller; animated=\(animated)")
+        
+        if animated {
+            if presenter.presentedViewController == nil {
+                DDLogInfo("InstantPresenter: no presented controller, present controller")
+                presenter.present(controller, animated: true, completion: completion)
+                return
+            }
+            
+            DDLogInfo("InstantPresenter: previously presented controller, dismiss")
+            presenter.dismiss(animated: true, completion: {
+                DDLogInfo("InstantPresenter: present controller")
+                presenter.present(controller, animated: true, completion: completion)
+            })
+            return
+        }
+        
+        show(presentedViewController: controller, by: presenter, in: window) { presenter, completion in
+            if presenter.presentedViewController == nil {
+                DDLogInfo("InstantPresenter: no presented controller, present controller")
+                presenter.present(controller, animated: false, completion: completion)
+                return
+            }
+            
+            DDLogInfo("InstantPresenter: previously presented controller, dismiss")
+            presenter.dismiss(animated: false, completion: {
+                DDLogInfo("InstantPresenter: present controller")
+                presenter.present(controller, animated: false, completion: completion)
+            })
+        }
+        
+        completion?()
+        
+        /// If the app tries to present a `UIViewController` on a `UIWindow` that is being shown after app launches,
+        /// there is a small delay where the underlying (presenting) `UIViewController` is visible.
+        /// So the launch animation looks bad, since you can see a snapshot of previous state (PDF reader),
+        /// then split view controller with collections and items and then PDF reader again.
+        /// Because of that we fake it a little with this function.
+        func show(presentedViewController: UIViewController, by presenter: UIViewController, in window: UIWindow, presentAction: (UIViewController, @escaping () -> Void) -> Void) {
+            // Store original rootViewController
+            guard let oldRootViewController = window.rootViewController else { return }
+            
+            // Show new view controller in the window so that it's layed out properly
+            window.rootViewController = presentedViewController
+            
+            // Make a screenshot of the window
+            UIGraphicsBeginImageContext(window.frame.size)
+            window.layer.render(in: UIGraphicsGetCurrentContext()!)
+            let image = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+            
+            // Create a temporary `UIImageView` with given screenshot
+            let imageView = UIImageView(image: image)
+            imageView.contentMode = .scaleAspectFill
+            imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            imageView.frame = window.bounds
+            
+            // Create a temporary `UIWindow` which will be shown above current window until it successfully presents the new view controller.
+            let tmpWindow = UIWindow(frame: window.frame)
+            tmpWindow.windowScene = window.windowScene
+            tmpWindow.addSubview(imageView)
+            tmpWindow.makeKeyAndVisible()
+            presentedRestoredControllerWindow = tmpWindow
+            
+            // New window is visible with a screenshot, restore original rootViewController and present
+            window.rootViewController = oldRootViewController
+            
+            presentAction(presenter) {
+                // Clean up temprary window
+                self.presentedRestoredControllerWindow = nil
+            }
+        }
+    }
+}

--- a/Zotero/Controllers/OpenItemsController.swift
+++ b/Zotero/Controllers/OpenItemsController.swift
@@ -11,30 +11,118 @@ import RxSwift
 
 import CocoaLumberjackSwift
 
+protocol OpenItemsPresenter: AnyObject {
+    func showPDF(at url: URL, key: String, library: Library)
+}
+
 final class OpenItemsController {
     // MARK: Types
     enum Item: Hashable, Equatable {
-        case pdf(library: Library, key: String, url: URL)
+        case pdf(library: Library, key: String)
     }
     
     // MARK: Properties
+    private unowned let dbStorage: DbStorage
+    private unowned let fileStorage: FileStorage
+    // TODO: Use a better data structure, such as an ordered set
+    // TODO: Keep track of user sorted items (for presentation), possibly in a separate list
+    // Items are sorted by most recently opened
     private(set) var items: [Item] = []
+    private var collection: Collection?
     let observable: PublishSubject<[Item]>
     private let disposeBag: DisposeBag
     
     // MARK: Object Lifecycle
-    init() {
-        self.observable = PublishSubject()
-        self.disposeBag = DisposeBag()
+    init(dbStorage: DbStorage, fileStorage: FileStorage) {
+        self.dbStorage = dbStorage
+        self.fileStorage = fileStorage
+        observable = PublishSubject()
+        disposeBag = DisposeBag()
     }
     
     // MARK: Actions
-    func open(_ item: Item) {
-        // TODO: Use a better data structure, such as an ordered set
-        // TODO: Keep track of last opened item
-        guard !items.contains(where: { $0 == item }) else { return }
+    func open(_ item: Item, in collection: Collection) {
+        DDLogInfo("OpenItemsController: opened item \(item) in collection \(collection)")
+        self.collection = collection
+        guard items.last != item else { return }
+        // Since item not last, will certainly need to be appended in the end
+        if let index = items.firstIndex(of: item) {
+            // Item already open, remove it to be appended
+            items.remove(at: index)
+            DDLogInfo("OpenItemsController: moving already opened item \(item) to most recent")
+        } else {
+            DDLogInfo("OpenItemsController: appending newly opened item \(item) as most recent")
+        }
         items.append(item)
-        DDLogInfo("OpenItemsController: opened \(item)")
+        DDLogInfo("OpenItemsController: opened item \(item) in collection \(collection)")
         observable.on(.next(items))
+    }
+    
+    func restoreMostRecentlyOpenedItem(using presenter: OpenItemsPresenter) {
+        // Will restore most recent opened item still present, or none if all fail
+        DDLogInfo("OpenItemsController: restoring last opened item using presenter \(presenter)")
+        var itemsChanged: Bool = false
+        defer {
+            if itemsChanged {
+                observable.on(.next(items))
+            }
+        }
+        var item: Item?
+        var url: URL?
+        while let _item = items.last {
+            if let _url = load(item: _item) {
+                item = _item
+                url = _url
+                break
+            }
+            DDLogWarn("OpenItemsController: removing not loaded item \(_item)")
+            _ = items.removeLast()
+            itemsChanged = true
+        }
+        guard let item, let url else { return }
+        switch item {
+        case .pdf(let library, let key):
+            presenter.showPDF(at: url, key: key, library: library)
+        }
+        DDLogInfo("OpenItemsController: restored item \(item) with URL \(url)")
+    }
+    
+    // MARK: Helper Methods
+    private func load(item: Item) -> URL? {
+        var url: URL?
+        
+        switch item {
+        case .pdf(let library, let key):
+            url = loadPDFItem(key: key, libraryId: library.identifier)
+        }
+        
+        return url
+        
+        func loadPDFItem(key: String, libraryId: LibraryIdentifier) -> URL? {
+            var url: URL?
+            do {
+                try dbStorage.perform(on: .main) { coordinator in
+                    let rItem = try coordinator.perform(request: ReadItemDbRequest(libraryId: libraryId, key: key))
+                    guard let attachment = AttachmentCreator.attachment(for: rItem, fileStorage: fileStorage, urlDetector: nil) else { return }
+                    switch attachment.type {
+                    case .file(let filename, let contentType, let location, _):
+                        switch location {
+                        case .local, .localAndChangedRemotely:
+                            let file = Files.attachmentFile(in: libraryId, key: key, filename: filename, contentType: contentType)
+                            url = file.createUrl()
+                            
+                        case .remote, .remoteMissing:
+                            break
+                        }
+                        
+                    default:
+                        break
+                    }
+                }
+            } catch let error {
+                DDLogError("OpenItemsController: can't load item \(item) - \(error)")
+            }
+            return url
+        }
     }
 }

--- a/Zotero/Controllers/OpenItemsController.swift
+++ b/Zotero/Controllers/OpenItemsController.swift
@@ -160,11 +160,14 @@ final class OpenItemsController {
             do {
                 try dbStorage.perform(on: .main) { coordinator in
                     for item in items {
-                        do {
-                            let rItem = try coordinator.perform(request: ReadItemGloballyDbRequest(key: item.key))
-                            itemTuples.append((item, rItem))
-                        } catch let itemError {
-                            DDLogError("OpenItemsController: can't load globally item \(item) - \(itemError)")
+                        switch item {
+                        case .pdf(let libraryId, let key):
+                            do {
+                                let rItem = try coordinator.perform(request: ReadItemDbRequest(libraryId: libraryId, key: key))
+                                itemTuples.append((item, rItem))
+                            } catch let itemError {
+                                DDLogError("OpenItemsController: can't load item \(item) - \(itemError)")
+                            }
                         }
                     }
                 }

--- a/Zotero/Controllers/OpenItemsController.swift
+++ b/Zotero/Controllers/OpenItemsController.swift
@@ -26,6 +26,13 @@ final class OpenItemsController {
         }
         
         // MARK: Properties
+        var key: String {
+            switch self {
+            case .pdf(_, let key):
+                return key
+            }
+        }
+        
         var type: ItemType {
             switch self {
             case .pdf:
@@ -104,9 +111,17 @@ final class OpenItemsController {
         observable.on(.next(items))
     }
     
-    func restoreMostRecentlyOpenedItem(using presenter: OpenItemsPresenter) {
+    @discardableResult
+    func restore(_ item: Item, using presenter: OpenItemsPresenter) -> Bool {
+        guard let (library, url) = load(item: item) else { return false }
+        presentItem(item, at: url, library: library, using: presenter)
+        return true
+    }
+    
+    @discardableResult
+    func restoreMostRecentlyOpenedItem(using presenter: OpenItemsPresenter) -> Item? {
         // Will restore most recent opened item still present, or none if all fail
-        DDLogInfo("OpenItemsController: restoring last opened item using presenter \(presenter)")
+        DDLogInfo("OpenItemsController: restoring most recently opened item using presenter \(presenter)")
         var itemsChanged: Bool = false
         defer {
             if itemsChanged {
@@ -127,48 +142,94 @@ final class OpenItemsController {
             _ = items.removeLast()
             itemsChanged = true
         }
-        guard let item, let library, let url else { return }
+        guard let item, let library, let url else { return nil }
+        presentItem(item, at: url, library: library, using: presenter)
+        return item
+    }
+    
+    func deferredOpenItemsMenuElement(disableOpenItem: Bool, itemActionCallback: @escaping (Item, UIAction) -> Void) -> UIDeferredMenuElement {
+        UIDeferredMenuElement { [weak self] elementProvider in
+            guard let self else {
+                elementProvider([])
+                return
+            }
+            var actions: [UIAction] = []
+            let items = self.items
+            let openItem: Item? = disableOpenItem ? items.last : nil
+            var itemTuples: [(Item, RItem)] = []
+            do {
+                try dbStorage.perform(on: .main) { coordinator in
+                    for item in items {
+                        do {
+                            let rItem = try coordinator.perform(request: ReadItemGloballyDbRequest(key: item.key))
+                            itemTuples.append((item, rItem))
+                        } catch let itemError {
+                            DDLogError("OpenItemsController: can't load globally item \(item) - \(itemError)")
+                        }
+                    }
+                }
+            } catch let error {
+                DDLogError("OpenItemsController: can't load multiple items - \(error)")
+            }
+            for (item, rItem) in itemTuples {
+                var attributes: UIMenuElement.Attributes = []
+                var state: UIMenuElement.State = .off
+                if item == openItem {
+                    attributes = [.disabled]
+                    state = .on
+                }
+                let itemAction = UIAction(title: rItem.displayTitle, attributes: attributes, state: state) { action in
+                    itemActionCallback(item, action)
+                }
+                actions.append(itemAction)
+            }
+            elementProvider(actions)
+        }
+    }
+    
+    // MARK: Helper Methods
+    private func load(item: Item) -> (Library, URL)? {
+        switch item {
+        case .pdf(let libraryId, let key):
+            return loadPDFItem(key: key, libraryId: libraryId)
+        }
+        
+        func loadPDFItem(key: String, libraryId: LibraryIdentifier) -> (Library, URL)? {
+            var library: Library?
+            var url: URL?
+            do {
+                try dbStorage.perform(on: .main) { coordinator in
+                    library = try coordinator.perform(request: ReadLibraryDbRequest(libraryId: libraryId))
+                    let rItem = try coordinator.perform(request: ReadItemDbRequest(libraryId: libraryId, key: key))
+                    guard let attachment = AttachmentCreator.attachment(for: rItem, fileStorage: fileStorage, urlDetector: nil) else { return }
+                    switch attachment.type {
+                    case .file(let filename, let contentType, let location, _):
+                        switch location {
+                        case .local, .localAndChangedRemotely:
+                            let file = Files.attachmentFile(in: libraryId, key: key, filename: filename, contentType: contentType)
+                            url = file.createUrl()
+                            
+                        case .remote, .remoteMissing:
+                            break
+                        }
+                        
+                    default:
+                        break
+                    }
+                }
+            } catch let error {
+                DDLogError("OpenItemsController: can't load item \(item) - \(error)")
+            }
+            guard let library, let url else { return nil }
+            return (library, url)
+        }
+    }
+    
+    private func presentItem(_ item: Item, at url: URL, library: Library, using presenter: OpenItemsPresenter) {
         switch item {
         case .pdf(_, let key):
             presenter.showPDF(at: url, key: key, library: library)
         }
-        DDLogInfo("OpenItemsController: restored item \(item) with URL \(url)")
-
-        func load(item: Item) -> (Library, URL)? {
-            switch item {
-            case .pdf(let libraryId, let key):
-                return loadPDFItem(key: key, libraryId: libraryId)
-            }
-            
-            func loadPDFItem(key: String, libraryId: LibraryIdentifier) -> (Library, URL)? {
-                var library: Library?
-                var url: URL?
-                do {
-                    try dbStorage.perform(on: .main) { coordinator in
-                        library = try coordinator.perform(request: ReadLibraryDbRequest(libraryId: libraryId))
-                        let rItem = try coordinator.perform(request: ReadItemDbRequest(libraryId: libraryId, key: key))
-                        guard let attachment = AttachmentCreator.attachment(for: rItem, fileStorage: fileStorage, urlDetector: nil) else { return }
-                        switch attachment.type {
-                        case .file(let filename, let contentType, let location, _):
-                            switch location {
-                            case .local, .localAndChangedRemotely:
-                                let file = Files.attachmentFile(in: libraryId, key: key, filename: filename, contentType: contentType)
-                                url = file.createUrl()
-                                
-                            case .remote, .remoteMissing:
-                                break
-                            }
-                            
-                        default:
-                            break
-                        }
-                    }
-                } catch let error {
-                    DDLogError("OpenItemsController: can't load item \(item) - \(error)")
-                }
-                guard let library, let url else { return nil }
-                return (library, url)
-            }
-        }
+        DDLogInfo("OpenItemsController: presented item \(item) at URL \(url)")
     }
 }

--- a/Zotero/Controllers/OpenItemsController.swift
+++ b/Zotero/Controllers/OpenItemsController.swift
@@ -1,0 +1,40 @@
+//
+//  OpenItemsController.swift
+//  Zotero
+//
+//  Created by Miltiadis Vasilakis on 20/9/23.
+//  Copyright © 2023 Corporation for Digital Scholarship. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+import CocoaLumberjackSwift
+
+final class OpenItemsController {
+    // MARK: Types
+    enum Item: Hashable, Equatable {
+        case pdf(library: Library, key: String, url: URL)
+    }
+    
+    // MARK: Properties
+    private(set) var items: [Item] = []
+    let observable: PublishSubject<[Item]>
+    private let disposeBag: DisposeBag
+    
+    // MARK: Object Lifecycle
+    init() {
+        self.observable = PublishSubject()
+        self.disposeBag = DisposeBag()
+    }
+    
+    // MARK: Actions
+    func open(_ item: Item) {
+        // TODO: Use a better data structure, such as an ordered set
+        // TODO: Keep track of last opened item
+        guard !items.contains(where: { $0 == item }) else { return }
+        items.append(item)
+        DDLogInfo("OpenItemsController: opened \(item)")
+        observable.on(.next(items))
+    }
+}

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -785,6 +785,8 @@ internal enum L10n {
     }
     /// Remove from Collection
     internal static let removeFromCollectionTitle = L10n.tr("Localizable", "items.remove_from_collection_title", fallback: "Remove from Collection")
+    /// Restore Open Items
+    internal static let restoreOpen = L10n.tr("Localizable", "items.restore_open", fallback: "Restore Open Items")
     /// Search Items
     internal static let searchTitle = L10n.tr("Localizable", "items.search_title", fallback: "Search Items")
     /// Select All

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -214,6 +214,8 @@ internal enum L10n {
       internal static let noteAnnotation = L10n.tr("Localizable", "accessibility.pdf.note_annotation", fallback: "Note annotation")
       /// Create note annotation
       internal static let noteAnnotationTool = L10n.tr("Localizable", "accessibility.pdf.note_annotation_tool", fallback: "Create note annotation")
+      /// Open Items
+      internal static let openItems = L10n.tr("Localizable", "accessibility.pdf.open_items", fallback: "Open Items")
       /// Open text reader
       internal static let openReader = L10n.tr("Localizable", "accessibility.pdf.open_reader", fallback: "Open text reader")
       /// Redo

--- a/Zotero/Extensions/NSUserActivity+Activities.swift
+++ b/Zotero/Extensions/NSUserActivity+Activities.swift
@@ -11,7 +11,7 @@ import Foundation
 struct RestoredStateData {
     let libraryId: LibraryIdentifier
     let collectionId: CollectionIdentifier
-    let openItems: [OpenItemsController.Item]
+    let openItems: [OpenItem]
     let restoreMostRecentlyOpenedItem: Bool
 }
 
@@ -24,7 +24,7 @@ extension NSUserActivity {
     private static let openItemsKey = "openItems"
     private static let restoreMostRecentlyOpenedItemKey = "restoreMostRecentlyOpenedItem"
     
-    static func mainActivity(with openItems: [OpenItemsController.Item]) -> NSUserActivity {
+    static func mainActivity(with openItems: [OpenItem]) -> NSUserActivity {
         let activity = NSUserActivity(activityType: self.mainId)
         activity.addUserInfoEntries(from: openItemsToUserInfo(openItems: openItems))
         let userInfo: [AnyHashable: Any] = [restoreMostRecentlyOpenedItemKey: false]
@@ -32,7 +32,7 @@ extension NSUserActivity {
         return activity
     }
 
-    static func pdfActivity(with openItems: [OpenItemsController.Item], libraryId: LibraryIdentifier, collectionId: CollectionIdentifier) -> NSUserActivity {
+    static func pdfActivity(with openItems: [OpenItem], libraryId: LibraryIdentifier, collectionId: CollectionIdentifier) -> NSUserActivity {
         let activity = NSUserActivity(activityType: self.pdfId)
         activity.addUserInfoEntries(from: openItemsToUserInfo(openItems: openItems))
         var userInfo: [AnyHashable: Any] = [libraryIdKey: libraryIdToString(libraryId), restoreMostRecentlyOpenedItemKey: true]
@@ -43,7 +43,7 @@ extension NSUserActivity {
         return activity
     }
     
-    private static func openItemsToUserInfo(openItems: [OpenItemsController.Item]) -> [AnyHashable: Any] {
+    private static func openItemsToUserInfo(openItems: [OpenItem]) -> [AnyHashable: Any] {
         var userInfo: [AnyHashable: Any] = [:]
         let encoder = JSONEncoder()
         userInfo[openItemsKey] = openItems.compactMap { try? encoder.encode($0) }
@@ -79,7 +79,7 @@ extension NSUserActivity {
         guard let userInfo else { return nil }
         var libraryId: LibraryIdentifier = Defaults.shared.selectedLibrary
         var collectionId: CollectionIdentifier = Defaults.shared.selectedCollectionId
-        var openItems: [OpenItemsController.Item] = []
+        var openItems: [OpenItem] = []
         var restoreMostRecentlyOpenedItem = false
         if let libraryString = userInfo[Self.libraryIdKey] as? String, let _libraryId = stringToLibraryId(libraryString) {
             libraryId = _libraryId
@@ -89,7 +89,7 @@ extension NSUserActivity {
             collectionId = _collectionId
         }
         if let openItemsDataArray = userInfo[Self.openItemsKey] as? [Data] {
-            openItems = openItemsDataArray.compactMap { try? decoder.decode(OpenItemsController.Item.self, from: $0) }
+            openItems = openItemsDataArray.compactMap { try? decoder.decode(OpenItem.self, from: $0) }
         }
         if let _restoreMostRecentlyOpenedItem = userInfo[Self.restoreMostRecentlyOpenedItemKey] as? Bool {
             restoreMostRecentlyOpenedItem = _restoreMostRecentlyOpenedItem

--- a/Zotero/Models/Notifications.swift
+++ b/Zotero/Models/Notifications.swift
@@ -13,6 +13,5 @@ extension Notification.Name {
     static let attachmentFileDeleted = Notification.Name("org.zotero.AttachmentFileDeleted")
     // Sent when attachment (`RItem`) is completely removed from the app (not just trashed). Used to remove attachment files of deleted attachments.
     static let attachmentDeleted = Notification.Name(rawValue: "org.zotero.AttachmentsDeleted")
-    static let willEnterForeground = Notification.Name(rawValue: "org.zotero.WillEnterForeground")
     static let forceReloadItems = Notification.Name(rawValue: "org.zotero.ForceReloadItems")
 }

--- a/Zotero/Models/Predicates.swift
+++ b/Zotero/Models/Predicates.swift
@@ -43,6 +43,10 @@ extension NSPredicate {
                                                                    .library(with: libraryId)])
     }
 
+    static func keysByLibraryIdentifier(_ keysByLibraryIdentifier: [LibraryIdentifier: Set<String>]) -> NSPredicate {
+        NSCompoundPredicate(orPredicateWithSubpredicates: keysByLibraryIdentifier.map({ .keys($0.value, in: $0.key) }))
+    }
+
     static func key(notIn keys: [String], in libraryId: LibraryIdentifier) -> NSPredicate {
         return NSCompoundPredicate(andPredicateWithSubpredicates: [.library(with: libraryId), .key(notIn: keys)])
     }

--- a/Zotero/SceneDelegate.swift
+++ b/Zotero/SceneDelegate.swift
@@ -34,7 +34,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Load state if available, setup scene & window
         setup(scene: scene, userActivity: userActivity, window: window, options: connectionOptions, session: session, controllers: controllers)
         // Start observing
-        setupObservers(controllers: controllers)
+        setupObservers(options: connectionOptions, session: session, controllers: controllers)
 
         func setup(scene: UIScene, userActivity: NSUserActivity?, window: UIWindow, options connectionOptions: UIScene.ConnectionOptions, session: UISceneSession, controllers: Controllers) {
             scene.userActivity = userActivity
@@ -46,20 +46,22 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             self.coordinator = coordinator
         }
 
-        func setupObservers(controllers: Controllers) {
+        func setupObservers(options connectionOptions: UIScene.ConnectionOptions, session: UISceneSession, controllers: Controllers) {
             sessionCancellable = controllers.userInitialized
                 .receive(on: DispatchQueue.main)
                 .sink(
                     receiveCompletion: { _ in },
                     receiveValue: { [weak self] result in
                         guard let self else { return }
+                        let _isLoggedIn: Bool
                         switch result {
                         case .success(let isLoggedIn):
-                            coordinator.showMainScreen(isLoggedIn: isLoggedIn)
+                            _isLoggedIn = isLoggedIn
 
                         case .failure:
-                            coordinator.showMainScreen(isLoggedIn: false)
+                            _isLoggedIn = false
                         }
+                        coordinator.showMainScreen(isLoggedIn: _isLoggedIn, options: connectionOptions, session: session, animated: false)
                     }
                 )
         }

--- a/Zotero/SceneDelegate.swift
+++ b/Zotero/SceneDelegate.swift
@@ -19,22 +19,50 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     private var sessionCancellable: AnyCancellable?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        guard let delegate = UIApplication.shared.delegate as? AppDelegate else { return }
+        guard let delegate = UIApplication.shared.delegate as? AppDelegate, let controllers = delegate.controllers else { return }
 
         let windowScene = scene as? UIWindowScene
         let frame = windowScene?.coordinateSpace.bounds ?? UIScreen.main.bounds
 
         // Assign activity counter
-        self.activityCounter = delegate
+        activityCounter = delegate
         // Create window for scene
         let window = UIWindow(frame: frame)
         self.window = window
-        self.window?.windowScene = windowScene
-        self.window?.makeKeyAndVisible()
+        window.windowScene = windowScene
+        window.makeKeyAndVisible()
         // Load state if available, setup scene & window
-        self.setup(scene: scene, window: window, options: connectionOptions, session: session, delegate: delegate)
+        setup(scene: scene, userActivity: userActivity, window: window, options: connectionOptions, session: session, controllers: controllers)
         // Start observing
-        self.setupObservers(controllers: delegate.controllers)
+        setupObservers(controllers: controllers)
+
+        func setup(scene: UIScene, userActivity: NSUserActivity?, window: UIWindow, options connectionOptions: UIScene.ConnectionOptions, session: UISceneSession, controllers: Controllers) {
+            scene.userActivity = userActivity
+            scene.title = userActivity?.title
+
+            // Setup app coordinator and present initial screen
+            let coordinator = AppCoordinator(window: window, controllers: controllers)
+            coordinator.start(options: connectionOptions, session: session)
+            self.coordinator = coordinator
+        }
+
+        func setupObservers(controllers: Controllers) {
+            sessionCancellable = controllers.userInitialized
+                .receive(on: DispatchQueue.main)
+                .sink(
+                    receiveCompletion: { _ in },
+                    receiveValue: { [weak self] result in
+                        guard let self else { return }
+                        switch result {
+                        case .success(let isLoggedIn):
+                            coordinator.showMainScreen(isLoggedIn: isLoggedIn)
+
+                        case .failure:
+                            coordinator.showMainScreen(isLoggedIn: false)
+                        }
+                    }
+                )
+        }
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
@@ -46,58 +74,38 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             DDLogInfo("SceneDelegate: App opened by \(urlContext.url.absoluteString) from \(sourceApp)")
 
             if let kind = urlController.process(url: urlContext.url) {
-                self.coordinator.show(customUrl: kind, animated: (UIApplication.shared.applicationState == .active))
+                coordinator.show(customUrl: kind, animated: (UIApplication.shared.applicationState == .active))
             }
         }
     }
 
-    private func setup(scene: UIScene, window: UIWindow, options connectionOptions: UIScene.ConnectionOptions, session: UISceneSession, delegate: AppDelegate) {
-        scene.userActivity = userActivity
-        scene.title = userActivity?.title
-
-        // Setup app coordinator and present initial screen
-        let coordinator = AppCoordinator(window: self.window, controllers: delegate.controllers)
-        coordinator.start(options: connectionOptions, session: session)
-        self.coordinator = coordinator
-    }
-
-    func windowScene(_ windowScene: UIWindowScene, didUpdate previousCoordinateSpace: UICoordinateSpace, interfaceOrientation previousInterfaceOrientation: UIInterfaceOrientation, traitCollection previousTraitCollection: UITraitCollection) {
+    func windowScene(
+        _ windowScene: UIWindowScene,
+        didUpdate previousCoordinateSpace: UICoordinateSpace,
+        interfaceOrientation previousInterfaceOrientation: UIInterfaceOrientation,
+        traitCollection previousTraitCollection: UITraitCollection
+    ) {
         guard let newSize = windowScene.windows.first?.frame.size else { return }
-        self.coordinator?.didRotate(to: newSize)
+        coordinator?.didRotate(to: newSize)
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-        self.window?.windowScene?.userActivity?.becomeCurrent()
+        window?.windowScene?.userActivity?.becomeCurrent()
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
-        self.window?.windowScene?.userActivity?.resignCurrent()
+        window?.windowScene?.userActivity?.resignCurrent()
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
-        self.activityCounter?.sceneWillEnterForeground()
+        activityCounter?.sceneWillEnterForeground()
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
-        self.activityCounter?.sceneDidEnterBackground()
+        activityCounter?.sceneDidEnterBackground()
     }
 
     func stateRestorationActivity(for scene: UIScene) -> NSUserActivity? {
         return scene.userActivity
-    }
-
-    private func setupObservers(controllers: Controllers) {
-        self.sessionCancellable = controllers.userInitialized
-                                             .receive(on: DispatchQueue.main)
-                                             .sink(receiveCompletion: { _ in },
-                                                   receiveValue: { [weak self] result in
-                                                 switch result {
-                                                 case .success(let isLoggedIn):
-                                                     self?.coordinator.showMainScreen(isLoggedIn: isLoggedIn)
-
-                                                 case .failure:
-                                                     self?.coordinator.showMainScreen(isLoggedIn: false)
-                                                 }
-                                             })
     }
 }

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -815,7 +815,14 @@ extension AppCoordinator: SyncRequestReceiver {
 }
 
 extension AppCoordinator: OpenItemsPresenter {
-    func showPDF(at url: URL, key: String, library: Library) {
+    func showItem(with presentation: ItemPresentation) {
+        switch presentation {
+        case .pdf(let library, let key, let url):
+            showPDF(at: url, key: key, library: library)
+        }
+    }
+    
+    private func showPDF(at url: URL, key: String, library: Library) {
         guard let window, let mainController = window.rootViewController as? MainViewController else { return }
         mainController.getDetailCoordinator { [weak self] coordinator in
             guard let self else { return }

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -33,11 +33,11 @@ protocol AppLoginCoordinatorDelegate: AnyObject {
 
 final class AppCoordinator: NSObject {
     private typealias Action = (UIViewController) -> Void
-    
+
     private static let debugButtonSize = CGSize(width: 60, height: 60)
     private static let debugButtonOffset: CGFloat = 50
     private let controllers: Controllers
-    
+
     private weak var window: UIWindow?
     private var debugWindow: UIWindow?
     private var originalDebugWindowFrame: CGRect?
@@ -47,19 +47,19 @@ final class AppCoordinator: NSObject {
     private var downloadDisposeBag: DisposeBag?
     private var tmpConnectionOptions: UIScene.ConnectionOptions?
     private var tmpSession: UISceneSession?
-    
+
     private var viewController: UIViewController? {
         guard let viewController = self.window?.rootViewController else { return nil }
         let topController = viewController.topController
         return (topController as? MainViewController)?.viewControllers.last ?? topController
     }
-    
+
     init(window: UIWindow?, controllers: Controllers) {
         self.window = window
         self.controllers = controllers
         super.init()
     }
-    
+
     func start(options connectionOptions: UIScene.ConnectionOptions, session: UISceneSession) {
         if !self.controllers.sessionController.isInitialized {
             DDLogInfo("AppCoordinator: start while waiting for initialization")
@@ -70,39 +70,39 @@ final class AppCoordinator: NSObject {
             DDLogInfo("AppCoordinator: start logged \(self.controllers.sessionController.isLoggedIn ? "in" : "out")")
             self.showMainScreen(isLogged: self.controllers.sessionController.isLoggedIn, options: connectionOptions, session: session, animated: false)
         }
-        
+
         // If db needs to be wiped and this is the first start of the app, show beta alert
         if self.controllers.userControllers?.dbStorage.willPerformBetaWipe == true && self.controllers.sessionController.isLoggedIn {
             DDLogInfo("AppCoordinator: show beta alert")
             showBetaAlert()
         }
-        
+
         if self.controllers.sessionController.isInitialized && self.controllers.debugLogging.isEnabled {
             DDLogInfo("AppCoordinator: show debug window")
             self.setDebugWindow(visible: true)
         }
-        
+
         self.controllers.debugLogging.coordinator = self
         self.controllers.crashReporter.coordinator = self
         self.controllers.translatorsAndStylesController.coordinator = self
-        
+
         func showBetaAlert() {
             let controller = UIAlertController(title: L10n.betaWipeTitle, message: L10n.betaWipeMessage, preferredStyle: .alert)
             controller.addAction(UIAlertAction(title: L10n.ok, style: .cancel, handler: nil))
             self.window?.rootViewController?.present(controller, animated: true, completion: nil)
         }
     }
-    
+
     // MARK: - Navigation
-    
+
     private func showLaunchScreen() {
         guard let controller = UIStoryboard(name: "LaunchScreen", bundle: nil).instantiateInitialViewController() else { return }
         self.window?.rootViewController = controller
     }
-    
+
     private func showMainScreen(isLogged: Bool, options connectionOptions: UIScene.ConnectionOptions?, session: UISceneSession?, animated: Bool) {
         guard let window else { return }
-        
+
         let viewController: UIViewController
         var urlContext: UIOpenURLContext?
         var data: RestoredStateData?
@@ -110,7 +110,7 @@ final class AppCoordinator: NSObject {
             let controller = OnboardingViewController(size: window.frame.size, htmlConverter: self.controllers.htmlAttributedStringConverter)
             controller.coordinatorDelegate = self
             viewController = controller
-            
+
             self.conflictReceiverAlertController = nil
             self.conflictAlertQueueController = nil
             self.controllers.userControllers?.syncScheduler.syncController.set(coordinator: nil)
@@ -118,28 +118,28 @@ final class AppCoordinator: NSObject {
             (urlContext, data) = preprocess(connectionOptions: connectionOptions, session: session)
             let controller = MainViewController(controllers: self.controllers)
             viewController = controller
-            
+
             self.conflictReceiverAlertController = ConflictReceiverAlertController(viewController: controller)
             self.conflictAlertQueueController = ConflictAlertQueueController(viewController: controller)
             self.controllers.userControllers?.syncScheduler.syncController.set(coordinator: self)
         }
-        
+
         DDLogInfo("AppCoordinator: show main screen logged \(isLogged ? "in" : "out"); animated=\(animated)")
         show(viewController: viewController, in: window, animated: animated) {
             process(urlContext: urlContext, data: data)
         }
-        
+
         func show(viewController: UIViewController?, in window: UIWindow, animated: Bool = false, completion: @escaping () -> Void) {
             window.rootViewController = viewController
-            
+
             guard animated else {
                 completion()
                 return
             }
-            
+
             UIView.transition(with: window, duration: 0.2, options: .transitionCrossDissolve, animations: {}, completion: { _ in completion() })
         }
-        
+
         func preprocess(connectionOptions: UIScene.ConnectionOptions?, session: UISceneSession?) -> (UIOpenURLContext?, RestoredStateData?) {
             let urlContext = connectionOptions?.urlContexts.first
             let userActivity = connectionOptions?.userActivities.first ?? session?.stateRestorationActivity
@@ -153,25 +153,25 @@ final class AppCoordinator: NSObject {
             }
             return (urlContext, data)
         }
-        
+
         func process(urlContext: UIOpenURLContext?, data: RestoredStateData?) {
             if let urlContext, let urlController = self.controllers.userControllers?.customUrlController {
                 // If scene was started from custom URL
                 let sourceApp = urlContext.options.sourceApplication ?? "unknown"
                 DDLogInfo("AppCoordinator: App launched by \(urlContext.url.absoluteString) from \(sourceApp)")
-                
+
                 if let kind = urlController.process(url: urlContext.url) {
                     self.show(customUrl: kind, animated: false)
                     return
                 }
             }
-            
+
             if let data, data.restoreMostRecentlyOpenedItem {
                 DDLogInfo("AppCoordinator: Processing restored state - \(data)")
                 // If scene had state stored, restore state
                 showRestoredState(for: data)
             }
-            
+
             func showRestoredState(for data: RestoredStateData) {
                 guard let openItemsController = controllers.userControllers?.openItemsController else { return }
                 DDLogInfo("AppCoordinator: show restored state")
@@ -195,13 +195,13 @@ final class AppCoordinator: NSObject {
                 }
                 mainController.showItems(for: collection, in: library)
                 openItemsController.restoreMostRecentlyOpenedItem(using: self)
-                
+
                 func loadRestoredStateData(libraryId: LibraryIdentifier, collectionId: CollectionIdentifier) -> (Library, Collection?)? {
                     guard let dbStorage = self.controllers.userControllers?.dbStorage else { return nil }
-                    
+
                     var library: Library?
                     var collection: Collection?
-                    
+
                     do {
                         try dbStorage.perform(on: .main, with: { coordinator in
                             let (_collection, _library) = try coordinator.perform(request: ReadCollectionAndLibraryDbRequest(collectionId: collectionId, libraryId: libraryId))
@@ -212,7 +212,7 @@ final class AppCoordinator: NSObject {
                         DDLogError("AppCoordinator: can't load restored data - \(error)")
                         return nil
                     }
-                    
+
                     if let library = library {
                         return (library, collection)
                     }
@@ -221,23 +221,23 @@ final class AppCoordinator: NSObject {
             }
         }
     }
-    
+
     func show(customUrl: CustomURLController.Kind, animated: Bool) {
         guard let window, let mainController = window.rootViewController as? MainViewController else {
             DDLogWarn("AppCoordinator: show custom url aborted - invalid root view controller")
             return
         }
-        
+
         switch customUrl {
         case .itemDetail(let key, let library, let preselectedChildKey):
             DDLogInfo("AppCoordinator: show custom url - item detail; key=\(key); library=\(library.identifier)")
             showItemDetail(in: mainController, key: key, library: library, selectChildKey: preselectedChildKey, animated: animated, dismissIfPresenting: true)
-            
+
         case .pdfReader(let attachment, let library, let page, let annotation, let parentKey, let isAvailable):
             let message = DDLogMessageFormat(
                 stringLiteral:
                     "AppCoordinator: show custom url - pdf reader; key=\(attachment.key); library=\(library.identifier);" +
-                    " page=\(page.flatMap(String.init) ?? "nil"); annotation=\(annotation ?? "nil"); parentKey=\(parentKey ?? "nil")"
+                " page=\(page.flatMap(String.init) ?? "nil"); annotation=\(annotation ?? "nil"); parentKey=\(parentKey ?? "nil")"
             )
             DDLogInfo(message)
             mainController.getDetailCoordinator { coordinator in
@@ -254,62 +254,62 @@ final class AppCoordinator: NSObject {
                 }
             }
         }
-            
+
         func showItemDetail(in mainController: MainViewController, key: String, library: Library, selectChildKey childKey: String?, animated: Bool, dismissIfPresenting: Bool) {
             let dismissPresented = dismissIfPresenting && (mainController.presentedViewController != nil)
             let itemDetailAnimated = dismissPresented ? false : animated
-            
+
             // Show "All" collection in given library/group
             if let coordinator = mainController.masterCoordinator,
                coordinator.visibleLibraryId != library.identifier ||
                 (coordinator.navigationController?.visibleViewController as? CollectionsViewController)?.selectedIdentifier != .custom(.all) {
                 coordinator.showCollections(for: library.identifier, preselectedCollection: .custom(.all), animated: itemDetailAnimated)
             }
-            
+
             // Show item detail of given key
             mainController.getDetailCoordinator { coordinator in
                 if (coordinator.navigationController?.visibleViewController as? ItemDetailViewController)?.key != key {
                     coordinator.showItemDetail(for: .preview(key: key), library: library, scrolledToKey: childKey, animated: itemDetailAnimated)
                 }
             }
-            
+
             if dismissPresented {
                 // Dismiss presented screen if any visible
                 mainController.dismiss(animated: animated)
             }
         }
-            
+
         func download(attachment: Attachment, parentKey: String?, completion: @escaping () -> Void) {
             guard let downloader = self.controllers.userControllers?.fileDownloader else {
                 completion()
                 return
             }
-            
+
             let disposeBag = DisposeBag()
-            
+
             downloader.observable
                 .observe(on: MainScheduler.instance)
                 .subscribe(onNext: { [weak self] update in
                     guard let self, update.libraryId == attachment.libraryId && update.key == attachment.key else { return }
-                    
+
                     switch update.kind {
                     case .ready:
                         completion()
                         self.downloadDisposeBag = nil
-                        
+
                     case .cancelled, .failed:
                         self.downloadDisposeBag = nil
-                        
+
                     case .progress:
                         break
                     }
                 })
                 .disposed(by: disposeBag)
-            
+
             self.downloadDisposeBag = disposeBag
             downloader.downloadIfNeeded(attachment: attachment, parentKey: parentKey)
         }
-        
+
         func open(
             attachment: Attachment,
             library: Library,
@@ -327,21 +327,21 @@ final class AppCoordinator: NSObject {
                 let url = file.createUrl()
                 let controller = detailCoordinator.createPDFController(key: attachment.key, library: library, url: url, page: page, preselectedAnnotationKey: annotation)
                 self.show(controller: controller, by: presenter, in: window, animated: animated, completion: completion)
-                
+
             default:
                 completion?()
             }
         }
     }
-    
+
     private func showAlert(title: String, message: String, actions: [UIAlertAction]) {
         let controller = UIAlertController(title: title, message: message, preferredStyle: .alert)
         actions.forEach({ controller.addAction($0) })
         self.viewController?.present(controller, animated: true, completion: nil)
     }
-    
+
     // MARK: - Helpers
-    
+
     private func debugWindowFrame(for windowSize: CGSize, xPos: CGFloat) -> CGRect {
         let yPos = windowSize.height - AppCoordinator.debugButtonSize.height - AppCoordinator.debugButtonOffset
         return CGRect(origin: CGPoint(x: xPos, y: yPos), size: AppCoordinator.debugButtonSize)
@@ -354,7 +354,7 @@ extension AppCoordinator: AppDelegateCoordinatorDelegate {
         self.tmpConnectionOptions = nil
         self.tmpSession = nil
     }
-    
+
     func didRotate(to size: CGSize) {
         guard let window = self.debugWindow else { return }
         let xPos = window.frame.minX == AppCoordinator.debugButtonOffset ? window.frame.minX : size.width - AppCoordinator.debugButtonSize.width - AppCoordinator.debugButtonOffset
@@ -372,20 +372,20 @@ extension AppCoordinator: DebugLoggingCoordinator {
     func createDebugAlertActions() -> ((Result<(String, String?, Int), DebugLogging.Error>, [URL]?, (() -> Void)?, (() -> Void)?) -> Void, (Double) -> Void) {
         var progressAlert: UIAlertController?
         var progressView: CircularProgressView?
-        
+
         let createProgressAlert: (Double) -> Void = { [weak self] progress in
             guard let self, progress > 0 && progress < 1 else { return }
-            
+
             if progressAlert == nil {
                 let (controller, progress) = createCircularProgressAlertController(title: L10n.Settings.LogAlert.progressTitle)
                 self.window?.rootViewController?.present(controller, animated: true, completion: nil)
                 progressAlert = controller
                 progressView = progress
             }
-            
+
             progressView?.progress = CGFloat(progress)
         }
-        
+
         let createCompletionAlert: (Result<(String, String?, Int), DebugLogging.Error>, [URL]?, (() -> Void)?, (() -> Void)?) -> Void = { result, logs, retry, completion in
             if let controller = progressAlert {
                 controller.presentingViewController?.dismiss(animated: true, completion: {
@@ -395,34 +395,34 @@ extension AppCoordinator: DebugLoggingCoordinator {
                 showAlert(for: result, logs: logs, retry: retry, completion: completion)
             }
         }
-        
+
         return (createCompletionAlert, createProgressAlert)
-        
+
         func createCircularProgressAlertController(title: String) -> (UIAlertController, CircularProgressView) {
             let progressView = CircularProgressView(size: 40, lineWidth: 3)
             progressView.translatesAutoresizingMaskIntoConstraints = false
-            
+
             let controller = UIAlertController(title: title, message: "\n\n\n", preferredStyle: .alert)
             controller.view.addSubview(progressView)
-            
+
             NSLayoutConstraint.activate([
                 controller.view.bottomAnchor.constraint(equalTo: progressView.bottomAnchor, constant: 20),
                 progressView.centerXAnchor.constraint(equalTo: controller.view.centerXAnchor)
             ])
-            
+
             return (controller, progressView)
         }
-        
+
         func showAlert(for result: Result<(String, String?, Int), DebugLogging.Error>, logs: [URL]?, retry: (() -> Void)?, completion: (() -> Void)?) {
             switch result {
             case .success((let debugId, let customMessage, let userId)):
                 share(debugId: debugId, customMessage: customMessage, userId: userId)
                 completion?()
-                
+
             case .failure(let error):
                 self.show(error: error, logs: logs, retry: retry, completed: completion)
             }
-            
+
             func share(debugId: String, customMessage: String?, userId: Int) {
                 var actions = [
                     UIAlertAction(title: L10n.ok, style: .cancel, handler: nil),
@@ -430,7 +430,7 @@ extension AppCoordinator: DebugLoggingCoordinator {
                         UIPasteboard.general.string = debugId
                     })
                 ]
-                
+
                 if userId > 0 {
                     let action = UIAlertAction(title: L10n.Settings.CrashAlert.exportDb, style: .default) { [weak self] _ in
                         UIPasteboard.general.string = debugId
@@ -438,32 +438,32 @@ extension AppCoordinator: DebugLoggingCoordinator {
                     }
                     actions.append(action)
                 }
-                
+
                 let message = customMessage ?? L10n.Settings.LogAlert.message(debugId)
                 self.showAlert(title: L10n.Settings.LogAlert.title, message: message, actions: actions)
             }
         }
     }
-    
+
     func show(error: DebugLogging.Error, logs: [URL]?, retry: (() -> Void)?, completed: (() -> Void)?) {
         let message: String
         switch error {
         case .start:
             message = L10n.Errors.Logging.start
-            
+
         case .contentReading, .cantCreateData:
             message = L10n.Errors.Logging.contentReading
-            
+
         case .noLogsRecorded:
             message = L10n.Errors.Logging.noLogsRecorded
-            
+
         case .upload:
             message = L10n.Errors.Logging.upload
-            
+
         case .responseParsing:
             message = L10n.Errors.Logging.responseParsing
         }
-        
+
         var actions = [UIAlertAction(title: L10n.ok, style: .cancel, handler: { _ in
             completed?()
         })]
@@ -477,33 +477,33 @@ extension AppCoordinator: DebugLoggingCoordinator {
                 presentActivityViewController(with: logs, completed: completed)
             }))
         }
-        
+
         self.showAlert(title: L10n.Errors.Logging.title, message: message, actions: actions)
-        
+
         func presentActivityViewController(with items: [Any], completed: @escaping () -> Void) {
             guard let viewController else { return }
-            
+
             let controller = UIActivityViewController(activityItems: items, applicationActivities: nil)
             controller.completionWithItemsHandler = { (_, _, _, _) in
                 completed()
             }
-            
+
             controller.popoverPresentationController?.sourceView = viewController.view
             controller.popoverPresentationController?.sourceRect = viewController.view.frame.insetBy(dx: 100, dy: 100)
             viewController.present(controller, animated: true, completion: nil)
         }
     }
-    
+
     func setDebugWindow(visible: Bool) {
         if visible {
             showDebugWindow()
         } else {
             hideDebugWindow()
         }
-        
+
         func showDebugWindow() {
             guard let window else { return }
-            
+
             // Create button
             let view = UIButton(frame: CGRect(origin: CGPoint(), size: AppCoordinator.debugButtonSize))
             view.setImage(UIImage(systemName: "square.fill"), for: .normal)
@@ -522,37 +522,37 @@ extension AppCoordinator: DebugLoggingCoordinator {
             // Show the window
             debugWindow.makeKeyAndVisible()
             self.debugWindow = debugWindow
-            
+
             let panRecognizer = UIPanGestureRecognizer(target: self, action: #selector(AppCoordinator.didPan))
             self.debugWindow?.addGestureRecognizer(panRecognizer)
         }
-        
+
         func hideDebugWindow() {
             self.debugWindow = nil
         }
     }
-    
+
     @objc private func didPan(recognizer: UIPanGestureRecognizer) {
         guard let debugWindow, let window else { return }
-        
+
         switch recognizer.state {
         case .began:
             self.originalDebugWindowFrame = debugWindow.frame
-            
+
         case .changed:
             guard let originalFrame = self.originalDebugWindowFrame else { return }
             let translation = recognizer.translation(in: window)
             debugWindow.frame = originalFrame.offsetBy(dx: translation.x, dy: translation.y)
-            
+
         case .cancelled, .ended, .failed:
             self.originalDebugWindowFrame = nil
-            
+
             let velocity = recognizer.velocity(in: window)
             let endPosLeft = velocity.x == 0 ? (debugWindow.center.x <= (window.frame.width / 2)) : (velocity.x < 0)
             let xPos = endPosLeft ? AppCoordinator.debugButtonOffset : window.frame.width - AppCoordinator.debugButtonSize.width - AppCoordinator.debugButtonOffset
             let frame = self.debugWindowFrame(for: window.frame.size, xPos: xPos)
             let viewVelocity = abs(velocity.x / (xPos - debugWindow.frame.minX))
-            
+
             UIView.animate(
                 withDuration: 0.5,
                 delay: 0,
@@ -564,15 +564,15 @@ extension AppCoordinator: DebugLoggingCoordinator {
                 },
                 completion: nil
             )
-            
+
         case .possible:
             break
-            
+
         @unknown default:
             break
         }
     }
-    
+
     @objc private func stopLogging() {
         self.controllers.debugLogging.stop()
     }
@@ -597,7 +597,7 @@ extension AppCoordinator: AppOnboardingCoordinatorDelegate {
         controller.isModalInPresentation = false
         self.window?.rootViewController?.present(controller, animated: true, completion: nil)
     }
-    
+
     func presentRegister() {
         let controller = SFSafariViewController(url: URL(string: "https://www.zotero.org/user/register?app=1")!)
         self.window?.rootViewController?.present(controller, animated: true, completion: nil)
@@ -609,7 +609,7 @@ extension AppCoordinator: AppLoginCoordinatorDelegate {
         guard let url = URL(string: "https://www.zotero.org/user/lostpassword?app=1") else { return }
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
-    
+
     func dismiss() {
         self.window?.rootViewController?.dismiss(animated: true, completion: nil)
     }
@@ -624,7 +624,7 @@ extension AppCoordinator: CrashReporterCoordinator {
                 completion()
             })
         ]
-        
+
         let userId = Defaults.shared.userId
         if userId > 0 {
             let action = UIAlertAction(title: L10n.Settings.CrashAlert.exportDb, style: .default) { [weak self] _ in
@@ -633,14 +633,14 @@ extension AppCoordinator: CrashReporterCoordinator {
             }
             actions.append(action)
         }
-        
+
         self.showAlert(title: L10n.Settings.CrashAlert.title, message: L10n.Settings.CrashAlert.message(id), actions: actions)
     }
-    
+
     private func exportDb(with userId: Int, completion: (() -> Void)?) {
         let mainUrl = Files.dbFile(for: userId).createUrl()
         let bundledUrl = Files.bundledDataDbFile.createUrl()
-        
+
         let controller = UIActivityViewController(activityItems: [mainUrl, bundledUrl], applicationActivities: nil)
         controller.modalPresentationStyle = .pageSheet
         controller.popoverPresentationController?.sourceView = self.viewController?.view
@@ -660,7 +660,7 @@ extension AppCoordinator: TranslatorsControllerCoordinatorDelegate {
             actions: [UIAlertAction(title: L10n.no, style: .cancel, handler: { _ in result(false) }), UIAlertAction(title: L10n.yes, style: .default, handler: { _ in result(true) })]
         )
     }
-    
+
     func showResetToBundleError() {
         self.showAlert(title: L10n.error, message: L10n.Errors.Translators.bundleReset, actions: [UIAlertAction(title: L10n.ok, style: .cancel, handler: nil)])
     }
@@ -671,7 +671,7 @@ extension AppCoordinator: ConflictReceiver {
         DispatchQueue.main.async {
             _resolve(conflict: conflict, completed: completed)
         }
-        
+
         func _resolve(conflict: Conflict, completed: @escaping (ConflictResolution?) -> Void) {
             switch conflict {
             case .objectsRemovedRemotely(let libraryId, let collections, let items, let searches, let tags):
@@ -689,7 +689,7 @@ extension AppCoordinator: ConflictReceiver {
                     )
                     return
                 }
-                
+
                 let handler = ActiveObjectDeletedConflictReceiverHandler(
                     collections: collections,
                     items: items,
@@ -708,31 +708,31 @@ extension AppCoordinator: ConflictReceiver {
                     )
                 }
                 controller.start(with: handler)
-                
+
             case .removedItemsHaveLocalChanges(let items, let libraryId):
                 guard let controller = self.conflictAlertQueueController else {
                     completed(.remoteDeletionOfChangedItem(libraryId: libraryId, toDelete: items.map({ $0.0 }), toRestore: []))
                     return
                 }
-                
+
                 let handler = ChangedItemsDeletedAlertQueueHandler(items: items) { toDelete, toRestore in
                     completed(.remoteDeletionOfChangedItem(libraryId: libraryId, toDelete: toDelete, toRestore: toRestore))
                 }
                 controller.start(with: handler)
-                
+
             case .groupRemoved, .groupMetadataWriteDenied, .groupFileWriteDenied:
                 presentAlert(for: conflict, completed: completed)
             }
-            
+
             func presentAlert(for conflict: Conflict, completed: @escaping (ConflictResolution?) -> Void) {
                 let (title, message, actions) = createAlert(for: conflict, completed: completed)
-                
+
                 let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
                 actions.forEach { action in
                     alert.addAction(action)
                 }
                 self.viewController?.present(alert, animated: true, completion: nil)
-                
+
                 func createAlert(for conflict: Conflict, completed: @escaping (ConflictResolution?) -> Void) -> (title: String, message: String, actions: [UIAlertAction]) {
                     switch conflict {
                     case .groupRemoved(let groupId, let groupName):
@@ -743,7 +743,7 @@ extension AppCoordinator: ConflictReceiver {
                             completed(.markGroupAsLocalOnly(groupId))
                         })]
                         return (L10n.warning, L10n.Errors.Sync.groupRemoved(groupName), actions)
-                        
+
                     case .groupMetadataWriteDenied(let groupId, let groupName):
                         let actions = [UIAlertAction(title: L10n.Errors.Sync.revertToOriginal, style: .cancel, handler: { _ in
                             completed(.revertGroupChanges(.group(groupId)))
@@ -752,10 +752,10 @@ extension AppCoordinator: ConflictReceiver {
                             completed(.keepGroupChanges(.group(groupId)))
                         })]
                         return (L10n.warning, L10n.Errors.Sync.metadataWriteDenied(groupName), actions)
-                        
+
                     case .groupFileWriteDenied(let groupId, let groupName):
                         guard let webDavController = self.controllers.userControllers?.webDavController else { return ("", "", []) }
-                        
+
                         let domainName: String
                         if !webDavController.sessionStorage.isEnabled {
                             domainName = "zotero.org"
@@ -767,7 +767,7 @@ extension AppCoordinator: ConflictReceiver {
                                 domainName = url?.host ?? ""
                             }
                         }
-                        
+
                         let actions = [UIAlertAction(title: L10n.Errors.Sync.resetGroupFiles, style: .cancel, handler: { _ in
                             completed(.revertGroupFiles(.group(groupId)))
                         }),
@@ -775,7 +775,7 @@ extension AppCoordinator: ConflictReceiver {
                             completed(.skipGroup(.group(groupId)))
                         })]
                         return (L10n.warning, L10n.Errors.Sync.fileWriteDenied(groupName, domainName), actions)
-                        
+
                     case .objectsRemovedRemotely, .removedItemsHaveLocalChanges:
                         return ("", "", [])
                     }
@@ -792,12 +792,12 @@ extension AppCoordinator: SyncRequestReceiver {
         controller.addAction(UIAlertAction(title: L10n.create, style: .default, handler: { _ in create() }))
         self.viewController?.present(controller, animated: true, completion: nil)
     }
-    
+
     func askForPermission(message: String, completed: @escaping (DebugPermissionResponse) -> Void) {
         DispatchQueue.main.async {
             _askForPermission(message: message, completed: completed)
         }
-        
+
         func _askForPermission(message: String, completed: @escaping (DebugPermissionResponse) -> Void) {
             let alert = UIAlertController(title: "Confirm action", message: message, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "Allow", style: .default, handler: { _ in

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -33,11 +33,11 @@ protocol AppLoginCoordinatorDelegate: AnyObject {
 
 final class AppCoordinator: NSObject {
     private typealias Action = (UIViewController) -> Void
-
+    
     private static let debugButtonSize = CGSize(width: 60, height: 60)
     private static let debugButtonOffset: CGFloat = 50
     private let controllers: Controllers
-
+    
     private weak var window: UIWindow?
     private var debugWindow: UIWindow?
     private var originalDebugWindowFrame: CGRect?
@@ -47,19 +47,19 @@ final class AppCoordinator: NSObject {
     private var downloadDisposeBag: DisposeBag?
     private var tmpConnectionOptions: UIScene.ConnectionOptions?
     private var tmpSession: UISceneSession?
-
+    
     private var viewController: UIViewController? {
         guard let viewController = self.window?.rootViewController else { return nil }
         let topController = viewController.topController
         return (topController as? MainViewController)?.viewControllers.last ?? topController
     }
-
+    
     init(window: UIWindow?, controllers: Controllers) {
         self.window = window
         self.controllers = controllers
         super.init()
     }
-
+    
     func start(options connectionOptions: UIScene.ConnectionOptions, session: UISceneSession) {
         if !self.controllers.sessionController.isInitialized {
             DDLogInfo("AppCoordinator: start while waiting for initialization")
@@ -70,33 +70,39 @@ final class AppCoordinator: NSObject {
             DDLogInfo("AppCoordinator: start logged \(self.controllers.sessionController.isLoggedIn ? "in" : "out")")
             self.showMainScreen(isLogged: self.controllers.sessionController.isLoggedIn, options: connectionOptions, session: session, animated: false)
         }
-
+        
         // If db needs to be wiped and this is the first start of the app, show beta alert
         if self.controllers.userControllers?.dbStorage.willPerformBetaWipe == true && self.controllers.sessionController.isLoggedIn {
             DDLogInfo("AppCoordinator: show beta alert")
-            self.showBetaAlert()
+            showBetaAlert()
         }
-
+        
         if self.controllers.sessionController.isInitialized && self.controllers.debugLogging.isEnabled {
             DDLogInfo("AppCoordinator: show debug window")
             self.setDebugWindow(visible: true)
         }
-
+        
         self.controllers.debugLogging.coordinator = self
         self.controllers.crashReporter.coordinator = self
         self.controllers.translatorsAndStylesController.coordinator = self
+        
+        func showBetaAlert() {
+            let controller = UIAlertController(title: L10n.betaWipeTitle, message: L10n.betaWipeMessage, preferredStyle: .alert)
+            controller.addAction(UIAlertAction(title: L10n.ok, style: .cancel, handler: nil))
+            self.window?.rootViewController?.present(controller, animated: true, completion: nil)
+        }
     }
-
+    
     // MARK: - Navigation
-
+    
     private func showLaunchScreen() {
         guard let controller = UIStoryboard(name: "LaunchScreen", bundle: nil).instantiateInitialViewController() else { return }
         self.window?.rootViewController = controller
     }
-
+    
     private func showMainScreen(isLogged: Bool, options connectionOptions: UIScene.ConnectionOptions?, session: UISceneSession?, animated: Bool) {
-        guard let window = self.window else { return }
-
+        guard let window else { return }
+        
         let viewController: UIViewController
         var urlContext: UIOpenURLContext?
         var data: RestoredStateData?
@@ -104,7 +110,7 @@ final class AppCoordinator: NSObject {
             let controller = OnboardingViewController(size: window.frame.size, htmlConverter: self.controllers.htmlAttributedStringConverter)
             controller.coordinatorDelegate = self
             viewController = controller
-
+            
             self.conflictReceiverAlertController = nil
             self.conflictAlertQueueController = nil
             self.controllers.userControllers?.syncScheduler.syncController.set(coordinator: nil)
@@ -112,56 +118,67 @@ final class AppCoordinator: NSObject {
             (urlContext, data) = preprocess(connectionOptions: connectionOptions, session: session)
             let controller = MainViewController(controllers: self.controllers)
             viewController = controller
-
+            
             self.conflictReceiverAlertController = ConflictReceiverAlertController(viewController: controller)
             self.conflictAlertQueueController = ConflictAlertQueueController(viewController: controller)
             self.controllers.userControllers?.syncScheduler.syncController.set(coordinator: self)
         }
-
+        
         DDLogInfo("AppCoordinator: show main screen logged \(isLogged ? "in" : "out"); animated=\(animated)")
-        show(viewController: viewController, in: window, animated: animated) { [weak self] in
-            self?.process(urlContext: urlContext, data: data)
+        show(viewController: viewController, in: window, animated: animated) {
+            process(urlContext: urlContext, data: data)
         }
-    }
-
-    private func preprocess(connectionOptions: UIScene.ConnectionOptions?, session: UISceneSession?) -> (UIOpenURLContext?, RestoredStateData?) {
-        let urlContext = connectionOptions?.urlContexts.first
-        let userActivity = connectionOptions?.userActivities.first ?? session?.stateRestorationActivity
-        let data = userActivity?.restoredStateData
-        if let data {
-            // If scene had state stored, check if defaults need to be updated first
-            DDLogInfo("AppCoordinator: Preprocessing restored state - \(data)")
-            Defaults.shared.selectedLibrary = data.libraryId
-            Defaults.shared.selectedCollectionId = data.collectionId
-        }
-        return (urlContext, data)
-    }
-    
-    private func process(urlContext: UIOpenURLContext?, data: RestoredStateData?) {
-        if let urlContext, let urlController = self.controllers.userControllers?.customUrlController {
-            // If scene was started from custom URL
-            let sourceApp = urlContext.options.sourceApplication ?? "unknown"
-            DDLogInfo("AppCoordinator: App launched by \(urlContext.url.absoluteString) from \(sourceApp)")
-
-            if let kind = urlController.process(url: urlContext.url) {
-                self.show(customUrl: kind, animated: false)
+        
+        func show(viewController: UIViewController?, in window: UIWindow, animated: Bool = false, completion: @escaping () -> Void) {
+            window.rootViewController = viewController
+            
+            guard animated else {
+                completion()
                 return
             }
+            
+            UIView.transition(with: window, duration: 0.2, options: .transitionCrossDissolve, animations: {}, completion: { _ in completion() })
         }
-
-        if let data {
-            DDLogInfo("AppCoordinator: Processing restored state - \(data)")
-            // If scene had state stored, restore state
-            self.showRestoredState(for: data)
+        
+        func preprocess(connectionOptions: UIScene.ConnectionOptions?, session: UISceneSession?) -> (UIOpenURLContext?, RestoredStateData?) {
+            let urlContext = connectionOptions?.urlContexts.first
+            let userActivity = connectionOptions?.userActivities.first ?? session?.stateRestorationActivity
+            let data = userActivity?.restoredStateData
+            if let data {
+                // If scene had state stored, check if defaults need to be updated first
+                DDLogInfo("AppCoordinator: Preprocessing restored state - \(data)")
+                Defaults.shared.selectedLibrary = data.libraryId
+                Defaults.shared.selectedCollectionId = data.collectionId
+            }
+            return (urlContext, data)
+        }
+        
+        func process(urlContext: UIOpenURLContext?, data: RestoredStateData?) {
+            if let urlContext, let urlController = self.controllers.userControllers?.customUrlController {
+                // If scene was started from custom URL
+                let sourceApp = urlContext.options.sourceApplication ?? "unknown"
+                DDLogInfo("AppCoordinator: App launched by \(urlContext.url.absoluteString) from \(sourceApp)")
+                
+                if let kind = urlController.process(url: urlContext.url) {
+                    self.show(customUrl: kind, animated: false)
+                    return
+                }
+            }
+            
+            if let data {
+                DDLogInfo("AppCoordinator: Processing restored state - \(data)")
+                // If scene had state stored, restore state
+                self.showRestoredState(for: data)
+            }
         }
     }
-
+    
     func show(customUrl: CustomURLController.Kind, animated: Bool) {
         switch customUrl {
         case .itemDetail(let key, let library, let preselectedChildKey):
             DDLogInfo("AppCoordinator: show custom url - item detail; key=\(key); library=\(library.identifier)")
-            self.showItemDetail(key: key, library: library, selectChildKey: preselectedChildKey, animated: animated)
-
+            showItemDetail(key: key, library: library, selectChildKey: preselectedChildKey, animated: animated)
+            
         case .pdfReader(let attachment, let library, let page, let annotation, let parentKey, let isAvailable):
             let message = DDLogMessageFormat(
                 stringLiteral:
@@ -170,76 +187,105 @@ final class AppCoordinator: NSObject {
             )
             DDLogInfo(message)
             if isAvailable {
-                self.open(attachment: attachment, library: library, on: page, annotation: annotation, parentKey: parentKey, animated: animated)
+                open(attachment: attachment, library: library, on: page, annotation: annotation, parentKey: parentKey, animated: animated)
                 return
             }
-
-            guard let window = self.window, let mainController = window.rootViewController as? MainViewController else { return }
-
+            
+            guard let window, let mainController = window.rootViewController as? MainViewController else { return }
+            
             mainController.getDetailCoordinator { [weak self] coordinator in
-                guard let self = self else { return }
-                self.showItemDetail(key: (parentKey ?? attachment.key), library: library, selectChildKey: attachment.key, animated: animated)
-                self.download(attachment: attachment, parentKey: parentKey) { [weak self] in
-                    self?._open(attachment: attachment, library: library, on: page, annotation: annotation, window: window, detailCoordinator: coordinator, animated: true)
+                guard let self else { return }
+                showItemDetail(key: (parentKey ?? attachment.key), library: library, selectChildKey: attachment.key, animated: animated)
+                download(attachment: attachment, parentKey: parentKey) {
+                    _open(attachment: attachment, library: library, on: page, annotation: annotation, window: window, detailCoordinator: coordinator, animated: true)
                 }
             }
         }
-    }
-
-    private func showItemDetail(key: String, library: Library, selectChildKey childKey: String?, animated: Bool) {
-        // Dismiss presented screen if any visible
-        if let mainController = self.window?.rootViewController as? MainViewController, mainController.presentedViewController != nil {
-            self._showItemDetail(key: key, library: library, selectChildKey: childKey, animated: false)
-            mainController.dismiss(animated: animated)
-        } else {
-            self._showItemDetail(key: key, library: library, selectChildKey: childKey, animated: animated)
+        
+        func showItemDetail(key: String, library: Library, selectChildKey childKey: String?, animated: Bool) {
+            // Dismiss presented screen if any visible
+            if let mainController = self.window?.rootViewController as? MainViewController, mainController.presentedViewController != nil {
+                _showItemDetail(key: key, library: library, selectChildKey: childKey, animated: false)
+                mainController.dismiss(animated: animated)
+            } else {
+                _showItemDetail(key: key, library: library, selectChildKey: childKey, animated: animated)
+            }
         }
-    }
-
-    private func _showItemDetail(key: String, library: Library, selectChildKey childKey: String?, animated: Bool) {
-        guard let mainController = self.window?.rootViewController as? MainViewController else { return }
-
-        // Show "All" collection in given library/group
-        if mainController.masterCoordinator?.visibleLibraryId != library.identifier ||
-           (mainController.masterCoordinator?.navigationController?.visibleViewController as? CollectionsViewController)?.selectedIdentifier != .custom(.all) {
-            mainController.masterCoordinator?.showCollections(for: library.identifier, preselectedCollection: .custom(.all), animated: animated)
+        
+        func open(attachment: Attachment, library: Library, on page: Int?, annotation: String?, parentKey: String?, animated: Bool) {
+            guard let window, let mainController = window.rootViewController as? MainViewController else { return }
+            
+            mainController.getDetailCoordinator { coordinator in
+                guard (coordinator.navigationController?.presentedViewController as? PDFReaderViewController)?.key != attachment.key else { return }
+                _open(attachment: attachment, library: library, on: page, annotation: annotation, window: window, detailCoordinator: coordinator, animated: animated) {
+                    _showItemDetail(key: (parentKey ?? attachment.key), library: library, selectChildKey: attachment.key, animated: animated)
+                }
+            }
         }
-
-        // Show item detail of given key
-        mainController.getDetailCoordinator { coordinator in
-            if (coordinator.navigationController?.visibleViewController as? ItemDetailViewController)?.key != key {
-                coordinator.showItemDetail(for: .preview(key: key), library: library, scrolledToKey: childKey, animated: animated)
+        
+        func download(attachment: Attachment, parentKey: String?, completion: @escaping () -> Void) {
+            guard let downloader = self.controllers.userControllers?.fileDownloader else {
+                completion()
+                return
+            }
+            
+            let disposeBag = DisposeBag()
+            
+            downloader.observable
+                .observe(on: MainScheduler.instance)
+                .subscribe(onNext: { [weak self] update in
+                    guard let self, update.libraryId == attachment.libraryId && update.key == attachment.key else { return }
+                    
+                    switch update.kind {
+                    case .ready:
+                        completion()
+                        self.downloadDisposeBag = nil
+                        
+                    case .cancelled, .failed:
+                        self.downloadDisposeBag = nil
+                    case .progress: break
+                    }
+                })
+                .disposed(by: disposeBag)
+            
+            self.downloadDisposeBag = disposeBag
+            downloader.downloadIfNeeded(attachment: attachment, parentKey: parentKey)
+        }
+        
+        func _showItemDetail(key: String, library: Library, selectChildKey childKey: String?, animated: Bool) {
+            guard let mainController = self.window?.rootViewController as? MainViewController else { return }
+            
+            // Show "All" collection in given library/group
+            if mainController.masterCoordinator?.visibleLibraryId != library.identifier ||
+                (mainController.masterCoordinator?.navigationController?.visibleViewController as? CollectionsViewController)?.selectedIdentifier != .custom(.all) {
+                mainController.masterCoordinator?.showCollections(for: library.identifier, preselectedCollection: .custom(.all), animated: animated)
+            }
+            
+            // Show item detail of given key
+            mainController.getDetailCoordinator { coordinator in
+                if (coordinator.navigationController?.visibleViewController as? ItemDetailViewController)?.key != key {
+                    coordinator.showItemDetail(for: .preview(key: key), library: library, scrolledToKey: childKey, animated: animated)
+                }
+            }
+        }
+        
+        func _open(attachment: Attachment, library: Library, on page: Int?, annotation: String?, window: UIWindow, detailCoordinator: DetailCoordinator, animated: Bool, completion: (() -> Void)? = nil) {
+            switch attachment.type {
+            case .file(let filename, let contentType, _, _) where contentType == "application/pdf":
+                let file = Files.attachmentFile(in: library.identifier, key: attachment.key, filename: filename, contentType: contentType)
+                let url = file.createUrl()
+                let controller = self.pdfController(key: attachment.key, library: library, url: url, page: page, preselectedAnnotationKey: annotation, detailCoordinator: detailCoordinator)
+                self.show(pdfController: controller, in: window, animated: animated, completion: completion)
+                
+            default:
+                completion?()
             }
         }
     }
-
-    private func open(attachment: Attachment, library: Library, on page: Int?, annotation: String?, parentKey: String?, animated: Bool) {
-        guard let window = self.window, let mainController = window.rootViewController as? MainViewController else { return }
-
-        mainController.getDetailCoordinator { [weak self] coordinator in
-            guard let self = self, (coordinator.navigationController?.presentedViewController as? PDFReaderViewController)?.key != attachment.key else { return }
-            self._open(attachment: attachment, library: library, on: page, annotation: annotation, window: window, detailCoordinator: coordinator, animated: animated) {
-                self._showItemDetail(key: (parentKey ?? attachment.key), library: library, selectChildKey: attachment.key, animated: animated)
-            }
-        }
-    }
-
-    private func _open(attachment: Attachment, library: Library, on page: Int?, annotation: String?, window: UIWindow, detailCoordinator: DetailCoordinator, animated: Bool, completion: (() -> Void)? = nil) {
-        switch attachment.type {
-        case .file(let filename, let contentType, _, _) where contentType == "application/pdf":
-            let file = Files.attachmentFile(in: library.identifier, key: attachment.key, filename: filename, contentType: contentType)
-            let url = file.createUrl()
-            let controller = self.pdfController(key: attachment.key, library: library, url: url, page: page, preselectedAnnotationKey: annotation, detailCoordinator: detailCoordinator)
-            self.show(pdfController: controller, in: window, animated: animated, completion: completion)
-
-        default:
-            completion?()
-        }
-    }
-
+    
     private func showRestoredState(for data: RestoredStateData) {
         guard let mainController = self.window?.rootViewController as? MainViewController,
-              let (url, library, collection) = self.loadRestoredStateData(forKey: data.key, libraryId: data.libraryId, collectionId: data.collectionId) else { return }
+              let (url, library, collection) = loadRestoredStateData(forKey: data.key, libraryId: data.libraryId, collectionId: data.collectionId) else { return }
         if let collection {
             DDLogInfo("AppCoordinator: show restored state - \(data.key); \(data.libraryId); \(data.collectionId); \(url.relativePath)")
             mainController.showItems(for: collection, in: library, saveCollectionToDefaults: true)
@@ -249,76 +295,84 @@ final class AppCoordinator: NSObject {
             let collection = Collection(custom: .all)
             mainController.showItems(for: collection, in: library, saveCollectionToDefaults: false)
         }
-            
+        
         mainController.getDetailCoordinator { [weak self] coordinator in
-            guard let self = self, let window = self.window else { return }
+            guard let self, let window else { return }
             let controller = self.pdfController(key: data.key, library: library, url: url, page: nil, preselectedAnnotationKey: nil, detailCoordinator: coordinator)
             self.show(pdfController: controller, in: window, animated: false)
         }
+        
+        func loadRestoredStateData(forKey key: String, libraryId: LibraryIdentifier, collectionId: CollectionIdentifier) -> (URL, Library, Collection?)? {
+            guard let dbStorage = self.controllers.userControllers?.dbStorage else { return nil }
+            
+            var url: URL?
+            var library: Library?
+            var collection: Collection?
+            
+            do {
+                try dbStorage.perform(on: .main, with: { coordinator in
+                    let item = try coordinator.perform(request: ReadItemDbRequest(libraryId: libraryId, key: key))
+                    
+                    guard let attachment = AttachmentCreator.attachment(for: item, fileStorage: self.controllers.fileStorage, urlDetector: nil) else { return }
+                    
+                    switch attachment.type {
+                    case .file(let filename, let contentType, let location, _):
+                        switch location {
+                        case .local, .localAndChangedRemotely:
+                            let file = Files.attachmentFile(in: libraryId, key: key, filename: filename, contentType: contentType)
+                            url = file.createUrl()
+                            let (_collection, _library) = try coordinator.perform(request: ReadCollectionAndLibraryDbRequest(collectionId: collectionId, libraryId: libraryId))
+                            collection = _collection
+                            library = _library
+                            
+                        case .remote, .remoteMissing: break
+                        }
+                        
+                    default: break
+                    }
+                })
+            } catch let error {
+                DDLogError("AppCoordinator: can't load restored data - \(error)")
+                return nil
+            }
+            
+            if let url = url, let library = library {
+                return (url, library, collection)
+            }
+            return nil
+        }
     }
-
+    
     private func pdfController(key: String, library: Library, url: URL, page: Int?, preselectedAnnotationKey: String?, detailCoordinator: DetailCoordinator) -> UINavigationController {
         let navigationController = NavigationViewController()
         navigationController.modalPresentationStyle = .fullScreen
-
-        let coordinator = PDFCoordinator(key: key, library: library, url: url, page: page, preselectedAnnotationKey: preselectedAnnotationKey, navigationController: navigationController, controllers: self.controllers)
+        
+        let coordinator = PDFCoordinator(
+            key: key,
+            library: library,
+            url: url,
+            page: page,
+            preselectedAnnotationKey: preselectedAnnotationKey,
+            navigationController: navigationController,
+            controllers: controllers
+        )
         coordinator.parentCoordinator = detailCoordinator
         detailCoordinator.childCoordinators.append(coordinator)
         coordinator.start(animated: false)
-
+        
         return navigationController
     }
-
-    private func loadRestoredStateData(forKey key: String, libraryId: LibraryIdentifier, collectionId: CollectionIdentifier) -> (URL, Library, Collection?)? {
-        guard let dbStorage = self.controllers.userControllers?.dbStorage else { return nil }
-
-        var url: URL?
-        var library: Library?
-        var collection: Collection?
-
-        do {
-            try dbStorage.perform(on: .main, with: { coordinator in
-                let item = try coordinator.perform(request: ReadItemDbRequest(libraryId: libraryId, key: key))
-
-                guard let attachment = AttachmentCreator.attachment(for: item, fileStorage: self.controllers.fileStorage, urlDetector: nil) else { return }
-
-                switch attachment.type {
-                case .file(let filename, let contentType, let location, _):
-                    switch location {
-                    case .local, .localAndChangedRemotely:
-                        let file = Files.attachmentFile(in: libraryId, key: key, filename: filename, contentType: contentType)
-                        url = file.createUrl()
-                        let (_collection, _library) = try coordinator.perform(request: ReadCollectionAndLibraryDbRequest(collectionId: collectionId, libraryId: libraryId))
-                        collection = _collection
-                        library = _library
-
-                    case .remote, .remoteMissing: break
-                    }
-
-                default: break
-                }
-            })
-        } catch let error {
-            DDLogError("AppCoordinator: can't load restored data - \(error)")
-            return nil
-        }
-
-        if let url = url, let library = library {
-            return (url, library, collection)
-        }
-        return nil
-    }
-
+    
     private func show(pdfController: UIViewController, in window: UIWindow, animated: Bool, completion: (() -> Void)? = nil) {
         DDLogInfo("AppCoordinator: show pdf controller; animated=\(animated)")
-
+        
         if animated {
             if window.rootViewController?.presentedViewController == nil {
                 DDLogInfo("AppCoordinator: no presented controller, present pdf controller")
                 window.rootViewController?.present(pdfController, animated: true, completion: completion)
                 return
             }
-
+            
             DDLogInfo("AppCoordinator: previously presented controller, dismiss")
             window.rootViewController?.dismiss(animated: true, completion: {
                 DDLogInfo("AppCoordinator: present pdf controller")
@@ -326,133 +380,76 @@ final class AppCoordinator: NSObject {
             })
             return
         }
-
-        self.show(presentedViewController: pdfController, in: window) { viewController, completion in
+        
+        show(presentedViewController: pdfController, in: window) { viewController, completion in
             // Open PDF reader of given attachment
             if viewController.presentedViewController == nil {
                 DDLogInfo("AppCoordinator: no presented controller, present pdf controller")
                 viewController.present(pdfController, animated: false, completion: completion)
                 return
             }
-
+            
             DDLogInfo("AppCoordinator: previously presented controller, dismiss")
             viewController.dismiss(animated: false, completion: {
                 DDLogInfo("AppCoordinator: present pdf controller")
                 viewController.present(pdfController, animated: false, completion: completion)
             })
         }
-
+        
         completion?()
-    }
-
-    /// If the app tries to present a `UIViewController` on a `UIWindow` that is being shown after app launches, there is a small delay where the underlying (presenting) `UIViewController` is visible.
-    /// So the launch animation looks bad, since you can see a snapshot of previous state (PDF reader), then split view controller with collections and items and then PDF reader again. Because of that
-    /// we fake it a little with this function.
-    private func show(presentedViewController: UIViewController, in window: UIWindow, presentAction: (UIViewController, @escaping () -> Void) -> Void) {
-        // Store original `UIViewController`
-        guard let oldController = window.rootViewController else { return }
-
-        // Show new view controller in the window so that it's layed out properly
-        window.rootViewController = presentedViewController
-
-        // Make a screenshot of the window
-        UIGraphicsBeginImageContext(window.frame.size)
-        window.layer.render(in: UIGraphicsGetCurrentContext()!)
-        let image = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-
-        // Create a temporary `UIImageView` with given screenshot
-        let imageView = UIImageView(image: image)
-        imageView.contentMode = .scaleAspectFill
-        imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        imageView.frame = window.bounds
-
-        // Create a temporary `UIWindow` which will be shown above current window until it successfully presents the new view controller.
-        let tmpWindow = UIWindow(frame: window.frame)
-        tmpWindow.windowScene = window.windowScene
-        tmpWindow.addSubview(imageView)
-        tmpWindow.makeKeyAndVisible()
-        self.presentedRestoredControllerWindow = tmpWindow
-
-        window.rootViewController = oldController
-
-        presentAction(oldController, {
-            // New window is visible with a screenshot, return old view controller and present the new one
+        
+        /// If the app tries to present a `UIViewController` on a `UIWindow` that is being shown after app launches,
+        /// there is a small delay where the underlying (presenting) `UIViewController` is visible.
+        /// So the launch animation looks bad, since you can see a snapshot of previous state (PDF reader),
+        /// then split view controller with collections and items and then PDF reader again.
+        /// Because of that we fake it a little with this function.
+        func show(presentedViewController: UIViewController, in window: UIWindow, presentAction: (UIViewController, @escaping () -> Void) -> Void) {
+            // Store original `UIViewController`
+            guard let oldController = window.rootViewController else { return }
+            
+            // Show new view controller in the window so that it's layed out properly
+            window.rootViewController = presentedViewController
+            
+            // Make a screenshot of the window
+            UIGraphicsBeginImageContext(window.frame.size)
+            window.layer.render(in: UIGraphicsGetCurrentContext()!)
+            let image = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+            
+            // Create a temporary `UIImageView` with given screenshot
+            let imageView = UIImageView(image: image)
+            imageView.contentMode = .scaleAspectFill
+            imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            imageView.frame = window.bounds
+            
+            // Create a temporary `UIWindow` which will be shown above current window until it successfully presents the new view controller.
+            let tmpWindow = UIWindow(frame: window.frame)
+            tmpWindow.windowScene = window.windowScene
+            tmpWindow.addSubview(imageView)
+            tmpWindow.makeKeyAndVisible()
+            self.presentedRestoredControllerWindow = tmpWindow
+            
             window.rootViewController = oldController
-            self.presentedRestoredControllerWindow = nil
-        })
-    }
-
-    private func showBetaAlert() {
-        let controller = UIAlertController(title: L10n.betaWipeTitle, message: L10n.betaWipeMessage, preferredStyle: .alert)
-        controller.addAction(UIAlertAction(title: L10n.ok, style: .cancel, handler: nil))
-        self.window?.rootViewController?.present(controller, animated: true, completion: nil)
-    }
-
-    private func show(viewController: UIViewController?, in window: UIWindow, animated: Bool = false, completion: @escaping () -> Void) {
-        window.rootViewController = viewController
-
-        guard animated else {
-            completion()
-            return
+            
+            presentAction(oldController) {
+                // New window is visible with a screenshot, return old view controller and present the new one
+                window.rootViewController = oldController
+                self.presentedRestoredControllerWindow = nil
+            }
         }
-
-        UIView.transition(with: window, duration: 0.2, options: .transitionCrossDissolve, animations: {}, completion: { _ in completion() })
     }
-
-    private func presentActivityViewController(with items: [Any], completed: @escaping () -> Void) {
-        guard let viewController = self.viewController else { return }
-
-        let controller = UIActivityViewController(activityItems: items, applicationActivities: nil)
-        controller.completionWithItemsHandler = { (_, _, _, _) in
-            completed()
-        }
-
-        controller.popoverPresentationController?.sourceView = viewController.view
-        controller.popoverPresentationController?.sourceRect = viewController.view.frame.insetBy(dx: 100, dy: 100)
-        viewController.present(controller, animated: true, completion: nil)
-    }
-
+    
     private func showAlert(title: String, message: String, actions: [UIAlertAction]) {
         let controller = UIAlertController(title: title, message: message, preferredStyle: .alert)
         actions.forEach({ controller.addAction($0) })
         self.viewController?.present(controller, animated: true, completion: nil)
     }
-
+    
     // MARK: - Helpers
-
+    
     private func debugWindowFrame(for windowSize: CGSize, xPos: CGFloat) -> CGRect {
         let yPos = windowSize.height - AppCoordinator.debugButtonSize.height - AppCoordinator.debugButtonOffset
         return CGRect(origin: CGPoint(x: xPos, y: yPos), size: AppCoordinator.debugButtonSize)
-    }
-
-    private func download(attachment: Attachment, parentKey: String?, completion: @escaping () -> Void) {
-        guard let downloader = self.controllers.userControllers?.fileDownloader else {
-            completion()
-            return
-        }
-
-        let disposeBag = DisposeBag()
-
-        downloader.observable
-                  .observe(on: MainScheduler.instance)
-                  .subscribe(onNext: { [weak self] update in
-                      guard let self = self, update.libraryId == attachment.libraryId && update.key == attachment.key else { return }
-
-                      switch update.kind {
-                      case .ready:
-                          completion()
-                          self.downloadDisposeBag = nil
-
-                      case .cancelled, .failed:
-                          self.downloadDisposeBag = nil
-                      case .progress: break
-                      }
-                  })
-                  .disposed(by: disposeBag)
-
-        self.downloadDisposeBag = disposeBag
-        downloader.downloadIfNeeded(attachment: attachment, parentKey: parentKey)
     }
 }
 
@@ -462,7 +459,7 @@ extension AppCoordinator: AppDelegateCoordinatorDelegate {
         self.tmpConnectionOptions = nil
         self.tmpSession = nil
     }
-
+    
     func didRotate(to size: CGSize) {
         guard let window = self.debugWindow else { return }
         let xPos = window.frame.minX == AppCoordinator.debugButtonOffset ? window.frame.minX : size.width - AppCoordinator.debugButtonSize.width - AppCoordinator.debugButtonOffset
@@ -480,96 +477,98 @@ extension AppCoordinator: DebugLoggingCoordinator {
     func createDebugAlertActions() -> ((Result<(String, String?, Int), DebugLogging.Error>, [URL]?, (() -> Void)?, (() -> Void)?) -> Void, (Double) -> Void) {
         var progressAlert: UIAlertController?
         var progressView: CircularProgressView?
-
+        
         let createProgressAlert: (Double) -> Void = { [weak self] progress in
-            guard let self = self, progress > 0 && progress < 1 else { return }
-
+            guard let self, progress > 0 && progress < 1 else { return }
+            
             if progressAlert == nil {
-                let (controller, progress) = self.createCircularProgressAlertController(title: L10n.Settings.LogAlert.progressTitle)
+                let (controller, progress) = createCircularProgressAlertController(title: L10n.Settings.LogAlert.progressTitle)
                 self.window?.rootViewController?.present(controller, animated: true, completion: nil)
                 progressAlert = controller
                 progressView = progress
             }
-
+            
             progressView?.progress = CGFloat(progress)
         }
-
-        let createCompletionAlert: (Result<(String, String?, Int), DebugLogging.Error>, [URL]?, (() -> Void)?, (() -> Void)?) -> Void = { [weak self] result, logs, retry, completion in
+        
+        let createCompletionAlert: (Result<(String, String?, Int), DebugLogging.Error>, [URL]?, (() -> Void)?, (() -> Void)?) -> Void = { result, logs, retry, completion in
             if let controller = progressAlert {
                 controller.presentingViewController?.dismiss(animated: true, completion: {
-                    self?.showAlert(for: result, logs: logs, retry: retry, completion: completion)
+                    showAlert(for: result, logs: logs, retry: retry, completion: completion)
                 })
             } else {
-                self?.showAlert(for: result, logs: logs, retry: retry, completion: completion)
+                showAlert(for: result, logs: logs, retry: retry, completion: completion)
             }
         }
-
+        
         return (createCompletionAlert, createProgressAlert)
-    }
-
-    private func createCircularProgressAlertController(title: String) -> (UIAlertController, CircularProgressView) {
-        let progressView = CircularProgressView(size: 40, lineWidth: 3)
-        progressView.translatesAutoresizingMaskIntoConstraints = false
-
-        let controller = UIAlertController(title: title, message: "\n\n\n", preferredStyle: .alert)
-        controller.view.addSubview(progressView)
-
-        NSLayoutConstraint.activate([
-            controller.view.bottomAnchor.constraint(equalTo: progressView.bottomAnchor, constant: 20),
-            progressView.centerXAnchor.constraint(equalTo: controller.view.centerXAnchor)
-        ])
-
-        return (controller, progressView)
-    }
-
-    private func showAlert(for result: Result<(String, String?, Int), DebugLogging.Error>, logs: [URL]?, retry: (() -> Void)?, completion: (() -> Void)?) {
-        switch result {
-        case .success((let debugId, let customMessage, let userId)):
-            self.share(debugId: debugId, customMessage: customMessage, userId: userId)
-            completion?()
-
-        case .failure(let error):
-            self.show(error: error, logs: logs, retry: retry, completed: completion)
+        
+        func createCircularProgressAlertController(title: String) -> (UIAlertController, CircularProgressView) {
+            let progressView = CircularProgressView(size: 40, lineWidth: 3)
+            progressView.translatesAutoresizingMaskIntoConstraints = false
+            
+            let controller = UIAlertController(title: title, message: "\n\n\n", preferredStyle: .alert)
+            controller.view.addSubview(progressView)
+            
+            NSLayoutConstraint.activate([
+                controller.view.bottomAnchor.constraint(equalTo: progressView.bottomAnchor, constant: 20),
+                progressView.centerXAnchor.constraint(equalTo: controller.view.centerXAnchor)
+            ])
+            
+            return (controller, progressView)
         }
-    }
-
-    private func share(debugId: String, customMessage: String?, userId: Int) {
-        var actions = [UIAlertAction(title: L10n.ok, style: .cancel, handler: nil),
-                       UIAlertAction(title: L10n.copy, style: .default, handler: { _ in
-                          UIPasteboard.general.string = debugId
-                       })]
-
-        if userId > 0 {
-            let action = UIAlertAction(title: L10n.Settings.CrashAlert.exportDb, style: .default) { [weak self] _ in
-                UIPasteboard.general.string = debugId
-                self?.exportDb(with: userId, completion: nil)
+        
+        func showAlert(for result: Result<(String, String?, Int), DebugLogging.Error>, logs: [URL]?, retry: (() -> Void)?, completion: (() -> Void)?) {
+            switch result {
+            case .success((let debugId, let customMessage, let userId)):
+                share(debugId: debugId, customMessage: customMessage, userId: userId)
+                completion?()
+                
+            case .failure(let error):
+                self.show(error: error, logs: logs, retry: retry, completed: completion)
             }
-            actions.append(action)
+            
+            func share(debugId: String, customMessage: String?, userId: Int) {
+                var actions = [
+                    UIAlertAction(title: L10n.ok, style: .cancel, handler: nil),
+                    UIAlertAction(title: L10n.copy, style: .default, handler: { _ in
+                        UIPasteboard.general.string = debugId
+                    })
+                ]
+                
+                if userId > 0 {
+                    let action = UIAlertAction(title: L10n.Settings.CrashAlert.exportDb, style: .default) { [weak self] _ in
+                        UIPasteboard.general.string = debugId
+                        self?.exportDb(with: userId, completion: nil)
+                    }
+                    actions.append(action)
+                }
+                
+                let message = customMessage ?? L10n.Settings.LogAlert.message(debugId)
+                self.showAlert(title: L10n.Settings.LogAlert.title, message: message, actions: actions)
+            }
         }
-
-        let message = customMessage ?? L10n.Settings.LogAlert.message(debugId)
-        self.showAlert(title: L10n.Settings.LogAlert.title, message: message, actions: actions)
     }
-
+    
     func show(error: DebugLogging.Error, logs: [URL]?, retry: (() -> Void)?, completed: (() -> Void)?) {
         let message: String
         switch error {
         case .start:
             message = L10n.Errors.Logging.start
-
+            
         case .contentReading, .cantCreateData:
             message = L10n.Errors.Logging.contentReading
-
+            
         case .noLogsRecorded:
             message = L10n.Errors.Logging.noLogsRecorded
-
+            
         case .upload:
             message = L10n.Errors.Logging.upload
-
+            
         case .responseParsing:
             message = L10n.Errors.Logging.responseParsing
         }
-
+        
         var actions = [UIAlertAction(title: L10n.ok, style: .cancel, handler: { _ in
             completed?()
         })]
@@ -579,88 +578,117 @@ extension AppCoordinator: DebugLoggingCoordinator {
             }))
         }
         if let logs = logs, let completed = completed {
-            actions.append(UIAlertAction(title: L10n.Settings.sendManually, style: .default, handler: { [weak self] _ in
-                self?.presentActivityViewController(with: logs, completed: completed)
+            actions.append(UIAlertAction(title: L10n.Settings.sendManually, style: .default, handler: { _ in
+                presentActivityViewController(with: logs, completed: completed)
             }))
         }
-
+        
         self.showAlert(title: L10n.Errors.Logging.title, message: message, actions: actions)
-    }
-
-    func setDebugWindow(visible: Bool) {
-        if visible {
-            self.showDebugWindow()
-        } else {
-            self.hideDebugWindow()
+        
+        func presentActivityViewController(with items: [Any], completed: @escaping () -> Void) {
+            guard let viewController else { return }
+            
+            let controller = UIActivityViewController(activityItems: items, applicationActivities: nil)
+            controller.completionWithItemsHandler = { (_, _, _, _) in
+                completed()
+            }
+            
+            controller.popoverPresentationController?.sourceView = viewController.view
+            controller.popoverPresentationController?.sourceRect = viewController.view.frame.insetBy(dx: 100, dy: 100)
+            viewController.present(controller, animated: true, completion: nil)
         }
     }
-
-    private func showDebugWindow() {
-        guard let window = self.window else { return }
-
-        // Create button
-        let view = UIButton(frame: CGRect(origin: CGPoint(), size: AppCoordinator.debugButtonSize))
-        view.setImage(UIImage(systemName: "square.fill"), for: .normal)
-        view.addTarget(self, action: #selector(AppCoordinator.stopLogging), for: .touchUpInside)
-        view.tintColor = .white
-        view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        view.backgroundColor = Asset.Colors.zoteroBlueWithDarkMode.color
-        view.layer.cornerRadius = AppCoordinator.debugButtonSize.height / 2
-        view.layer.masksToBounds = true
-        // Create window with button
-        let debugWindow = UIWindow()
-        debugWindow.backgroundColor = .clear
-        debugWindow.windowScene = window.windowScene
-        debugWindow.frame = self.debugWindowFrame(for: window.frame.size, xPos: AppCoordinator.debugButtonOffset)
-        debugWindow.addSubview(view)
-        // Show the window
-        debugWindow.makeKeyAndVisible()
-        self.debugWindow = debugWindow
-
-        let panRecognizer = UIPanGestureRecognizer(target: self, action: #selector(AppCoordinator.didPan))
-        self.debugWindow?.addGestureRecognizer(panRecognizer)
+    
+    func setDebugWindow(visible: Bool) {
+        if visible {
+            showDebugWindow()
+        } else {
+            hideDebugWindow()
+        }
+        
+        func showDebugWindow() {
+            guard let window else { return }
+            
+            // Create button
+            let view = UIButton(frame: CGRect(origin: CGPoint(), size: AppCoordinator.debugButtonSize))
+            view.setImage(UIImage(systemName: "square.fill"), for: .normal)
+            view.addTarget(self, action: #selector(AppCoordinator.stopLogging), for: .touchUpInside)
+            view.tintColor = .white
+            view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            view.backgroundColor = Asset.Colors.zoteroBlueWithDarkMode.color
+            view.layer.cornerRadius = AppCoordinator.debugButtonSize.height / 2
+            view.layer.masksToBounds = true
+            // Create window with button
+            let debugWindow = UIWindow()
+            debugWindow.backgroundColor = .clear
+            debugWindow.windowScene = window.windowScene
+            debugWindow.frame = self.debugWindowFrame(for: window.frame.size, xPos: AppCoordinator.debugButtonOffset)
+            debugWindow.addSubview(view)
+            // Show the window
+            debugWindow.makeKeyAndVisible()
+            self.debugWindow = debugWindow
+            
+            let panRecognizer = UIPanGestureRecognizer(target: self, action: #selector(AppCoordinator.didPan))
+            self.debugWindow?.addGestureRecognizer(panRecognizer)
+        }
+        
+        func hideDebugWindow() {
+            self.debugWindow = nil
+        }
     }
-
+    
     @objc private func didPan(recognizer: UIPanGestureRecognizer) {
-        guard let debugWindow = self.debugWindow, let window = self.window else { return }
-
+        guard let debugWindow, let window else { return }
+        
         switch recognizer.state {
         case .began:
             self.originalDebugWindowFrame = debugWindow.frame
-
+            
         case .changed:
             guard let originalFrame = self.originalDebugWindowFrame else { return }
             let translation = recognizer.translation(in: window)
             debugWindow.frame = originalFrame.offsetBy(dx: translation.x, dy: translation.y)
-
+            
         case .cancelled, .ended, .failed:
             self.originalDebugWindowFrame = nil
-
+            
             let velocity = recognizer.velocity(in: window)
             let endPosLeft = velocity.x == 0 ? (debugWindow.center.x <= (window.frame.width / 2)) : (velocity.x < 0)
             let xPos = endPosLeft ? AppCoordinator.debugButtonOffset : window.frame.width - AppCoordinator.debugButtonSize.width - AppCoordinator.debugButtonOffset
             let frame = self.debugWindowFrame(for: window.frame.size, xPos: xPos)
             let viewVelocity = abs(velocity.x / (xPos - debugWindow.frame.minX))
-
-            UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: viewVelocity, options: [.curveEaseOut], animations: {
-                debugWindow.frame = frame
-            }, completion: nil)
-
-        case .possible: break
-        @unknown default: break
+            
+            UIView.animate(
+                withDuration: 0.5,
+                delay: 0,
+                usingSpringWithDamping: 1,
+                initialSpringVelocity: viewVelocity,
+                options: [.curveEaseOut],
+                animations: {
+                    debugWindow.frame = frame
+                },
+                completion: nil
+            )
+            
+        case .possible:
+            break
+            
+        @unknown default:
+            break
         }
     }
-
+    
     @objc private func stopLogging() {
         self.controllers.debugLogging.stop()
-    }
-
-    private func hideDebugWindow() {
-        self.debugWindow = nil
     }
 }
 
 extension AppCoordinator: AppOnboardingCoordinatorDelegate {
+    func showAbout() {
+        let controller = SFSafariViewController(url: URL(string: "https://www.zotero.org/?app=1")!)
+        self.window?.rootViewController?.present(controller, animated: true, completion: nil)
+    }
+
     func presentLogin() {
         let handler = LoginActionHandler(apiClient: self.controllers.apiClient, sessionController: self.controllers.sessionController)
         let controller = LoginViewController(viewModel: ViewModel(initialState: LoginState(), handler: handler))
@@ -674,7 +702,7 @@ extension AppCoordinator: AppOnboardingCoordinatorDelegate {
         controller.isModalInPresentation = false
         self.window?.rootViewController?.present(controller, animated: true, completion: nil)
     }
-
+    
     func presentRegister() {
         let controller = SFSafariViewController(url: URL(string: "https://www.zotero.org/user/register?app=1")!)
         self.window?.rootViewController?.present(controller, animated: true, completion: nil)
@@ -682,16 +710,11 @@ extension AppCoordinator: AppOnboardingCoordinatorDelegate {
 }
 
 extension AppCoordinator: AppLoginCoordinatorDelegate {
-    func showAbout() {
-        let controller = SFSafariViewController(url: URL(string: "https://www.zotero.org/?app=1")!)
-        self.window?.rootViewController?.present(controller, animated: true, completion: nil)
-    }
-
     func showForgotPassword() {
         guard let url = URL(string: "https://www.zotero.org/user/lostpassword?app=1") else { return }
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
-
+    
     func dismiss() {
         self.window?.rootViewController?.dismiss(animated: true, completion: nil)
     }
@@ -699,12 +722,14 @@ extension AppCoordinator: AppLoginCoordinatorDelegate {
 
 extension AppCoordinator: CrashReporterCoordinator {
     func report(id: String, completion: @escaping () -> Void) {
-        var actions = [UIAlertAction(title: L10n.ok, style: .cancel, handler: { _ in completion() }),
-                       UIAlertAction(title: L10n.Settings.CrashAlert.copyId, style: .default, handler: { _ in
-                          UIPasteboard.general.string = id
-                          completion()
-                       })]
-
+        var actions = [
+            UIAlertAction(title: L10n.ok, style: .cancel, handler: { _ in completion() }),
+            UIAlertAction(title: L10n.Settings.CrashAlert.copyId, style: .default, handler: { _ in
+                UIPasteboard.general.string = id
+                completion()
+            })
+        ]
+        
         let userId = Defaults.shared.userId
         if userId > 0 {
             let action = UIAlertAction(title: L10n.Settings.CrashAlert.exportDb, style: .default) { [weak self] _ in
@@ -713,14 +738,14 @@ extension AppCoordinator: CrashReporterCoordinator {
             }
             actions.append(action)
         }
-
+        
         self.showAlert(title: L10n.Settings.CrashAlert.title, message: L10n.Settings.CrashAlert.message(id), actions: actions)
     }
-
+    
     private func exportDb(with userId: Int, completion: (() -> Void)?) {
         let mainUrl = Files.dbFile(for: userId).createUrl()
         let bundledUrl = Files.bundledDataDbFile.createUrl()
-
+        
         let controller = UIActivityViewController(activityItems: [mainUrl, bundledUrl], applicationActivities: nil)
         controller.modalPresentationStyle = .pageSheet
         controller.popoverPresentationController?.sourceView = self.viewController?.view
@@ -734,112 +759,133 @@ extension AppCoordinator: CrashReporterCoordinator {
 
 extension AppCoordinator: TranslatorsControllerCoordinatorDelegate {
     func showBundleLoadTranslatorsError(result: @escaping (Bool) -> Void) {
-        self.showAlert(title: L10n.error,
-                       message: L10n.Errors.Translators.bundleLoading,
-                       actions: [UIAlertAction(title: L10n.no, style: .cancel, handler: { _ in result(false) }),
-                                 UIAlertAction(title: L10n.yes, style: .default, handler: { _ in result(true) })])
+        self.showAlert(
+            title: L10n.error,
+            message: L10n.Errors.Translators.bundleLoading,
+            actions: [UIAlertAction(title: L10n.no, style: .cancel, handler: { _ in result(false) }), UIAlertAction(title: L10n.yes, style: .default, handler: { _ in result(true) })]
+        )
     }
-
+    
     func showResetToBundleError() {
-        self.showAlert(title: L10n.error,
-                       message: L10n.Errors.Translators.bundleReset,
-                       actions: [UIAlertAction(title: L10n.ok, style: .cancel, handler: nil)])
+        self.showAlert(title: L10n.error, message: L10n.Errors.Translators.bundleReset, actions: [UIAlertAction(title: L10n.ok, style: .cancel, handler: nil)])
     }
 }
 
 extension AppCoordinator: ConflictReceiver {
     func resolve(conflict: Conflict, completed: @escaping (ConflictResolution?) -> Void) {
-        DispatchQueue.main.async { [weak self] in
-            self?._resolve(conflict: conflict, completed: completed)
+        DispatchQueue.main.async {
+            _resolve(conflict: conflict, completed: completed)
         }
-    }
-
-    private func _resolve(conflict: Conflict, completed: @escaping (ConflictResolution?) -> Void) {
-        switch conflict {
-        case .objectsRemovedRemotely(let libraryId, let collections, let items, let searches, let tags):
-            guard let controller = self.conflictReceiverAlertController else {
-                completed(.remoteDeletionOfActiveObject(libraryId: libraryId, toDeleteCollections: collections, toRestoreCollections: [],
-                                                        toDeleteItems: items, toRestoreItems: [], searches: searches, tags: tags))
-                return
+        
+        func _resolve(conflict: Conflict, completed: @escaping (ConflictResolution?) -> Void) {
+            switch conflict {
+            case .objectsRemovedRemotely(let libraryId, let collections, let items, let searches, let tags):
+                guard let controller = self.conflictReceiverAlertController else {
+                    completed(
+                        .remoteDeletionOfActiveObject(
+                            libraryId: libraryId,
+                            toDeleteCollections: collections,
+                            toRestoreCollections: [],
+                            toDeleteItems: items,
+                            toRestoreItems: [],
+                            searches: searches,
+                            tags: tags
+                        )
+                    )
+                    return
+                }
+                
+                let handler = ActiveObjectDeletedConflictReceiverHandler(
+                    collections: collections,
+                    items: items,
+                    libraryId: libraryId
+                ) { toDeleteCollections, toRestoreCollections, toDeleteItems, toRestoreItems in
+                    completed(
+                        .remoteDeletionOfActiveObject(
+                            libraryId: libraryId,
+                            toDeleteCollections: toDeleteCollections,
+                            toRestoreCollections: toRestoreCollections,
+                            toDeleteItems: toDeleteItems,
+                            toRestoreItems: toRestoreItems,
+                            searches: searches,
+                            tags: tags
+                        )
+                    )
+                }
+                controller.start(with: handler)
+                
+            case .removedItemsHaveLocalChanges(let items, let libraryId):
+                guard let controller = self.conflictAlertQueueController else {
+                    completed(.remoteDeletionOfChangedItem(libraryId: libraryId, toDelete: items.map({ $0.0 }), toRestore: []))
+                    return
+                }
+                
+                let handler = ChangedItemsDeletedAlertQueueHandler(items: items) { toDelete, toRestore in
+                    completed(.remoteDeletionOfChangedItem(libraryId: libraryId, toDelete: toDelete, toRestore: toRestore))
+                }
+                controller.start(with: handler)
+                
+            case .groupRemoved, .groupMetadataWriteDenied, .groupFileWriteDenied:
+                presentAlert(for: conflict, completed: completed)
             }
-
-            let handler = ActiveObjectDeletedConflictReceiverHandler(collections: collections, items: items, libraryId: libraryId) { toDeleteCollections, toRestoreCollections, toDeleteItems, toRestoreItems in
-                completed(.remoteDeletionOfActiveObject(libraryId: libraryId, toDeleteCollections: toDeleteCollections, toRestoreCollections: toRestoreCollections,
-                                                        toDeleteItems: toDeleteItems, toRestoreItems: toRestoreItems, searches: searches, tags: tags))
-            }
-            controller.start(with: handler)
-
-        case .removedItemsHaveLocalChanges(let items, let libraryId):
-            guard let controller = self.conflictAlertQueueController else {
-                completed(.remoteDeletionOfChangedItem(libraryId: libraryId, toDelete: items.map({ $0.0 }), toRestore: []))
-                return
-            }
-
-            let handler = ChangedItemsDeletedAlertQueueHandler(items: items) { toDelete, toRestore in
-                completed(.remoteDeletionOfChangedItem(libraryId: libraryId, toDelete: toDelete, toRestore: toRestore))
-            }
-            controller.start(with: handler)
-
-        case .groupRemoved, .groupMetadataWriteDenied, .groupFileWriteDenied:
-            self.presentAlert(for: conflict, completed: completed)
-        }
-    }
-
-    private func presentAlert(for conflict: Conflict, completed: @escaping (ConflictResolution?) -> Void) {
-        let (title, message, actions) = self.createAlert(for: conflict, completed: completed)
-
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        actions.forEach { action in
-            alert.addAction(action)
-        }
-        self.viewController?.present(alert, animated: true, completion: nil)
-    }
-
-    private func createAlert(for conflict: Conflict, completed: @escaping (ConflictResolution?) -> Void) -> (title: String, message: String, actions: [UIAlertAction]) {
-        switch conflict {
-        case .groupRemoved(let groupId, let groupName):
-            let actions = [UIAlertAction(title: L10n.remove, style: .destructive, handler: { _ in
-                               completed(.deleteGroup(groupId))
-                           }),
-                           UIAlertAction(title: L10n.keep, style: .default, handler: { _ in
-                               completed(.markGroupAsLocalOnly(groupId))
-                           })]
-            return (L10n.warning, L10n.Errors.Sync.groupRemoved(groupName), actions)
-
-        case .groupMetadataWriteDenied(let groupId, let groupName):
-            let actions = [UIAlertAction(title: L10n.Errors.Sync.revertToOriginal, style: .cancel, handler: { _ in
-                               completed(.revertGroupChanges(.group(groupId)))
-                           }),
-                           UIAlertAction(title: L10n.Errors.Sync.keepChanges, style: .default, handler: { _ in
-                               completed(.keepGroupChanges(.group(groupId)))
-                           })]
-            return (L10n.warning, L10n.Errors.Sync.metadataWriteDenied(groupName), actions)
-
-        case .groupFileWriteDenied(let groupId, let groupName):
-            guard let webDavController = self.controllers.userControllers?.webDavController else { return ("", "", []) }
-
-            let domainName: String
-            if !webDavController.sessionStorage.isEnabled {
-                domainName = "zotero.org"
-            } else {
-                let url = URL(string: webDavController.sessionStorage.url)
-                if #available(iOS 16.0, *) {
-                    domainName = url?.host() ?? ""
-                } else {
-                    domainName = url?.host ?? ""
+            
+            func presentAlert(for conflict: Conflict, completed: @escaping (ConflictResolution?) -> Void) {
+                let (title, message, actions) = createAlert(for: conflict, completed: completed)
+                
+                let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+                actions.forEach { action in
+                    alert.addAction(action)
+                }
+                self.viewController?.present(alert, animated: true, completion: nil)
+                
+                func createAlert(for conflict: Conflict, completed: @escaping (ConflictResolution?) -> Void) -> (title: String, message: String, actions: [UIAlertAction]) {
+                    switch conflict {
+                    case .groupRemoved(let groupId, let groupName):
+                        let actions = [UIAlertAction(title: L10n.remove, style: .destructive, handler: { _ in
+                            completed(.deleteGroup(groupId))
+                        }),
+                                       UIAlertAction(title: L10n.keep, style: .default, handler: { _ in
+                            completed(.markGroupAsLocalOnly(groupId))
+                        })]
+                        return (L10n.warning, L10n.Errors.Sync.groupRemoved(groupName), actions)
+                        
+                    case .groupMetadataWriteDenied(let groupId, let groupName):
+                        let actions = [UIAlertAction(title: L10n.Errors.Sync.revertToOriginal, style: .cancel, handler: { _ in
+                            completed(.revertGroupChanges(.group(groupId)))
+                        }),
+                                       UIAlertAction(title: L10n.Errors.Sync.keepChanges, style: .default, handler: { _ in
+                            completed(.keepGroupChanges(.group(groupId)))
+                        })]
+                        return (L10n.warning, L10n.Errors.Sync.metadataWriteDenied(groupName), actions)
+                        
+                    case .groupFileWriteDenied(let groupId, let groupName):
+                        guard let webDavController = self.controllers.userControllers?.webDavController else { return ("", "", []) }
+                        
+                        let domainName: String
+                        if !webDavController.sessionStorage.isEnabled {
+                            domainName = "zotero.org"
+                        } else {
+                            let url = URL(string: webDavController.sessionStorage.url)
+                            if #available(iOS 16.0, *) {
+                                domainName = url?.host() ?? ""
+                            } else {
+                                domainName = url?.host ?? ""
+                            }
+                        }
+                        
+                        let actions = [UIAlertAction(title: L10n.Errors.Sync.resetGroupFiles, style: .cancel, handler: { _ in
+                            completed(.revertGroupFiles(.group(groupId)))
+                        }),
+                                       UIAlertAction(title: L10n.Errors.Sync.skipGroup, style: .default, handler: { _ in
+                            completed(.skipGroup(.group(groupId)))
+                        })]
+                        return (L10n.warning, L10n.Errors.Sync.fileWriteDenied(groupName, domainName), actions)
+                        
+                    case .objectsRemovedRemotely, .removedItemsHaveLocalChanges:
+                        return ("", "", [])
+                    }
                 }
             }
-
-            let actions = [UIAlertAction(title: L10n.Errors.Sync.resetGroupFiles, style: .cancel, handler: { _ in
-                               completed(.revertGroupFiles(.group(groupId)))
-                           }),
-                           UIAlertAction(title: L10n.Errors.Sync.skipGroup, style: .default, handler: { _ in
-                               completed(.skipGroup(.group(groupId)))
-                           })]
-            return (L10n.warning, L10n.Errors.Sync.fileWriteDenied(groupName, domainName), actions)
-
-        case .objectsRemovedRemotely, .removedItemsHaveLocalChanges:
-            return ("", "", [])
         }
     }
 }
@@ -851,24 +897,24 @@ extension AppCoordinator: SyncRequestReceiver {
         controller.addAction(UIAlertAction(title: L10n.create, style: .default, handler: { _ in create() }))
         self.viewController?.present(controller, animated: true, completion: nil)
     }
-
+    
     func askForPermission(message: String, completed: @escaping (DebugPermissionResponse) -> Void) {
-        DispatchQueue.main.async { [weak self] in
-            self?._askForPermission(message: message, completed: completed)
+        DispatchQueue.main.async {
+            _askForPermission(message: message, completed: completed)
         }
-    }
-
-    private func _askForPermission(message: String, completed: @escaping (DebugPermissionResponse) -> Void) {
-        let alert = UIAlertController(title: "Confirm action", message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "Allow", style: .default, handler: { _ in
-            completed(.allowed)
-        }))
-        alert.addAction(UIAlertAction(title: "Skip", style: .default, handler: { _ in
-            completed(.skipAction)
-        }))
-        alert.addAction(UIAlertAction(title: "Cancel sync", style: .destructive, handler: { _ in
-            completed(.cancelSync)
-        }))
-        self.viewController?.present(alert, animated: true, completion: nil)
+        
+        func _askForPermission(message: String, completed: @escaping (DebugPermissionResponse) -> Void) {
+            let alert = UIAlertController(title: "Confirm action", message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "Allow", style: .default, handler: { _ in
+                completed(.allowed)
+            }))
+            alert.addAction(UIAlertAction(title: "Skip", style: .default, handler: { _ in
+                completed(.skipAction)
+            }))
+            alert.addAction(UIAlertAction(title: "Cancel sync", style: .destructive, handler: { _ in
+                completed(.cancelSync)
+            }))
+            self.viewController?.present(alert, animated: true, completion: nil)
+        }
     }
 }

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -149,7 +149,7 @@ final class AppCoordinator: NSObject {
                 DDLogInfo("AppCoordinator: Preprocessing restored state - \(data)")
                 Defaults.shared.selectedLibrary = data.libraryId
                 Defaults.shared.selectedCollectionId = data.collectionId
-                controllers.userControllers?.openItemsController.setItems(data.openItems)
+                controllers.userControllers?.openItemsController.setItems(data.openItems, validate: true)
             }
             return (urlContext, data)
         }

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -288,12 +288,13 @@ final class AppCoordinator: NSObject {
               let (url, library, collection) = loadRestoredStateData(forKey: data.key, libraryId: data.libraryId, collectionId: data.collectionId) else { return }
         if let collection {
             DDLogInfo("AppCoordinator: show restored state - \(data.key); \(data.libraryId); \(data.collectionId); \(url.relativePath)")
-            mainController.showItems(for: collection, in: library, saveCollectionToDefaults: true)
+            Defaults.shared.selectedCollectionId = collection.identifier
+            mainController.showItems(for: collection, in: library)
         } else {
             DDLogWarn("AppCoordinator: show restored state using all items collection - \(data.key); \(data.libraryId); \(url.relativePath)")
             // Collection is missing, show all items instead
             let collection = Collection(custom: .all)
-            mainController.showItems(for: collection, in: library, saveCollectionToDefaults: false)
+            mainController.showItems(for: collection, in: library)
         }
         
         mainController.getDetailCoordinator { [weak self] coordinator in

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -149,6 +149,7 @@ final class AppCoordinator: NSObject {
                 DDLogInfo("AppCoordinator: Preprocessing restored state - \(data)")
                 Defaults.shared.selectedLibrary = data.libraryId
                 Defaults.shared.selectedCollectionId = data.collectionId
+                controllers.userControllers?.openItemsController.setItems(data.openItems)
             }
             return (urlContext, data)
         }
@@ -165,10 +166,58 @@ final class AppCoordinator: NSObject {
                 }
             }
             
-            if let data {
+            if let data, data.restoreMostRecentlyOpenedItem {
                 DDLogInfo("AppCoordinator: Processing restored state - \(data)")
                 // If scene had state stored, restore state
-                self.showRestoredState(for: data)
+                showRestoredState(for: data)
+            }
+            
+            func showRestoredState(for data: RestoredStateData) {
+                guard let openItemsController = controllers.userControllers?.openItemsController else { return }
+                DDLogInfo("AppCoordinator: show restored state")
+                guard let mainController = self.window?.rootViewController as? MainViewController else {
+                    DDLogWarn("AppCoordinator: show restored state aborted - invalid root view controller")
+                    return
+                }
+                guard let (library, optionalCollection) = loadRestoredStateData(libraryId: data.libraryId, collectionId: data.collectionId) else {
+                    DDLogWarn("AppCoordinator: show restored state aborted - invalid restored state data")
+                    return
+                }
+                var collection: Collection
+                if let optionalCollection {
+                    DDLogInfo("AppCoordinator: show restored state using restored collection")
+                    collection = optionalCollection
+                    // No need to set selected collection identifier here, this happened already in show main screen / preprocess
+                } else {
+                    DDLogWarn("AppCoordinator: show restored state using all items collection")
+                    // Collection is missing, show all items instead
+                    collection = Collection(custom: .all)
+                }
+                mainController.showItems(for: collection, in: library)
+                openItemsController.restoreMostRecentlyOpenedItem(using: self)
+                
+                func loadRestoredStateData(libraryId: LibraryIdentifier, collectionId: CollectionIdentifier) -> (Library, Collection?)? {
+                    guard let dbStorage = self.controllers.userControllers?.dbStorage else { return nil }
+                    
+                    var library: Library?
+                    var collection: Collection?
+                    
+                    do {
+                        try dbStorage.perform(on: .main, with: { coordinator in
+                            let (_collection, _library) = try coordinator.perform(request: ReadCollectionAndLibraryDbRequest(collectionId: collectionId, libraryId: libraryId))
+                            collection = _collection
+                            library = _library
+                        })
+                    } catch let error {
+                        DDLogError("AppCoordinator: can't load restored data - \(error)")
+                        return nil
+                    }
+                    
+                    if let library = library {
+                        return (library, collection)
+                    }
+                    return nil
+                }
             }
         }
     }
@@ -208,7 +257,7 @@ final class AppCoordinator: NSObject {
             
         func showItemDetail(in mainController: MainViewController, key: String, library: Library, selectChildKey childKey: String?, animated: Bool, dismissIfPresenting: Bool) {
             let dismissPresented = dismissIfPresenting && (mainController.presentedViewController != nil)
-            var itemDetailAnimated = dismissPresented ? false : animated
+            let itemDetailAnimated = dismissPresented ? false : animated
             
             // Show "All" collection in given library/group
             if let coordinator = mainController.masterCoordinator,
@@ -281,75 +330,6 @@ final class AppCoordinator: NSObject {
             default:
                 completion?()
             }
-        }
-    }
-    
-    private func showRestoredState(for data: RestoredStateData) {
-        DDLogInfo("AppCoordinator: show restored state - \(data.key); \(data.libraryId); \(data.collectionId)")
-        guard let mainController = self.window?.rootViewController as? MainViewController else {
-            DDLogWarn("AppCoordinator: show restored state aborted - invalid root view controller")
-            return
-        }
-        guard let (url, library, optionalCollection) = loadRestoredStateData(forKey: data.key, libraryId: data.libraryId, collectionId: data.collectionId) else {
-            DDLogWarn("AppCoordinator: show restored state aborted - invalid restored state data")
-            return
-        }
-        var collection: Collection
-        if let optionalCollection {
-            DDLogInfo("AppCoordinator: show restored state using restored collection - \(url.relativePath)")
-            collection = optionalCollection
-            // No need to set selected collection identifier here, this happened already in show main screen / preprocess
-        } else {
-            DDLogWarn("AppCoordinator: show restored state using all items collection - \(url.relativePath)")
-            // Collection is missing, show all items instead
-            collection = Collection(custom: .all)
-        }
-        mainController.showItems(for: collection, in: library)
-        
-        mainController.getDetailCoordinator { [weak self] coordinator in
-            guard let self, let window else { return }
-            let controller = coordinator.createPDFController(key: data.key, library: library, url: url)
-            self.show(pdfController: controller, in: window, animated: false)
-        }
-        
-        func loadRestoredStateData(forKey key: String, libraryId: LibraryIdentifier, collectionId: CollectionIdentifier) -> (URL, Library, Collection?)? {
-            guard let dbStorage = self.controllers.userControllers?.dbStorage else { return nil }
-            
-            var url: URL?
-            var library: Library?
-            var collection: Collection?
-            
-            do {
-                try dbStorage.perform(on: .main, with: { coordinator in
-                    let item = try coordinator.perform(request: ReadItemDbRequest(libraryId: libraryId, key: key))
-                    
-                    guard let attachment = AttachmentCreator.attachment(for: item, fileStorage: self.controllers.fileStorage, urlDetector: nil) else { return }
-                    
-                    switch attachment.type {
-                    case .file(let filename, let contentType, let location, _):
-                        switch location {
-                        case .local, .localAndChangedRemotely:
-                            let file = Files.attachmentFile(in: libraryId, key: key, filename: filename, contentType: contentType)
-                            url = file.createUrl()
-                            let (_collection, _library) = try coordinator.perform(request: ReadCollectionAndLibraryDbRequest(collectionId: collectionId, libraryId: libraryId))
-                            collection = _collection
-                            library = _library
-                            
-                        case .remote, .remoteMissing: break
-                        }
-                        
-                    default: break
-                    }
-                })
-            } catch let error {
-                DDLogError("AppCoordinator: can't load restored data - \(error)")
-                return nil
-            }
-            
-            if let url = url, let library = library {
-                return (url, library, collection)
-            }
-            return nil
         }
     }
     
@@ -905,6 +885,17 @@ extension AppCoordinator: SyncRequestReceiver {
                 completed(.cancelSync)
             }))
             self.viewController?.present(alert, animated: true, completion: nil)
+        }
+    }
+}
+
+extension AppCoordinator: OpenItemsPresenter {
+    func showPDF(at url: URL, key: String, library: Library) {
+        guard let window, let mainController = window.rootViewController as? MainViewController else { return }
+        mainController.getDetailCoordinator { [weak self] coordinator in
+            guard let self else { return }
+            let controller = coordinator.createPDFController(key: key, library: library, url: url)
+            self.show(pdfController: controller, in: window, animated: false)
         }
     }
 }

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -816,18 +816,21 @@ extension AppCoordinator: SyncRequestReceiver {
 
 extension AppCoordinator: OpenItemsPresenter {
     func showItem(with presentation: ItemPresentation) {
-        switch presentation {
-        case .pdf(let library, let key, let url):
-            showPDF(at: url, key: key, library: library)
-        }
-    }
-    
-    private func showPDF(at url: URL, key: String, library: Library) {
         guard let window, let mainController = window.rootViewController as? MainViewController else { return }
         mainController.getDetailCoordinator { [weak self] coordinator in
             guard let self else { return }
-            let controller = coordinator.createPDFController(key: key, library: library, url: url)
-            self.show(controller: controller, by: mainController, in: window, animated: false)
+            var controller: UIViewController
+            switch presentation {
+            case .pdf(let library, let key, let url):
+                controller = coordinator.createPDFController(key: key, library: library, url: url)
+                
+            case .note(let library, let key, let text, let tags, let title):
+                let kind: NoteEditorKind = library.metadataEditable ? .edit(key: key) : .readOnly(key: key)
+                // TODO: Check if a callback is required
+                controller = coordinator.createNoteController(library: library, kind: kind, text: text, tags: tags, title: title) { _ in
+                }
+            }
+            show(controller: controller, by: mainController, in: window, animated: false)
         }
     }
 }

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -297,7 +297,7 @@ final class AppCoordinator: NSObject {
         if let optionalCollection {
             DDLogInfo("AppCoordinator: show restored state using restored collection - \(url.relativePath)")
             collection = optionalCollection
-            Defaults.shared.selectedCollectionId = collection.identifier
+            // No need to set selected collection identifier here, this happened already in show main screen / preprocess
         } else {
             DDLogWarn("AppCoordinator: show restored state using all items collection - \(url.relativePath)")
             // Collection is missing, show all items instead

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -174,10 +174,15 @@ final class AppCoordinator: NSObject {
     }
     
     func show(customUrl: CustomURLController.Kind, animated: Bool) {
+        guard let window, let mainController = window.rootViewController as? MainViewController else {
+            DDLogWarn("AppCoordinator: show custom url aborted - invalid root view controller")
+            return
+        }
+        
         switch customUrl {
         case .itemDetail(let key, let library, let preselectedChildKey):
             DDLogInfo("AppCoordinator: show custom url - item detail; key=\(key); library=\(library.identifier)")
-            showItemDetail(key: key, library: library, selectChildKey: preselectedChildKey, animated: animated)
+            showItemDetail(in: mainController, key: key, library: library, selectChildKey: preselectedChildKey, animated: animated, dismissIfPresenting: true)
             
         case .pdfReader(let attachment, let library, let page, let annotation, let parentKey, let isAvailable):
             let message = DDLogMessageFormat(
@@ -186,43 +191,45 @@ final class AppCoordinator: NSObject {
                     " page=\(page.flatMap(String.init) ?? "nil"); annotation=\(annotation ?? "nil"); parentKey=\(parentKey ?? "nil")"
             )
             DDLogInfo(message)
-            if isAvailable {
-                open(attachment: attachment, library: library, on: page, annotation: annotation, parentKey: parentKey, animated: animated)
-                return
-            }
-            
-            guard let window, let mainController = window.rootViewController as? MainViewController else { return }
-            
-            mainController.getDetailCoordinator { [weak self] coordinator in
-                guard let self else { return }
-                showItemDetail(key: (parentKey ?? attachment.key), library: library, selectChildKey: attachment.key, animated: animated)
-                download(attachment: attachment, parentKey: parentKey) {
-                    _open(attachment: attachment, library: library, on: page, annotation: annotation, window: window, detailCoordinator: coordinator, animated: true)
-                }
-            }
-        }
-        
-        func showItemDetail(key: String, library: Library, selectChildKey childKey: String?, animated: Bool) {
-            // Dismiss presented screen if any visible
-            if let mainController = self.window?.rootViewController as? MainViewController, mainController.presentedViewController != nil {
-                _showItemDetail(key: key, library: library, selectChildKey: childKey, animated: false)
-                mainController.dismiss(animated: animated)
-            } else {
-                _showItemDetail(key: key, library: library, selectChildKey: childKey, animated: animated)
-            }
-        }
-        
-        func open(attachment: Attachment, library: Library, on page: Int?, annotation: String?, parentKey: String?, animated: Bool) {
-            guard let window, let mainController = window.rootViewController as? MainViewController else { return }
-            
             mainController.getDetailCoordinator { coordinator in
-                guard (coordinator.navigationController?.presentedViewController as? PDFReaderViewController)?.key != attachment.key else { return }
-                _open(attachment: attachment, library: library, on: page, annotation: annotation, window: window, detailCoordinator: coordinator, animated: animated) {
-                    _showItemDetail(key: (parentKey ?? attachment.key), library: library, selectChildKey: attachment.key, animated: animated)
+                if isAvailable {
+                    guard (coordinator.navigationController?.presentedViewController as? PDFReaderViewController)?.key != attachment.key else { return }
+                    open(attachment: attachment, library: library, on: page, annotation: annotation, window: window, detailCoordinator: coordinator, animated: animated) {
+                        showItemDetail(in: mainController, key: (parentKey ?? attachment.key), library: library, selectChildKey: attachment.key, animated: animated, dismissIfPresenting: false)
+                    }
+                } else {
+                    showItemDetail(in: mainController, key: (parentKey ?? attachment.key), library: library, selectChildKey: attachment.key, animated: animated, dismissIfPresenting: true)
+                    download(attachment: attachment, parentKey: parentKey) {
+                        open(attachment: attachment, library: library, on: page, annotation: annotation, window: window, detailCoordinator: coordinator, animated: true)
+                    }
                 }
             }
         }
-        
+            
+        func showItemDetail(in mainController: MainViewController, key: String, library: Library, selectChildKey childKey: String?, animated: Bool, dismissIfPresenting: Bool) {
+            let dismissPresented = dismissIfPresenting && (mainController.presentedViewController != nil)
+            var itemDetailAnimated = dismissPresented ? false : animated
+            
+            // Show "All" collection in given library/group
+            if let coordinator = mainController.masterCoordinator,
+               coordinator.visibleLibraryId != library.identifier ||
+                (coordinator.navigationController?.visibleViewController as? CollectionsViewController)?.selectedIdentifier != .custom(.all) {
+                coordinator.showCollections(for: library.identifier, preselectedCollection: .custom(.all), animated: itemDetailAnimated)
+            }
+            
+            // Show item detail of given key
+            mainController.getDetailCoordinator { coordinator in
+                if (coordinator.navigationController?.visibleViewController as? ItemDetailViewController)?.key != key {
+                    coordinator.showItemDetail(for: .preview(key: key), library: library, scrolledToKey: childKey, animated: itemDetailAnimated)
+                }
+            }
+            
+            if dismissPresented {
+                // Dismiss presented screen if any visible
+                mainController.dismiss(animated: animated)
+            }
+        }
+            
         func download(attachment: Attachment, parentKey: String?, completion: @escaping () -> Void) {
             guard let downloader = self.controllers.userControllers?.fileDownloader else {
                 completion()
@@ -243,7 +250,9 @@ final class AppCoordinator: NSObject {
                         
                     case .cancelled, .failed:
                         self.downloadDisposeBag = nil
-                    case .progress: break
+                        
+                    case .progress:
+                        break
                     }
                 })
                 .disposed(by: disposeBag)
@@ -252,29 +261,21 @@ final class AppCoordinator: NSObject {
             downloader.downloadIfNeeded(attachment: attachment, parentKey: parentKey)
         }
         
-        func _showItemDetail(key: String, library: Library, selectChildKey childKey: String?, animated: Bool) {
-            guard let mainController = self.window?.rootViewController as? MainViewController else { return }
-            
-            // Show "All" collection in given library/group
-            if mainController.masterCoordinator?.visibleLibraryId != library.identifier ||
-                (mainController.masterCoordinator?.navigationController?.visibleViewController as? CollectionsViewController)?.selectedIdentifier != .custom(.all) {
-                mainController.masterCoordinator?.showCollections(for: library.identifier, preselectedCollection: .custom(.all), animated: animated)
-            }
-            
-            // Show item detail of given key
-            mainController.getDetailCoordinator { coordinator in
-                if (coordinator.navigationController?.visibleViewController as? ItemDetailViewController)?.key != key {
-                    coordinator.showItemDetail(for: .preview(key: key), library: library, scrolledToKey: childKey, animated: animated)
-                }
-            }
-        }
-        
-        func _open(attachment: Attachment, library: Library, on page: Int?, annotation: String?, window: UIWindow, detailCoordinator: DetailCoordinator, animated: Bool, completion: (() -> Void)? = nil) {
+        func open(
+            attachment: Attachment,
+            library: Library,
+            on page: Int?,
+            annotation: String?,
+            window: UIWindow,
+            detailCoordinator: DetailCoordinator,
+            animated: Bool,
+            completion: (() -> Void)? = nil
+        ) {
             switch attachment.type {
             case .file(let filename, let contentType, _, _) where contentType == "application/pdf":
                 let file = Files.attachmentFile(in: library.identifier, key: attachment.key, filename: filename, contentType: contentType)
                 let url = file.createUrl()
-                let controller = self.pdfController(key: attachment.key, library: library, url: url, page: page, preselectedAnnotationKey: annotation, detailCoordinator: detailCoordinator)
+                let controller = detailCoordinator.createPDFController(key: attachment.key, library: library, url: url, page: page, preselectedAnnotationKey: annotation)
                 self.show(pdfController: controller, in: window, animated: animated, completion: completion)
                 
             default:
@@ -289,7 +290,7 @@ final class AppCoordinator: NSObject {
             DDLogWarn("AppCoordinator: show restored state aborted - invalid root view controller")
             return
         }
-        guard var (url, library, optionalCollection) = loadRestoredStateData(forKey: data.key, libraryId: data.libraryId, collectionId: data.collectionId) else {
+        guard let (url, library, optionalCollection) = loadRestoredStateData(forKey: data.key, libraryId: data.libraryId, collectionId: data.collectionId) else {
             DDLogWarn("AppCoordinator: show restored state aborted - invalid restored state data")
             return
         }
@@ -307,7 +308,7 @@ final class AppCoordinator: NSObject {
         
         mainController.getDetailCoordinator { [weak self] coordinator in
             guard let self, let window else { return }
-            let controller = self.pdfController(key: data.key, library: library, url: url, page: nil, preselectedAnnotationKey: nil, detailCoordinator: coordinator)
+            let controller = coordinator.createPDFController(key: data.key, library: library, url: url)
             self.show(pdfController: controller, in: window, animated: false)
         }
         
@@ -350,26 +351,6 @@ final class AppCoordinator: NSObject {
             }
             return nil
         }
-    }
-    
-    private func pdfController(key: String, library: Library, url: URL, page: Int?, preselectedAnnotationKey: String?, detailCoordinator: DetailCoordinator) -> UINavigationController {
-        let navigationController = NavigationViewController()
-        navigationController.modalPresentationStyle = .fullScreen
-        
-        let coordinator = PDFCoordinator(
-            key: key,
-            library: library,
-            url: url,
-            page: page,
-            preselectedAnnotationKey: preselectedAnnotationKey,
-            navigationController: navigationController,
-            controllers: controllers
-        )
-        coordinator.parentCoordinator = detailCoordinator
-        detailCoordinator.childCoordinators.append(coordinator)
-        coordinator.start(animated: false)
-        
-        return navigationController
     }
     
     private func show(pdfController: UIViewController, in window: UIWindow, animated: Bool, completion: (() -> Void)? = nil) {

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -950,7 +950,7 @@ extension DetailCoordinator: OpenItemsPresenter {
         guard let navigationController else { return }
         let controller = createPDFController(key: key, library: library, url: url)
         controllers.userControllers?.openItemsController.open(.pdf(libraryId: library.identifier, key: key))
-        if navigationController.presentingViewController != nil {
+        if navigationController.presentedViewController != nil {
             navigationController.dismiss(animated: false) {
                 navigationController.present(controller, animated: false)
             }

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -25,7 +25,6 @@ protocol DetailItemsCoordinatorDelegate: AnyObject {
     func showCollectionsPicker(in library: Library, completed: @escaping (Set<String>) -> Void)
     func showItemDetail(for type: ItemDetailState.DetailType, library: Library, scrolledToKey childKey: String?, animated: Bool)
     func showAttachmentError(_ error: Error)
-    func showNote(with text: String, tags: [Tag], title: NoteEditorState.TitleData?, key: String?, library: Library, readOnly: Bool, save: @escaping (String, [Tag]) -> Void)
     func showAddActions(viewModel: ViewModel<ItemsActionHandler>, button: UIBarButtonItem)
     func showSortActions(viewModel: ViewModel<ItemsActionHandler>, button: UIBarButtonItem)
     func show(url: URL)
@@ -42,7 +41,6 @@ protocol DetailItemsCoordinatorDelegate: AnyObject {
 }
 
 protocol DetailItemDetailCoordinatorDelegate: AnyObject {
-    func showNote(with text: String, tags: [Tag], title: NoteEditorState.TitleData?, key: String?, library: Library, readOnly: Bool, save: @escaping (String, [Tag]) -> Void)
     func showAttachmentPicker(save: @escaping ([URL]) -> Void)
     func showTagPicker(libraryId: LibraryIdentifier, selected: Set<String>, picked: @escaping ([Tag]) -> Void)
     func showTypePicker(selected: String, picked: @escaping (String) -> Void)
@@ -58,9 +56,7 @@ protocol DetailItemDetailCoordinatorDelegate: AnyObject {
 }
 
 protocol DetailNoteEditorCoordinatorDelegate: AnyObject {
-    func showWeb(url: URL)
-    func show(url: URL)
-    func pushTagPicker(libraryId: LibraryIdentifier, selected: Set<String>, picked: @escaping ([Tag]) -> Void)
+    func showNote(library: Library, kind: NoteEditorKind, text: String, tags: [Tag], title: NoteEditorState.TitleData?, saveCallback: @escaping NoteEditorSaveCallback)
 }
 
 protocol DetailCitationCoordinatorDelegate: AnyObject {
@@ -380,9 +376,8 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
 
         controller.addAction(UIAlertAction(title: L10n.Items.newNote, style: .default, handler: { [weak self, weak viewModel] _ in
             guard let self, let viewModel else { return }
-            let key = KeyGenerator.newKey
-            showNote(with: "", tags: [], title: nil, key: nil, library: viewModel.state.library, readOnly: false) { [weak viewModel] text, tags in
-                viewModel?.process(action: .saveNote(key, text, tags))
+            showNote(library: viewModel.state.library, kind: .standaloneCreation(collection: viewModel.state.collection)) { [weak viewModel] result in
+                viewModel?.process(action: .processNoteSaveResult(result))
             }
         }))
 
@@ -455,25 +450,24 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
     }
 
     func createNoteController(
-        key: String?,
         library: Library,
-        text: String = "",
-        tags: [Tag] = [],
-        title: NoteEditorState.TitleData? = nil,
-        readOnly: Bool = false,
-        save: @escaping (String, [Tag]) -> Void = { _, _ in }
+        kind: NoteEditorKind,
+        text: String,
+        tags: [Tag],
+        title: NoteEditorState.TitleData?,
+        saveCallback: @escaping NoteEditorSaveCallback
     ) -> NavigationViewController {
         let navigationController = NavigationViewController()
         navigationController.modalPresentationStyle = .fullScreen
         navigationController.isModalInPresentation = true
 
         let coordinator = NoteEditorCoordinator(
+            library: library,
+            kind: kind,
             text: text,
             tags: tags,
             title: title,
-            library: library,
-            readOnly: readOnly,
-            save: save,
+            saveCallback: saveCallback,
             navigationController: navigationController,
             controllers: controllers
         )
@@ -482,21 +476,6 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
         coordinator.start(animated: false)
 
         return navigationController
-    }
-
-    func showNote(with text: String, tags: [Tag], title: NoteEditorState.TitleData?, key: String?, library: Library, readOnly: Bool, save: @escaping (String, [Tag]) -> Void) {
-        if let key {
-            DDLogInfo("DetailCoordinator: show note \(key)")
-        } else {
-            DDLogInfo("DetailCoordinator: show note creation")
-        }
-
-        if let presentedViewController = navigationController.presentedViewController {
-            guard let window = presentedViewController.view.window else { return }
-            show(controller: controller, by: navigationController, in: window, animated: false)
-            return
-        }
-        navigationController.present(controller, animated: true)
     }
 
     func showItemDetail(for type: ItemDetailState.DetailType, library: Library, scrolledToKey childKey: String?, animated: Bool) {
@@ -923,18 +902,30 @@ extension DetailCoordinator: DetailItemDetailCoordinatorDelegate {
 }
 
 extension DetailCoordinator: DetailNoteEditorCoordinatorDelegate {
-    func pushTagPicker(libraryId: LibraryIdentifier, selected: Set<String>, picked: @escaping ([Tag]) -> Void) {
-        guard let dbStorage = self.controllers.userControllers?.dbStorage else { return }
+    func showNote(
+        library: Library,
+        kind: NoteEditorKind,
+        text: String = "",
+        tags: [Tag] = [],
+        title: NoteEditorState.TitleData? = nil,
+        saveCallback: @escaping NoteEditorSaveCallback = { _ in }
+    ) {
+        guard let navigationController else { return }
+        let controller = createNoteController(library: library, kind: kind, text: text, tags: tags, title: title, saveCallback: saveCallback)
+        switch kind {
+        case .itemCreation, .standaloneCreation:
+            DDLogInfo("DetailCoordinator: show note creation")
+            
+        case .edit(let key), .readOnly(let key):
+            DDLogInfo("DetailCoordinator: show note \(key)")
+        }
 
-        DDLogInfo("DetailCoordinator: push tag picker for \(libraryId)")
-
-        let state = TagPickerState(libraryId: libraryId, selectedTags: selected)
-        let handler = TagPickerActionHandler(dbStorage: dbStorage)
-        let viewModel = ViewModel(initialState: state, handler: handler)
-        let controller = TagPickerViewController(viewModel: viewModel, saveAction: picked)
-
-        let navigationController = (self.navigationController?.presentedViewController as? UINavigationController) ?? self.navigationController
-        navigationController?.pushViewController(controller, animated: true)
+        if let presentedViewController = navigationController.presentedViewController {
+            guard let window = presentedViewController.view.window else { return }
+            show(controller: controller, by: navigationController, in: window, animated: false)
+            return
+        }
+        navigationController.present(controller, animated: true)
     }
 }
 

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -307,12 +307,6 @@ final class DetailCoordinator: Coordinator {
         return navigationController
     }
     
-    private func showPdf(at url: URL, key: String, library: Library) {
-        let controller = createPDFController(key: key, library: library, url: url)
-        controllers.userControllers?.openItemsController.open(.pdf(library: library, key: key), in: collection)
-        navigationController?.present(controller, animated: true, completion: nil)
-    }
-    
     private func showWebView(for url: URL) {
         guard let currentNavigationController = self.navigationController else { return }
         let controller = WebViewController(url: url)
@@ -955,7 +949,7 @@ extension DetailCoordinator: OpenItemsPresenter {
     func showPDF(at url: URL, key: String, library: Library) {
         guard let navigationController else { return }
         let controller = createPDFController(key: key, library: library, url: url)
-        controllers.userControllers?.openItemsController.open(.pdf(library: library, key: key), in: collection)
+        controllers.userControllers?.openItemsController.open(.pdf(libraryId: library.identifier, key: key))
         if navigationController.presentingViewController != nil {
             navigationController.dismiss(animated: false) {
                 navigationController.present(controller, animated: false)

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -90,6 +90,7 @@ final class DetailCoordinator: Coordinator {
     private var transitionDelegate: EmptyTransitioningDelegate?
     weak var itemsTagFilterDelegate: ItemsTagFilterDelegate?
     weak var navigationController: UINavigationController?
+    var presentedRestoredControllerWindow: UIWindow?
 
     let collection: Collection
     let library: Library
@@ -950,12 +951,14 @@ extension DetailCoordinator: OpenItemsPresenter {
         guard let navigationController else { return }
         let controller = createPDFController(key: key, library: library, url: url)
         controllers.userControllers?.openItemsController.open(.pdf(libraryId: library.identifier, key: key))
-        if navigationController.presentedViewController != nil {
-            navigationController.dismiss(animated: false) {
-                navigationController.present(controller, animated: false)
-            }
+        
+        if let presentedViewController = navigationController.presentedViewController {
+            guard let window = presentedViewController.view.window else { return }
+            show(controller: controller, by: navigationController, in: window, animated: false)
             return
         }
         navigationController.present(controller, animated: true)
     }
 }
+
+extension DetailCoordinator: InstantPresenter { }

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -307,7 +307,20 @@ final class DetailCoordinator: Coordinator {
         
         return navigationController
     }
-    
+
+    private func showPDF(at url: URL, key: String, library: Library) {
+        guard let navigationController else { return }
+        let controller = createPDFController(key: key, library: library, url: url)
+        controllers.userControllers?.openItemsController.open(.pdf(libraryId: library.identifier, key: key))
+
+        if let presentedViewController = navigationController.presentedViewController {
+            guard let window = presentedViewController.view.window else { return }
+            show(controller: controller, by: navigationController, in: window, animated: false)
+            return
+        }
+        navigationController.present(controller, animated: true)
+    }
+
     private func showWebView(for url: URL) {
         guard let currentNavigationController = self.navigationController else { return }
         let controller = WebViewController(url: url)
@@ -947,17 +960,11 @@ extension DetailCoordinator: DetailCitationCoordinatorDelegate {
 }
 
 extension DetailCoordinator: OpenItemsPresenter {
-    func showPDF(at url: URL, key: String, library: Library) {
-        guard let navigationController else { return }
-        let controller = createPDFController(key: key, library: library, url: url)
-        controllers.userControllers?.openItemsController.open(.pdf(libraryId: library.identifier, key: key))
-        
-        if let presentedViewController = navigationController.presentedViewController {
-            guard let window = presentedViewController.view.window else { return }
-            show(controller: controller, by: navigationController, in: window, animated: false)
-            return
+    func showItem(with presentation: ItemPresentation) {
+        switch presentation {
+        case .pdf(let library, let key, let url):
+            showPDF(at: url, key: key, library: library)
         }
-        navigationController.present(controller, animated: true)
     }
 }
 

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -911,15 +911,29 @@ extension DetailCoordinator: DetailNoteEditorCoordinatorDelegate {
         saveCallback: @escaping NoteEditorSaveCallback = { _ in }
     ) {
         guard let navigationController else { return }
-        let controller = createNoteController(library: library, kind: kind, text: text, tags: tags, title: title, saveCallback: saveCallback)
+        var amendedSaveCallback = saveCallback
         switch kind {
         case .itemCreation, .standaloneCreation:
             DDLogInfo("DetailCoordinator: show note creation")
-            
+            amendedSaveCallback = { [weak self] result in
+                switch result {
+                case .success(let note):
+                    // If indeed a new note is created inform open items controller about it.
+                    self?.controllers.userControllers?.openItemsController.open(.note(libraryId: library.identifier, key: note.key))
+
+                case .failure:
+                    break
+                }
+
+                saveCallback(result)
+            }
+
         case .edit(let key), .readOnly(let key):
             DDLogInfo("DetailCoordinator: show note \(key)")
+            controllers.userControllers?.openItemsController.open(.note(libraryId: library.identifier, key: key))
         }
 
+        let controller = createNoteController(library: library, kind: kind, text: text, tags: tags, title: title, saveCallback: amendedSaveCallback)
         if let presentedViewController = navigationController.presentedViewController {
             guard let window = presentedViewController.view.window else { return }
             show(controller: controller, by: navigationController, in: window, animated: false)
@@ -956,6 +970,11 @@ extension DetailCoordinator: OpenItemsPresenter {
         switch presentation {
         case .pdf(let library, let key, let url):
             showPDF(at: url, key: key, library: library)
+
+        case .note(let library, let key, let text, let tags, let title):
+            let kind: NoteEditorKind = library.metadataEditable ? .edit(key: key) : .readOnly(key: key)
+            // TODO: Check if a callback is required
+            showNote(library: library, kind: kind, text: text, tags: tags, title: title)
         }
     }
 }

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -25,7 +25,7 @@ protocol DetailItemsCoordinatorDelegate: AnyObject {
     func showCollectionsPicker(in library: Library, completed: @escaping (Set<String>) -> Void)
     func showItemDetail(for type: ItemDetailState.DetailType, library: Library, scrolledToKey childKey: String?, animated: Bool)
     func showAttachmentError(_ error: Error)
-    func showNote(with text: String, tags: [Tag], title: NoteEditorState.TitleData?, key: String?, libraryId: LibraryIdentifier, readOnly: Bool, save: @escaping (String, [Tag]) -> Void)
+    func showNote(with text: String, tags: [Tag], title: NoteEditorState.TitleData?, key: String?, library: Library, readOnly: Bool, save: @escaping (String, [Tag]) -> Void)
     func showAddActions(viewModel: ViewModel<ItemsActionHandler>, button: UIBarButtonItem)
     func showSortActions(viewModel: ViewModel<ItemsActionHandler>, button: UIBarButtonItem)
     func show(url: URL)
@@ -42,7 +42,7 @@ protocol DetailItemsCoordinatorDelegate: AnyObject {
 }
 
 protocol DetailItemDetailCoordinatorDelegate: AnyObject {
-    func showNote(with text: String, tags: [Tag], title: NoteEditorState.TitleData?, key: String?, libraryId: LibraryIdentifier, readOnly: Bool, save: @escaping (String, [Tag]) -> Void)
+    func showNote(with text: String, tags: [Tag], title: NoteEditorState.TitleData?, key: String?, library: Library, readOnly: Bool, save: @escaping (String, [Tag]) -> Void)
     func showAttachmentPicker(save: @escaping ([URL]) -> Void)
     func showTagPicker(libraryId: LibraryIdentifier, selected: Set<String>, picked: @escaping ([Tag]) -> Void)
     func showTypePicker(selected: String, picked: @escaping (String) -> Void)
@@ -381,7 +381,7 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
         controller.addAction(UIAlertAction(title: L10n.Items.newNote, style: .default, handler: { [weak self, weak viewModel] _ in
             guard let self, let viewModel else { return }
             let key = KeyGenerator.newKey
-            showNote(with: "", tags: [], title: nil, key: nil, libraryId: viewModel.state.library.identifier, readOnly: false) { [weak viewModel] text, tags in
+            showNote(with: "", tags: [], title: nil, key: nil, library: viewModel.state.library, readOnly: false) { [weak viewModel] text, tags in
                 viewModel?.process(action: .saveNote(key, text, tags))
             }
         }))
@@ -454,13 +454,15 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
         return ("\(L10n.Items.sortBy): \(sortType.field.title)", "\(L10n.Items.sortOrder): \(sortOrderTitle)")
     }
 
-    func showNote(with text: String, tags: [Tag], title: NoteEditorState.TitleData?, key: String?, libraryId: LibraryIdentifier, readOnly: Bool, save: @escaping (String, [Tag]) -> Void) {
-        if let key = key {
-            DDLogInfo("DetailCoordinator: show note \(key)")
-        } else {
-            DDLogInfo("DetailCoordinator: show note creation")
-        }
-
+    func createNoteController(
+        key: String?,
+        library: Library,
+        text: String = "",
+        tags: [Tag] = [],
+        title: NoteEditorState.TitleData? = nil,
+        readOnly: Bool = false,
+        save: @escaping (String, [Tag]) -> Void = { _, _ in }
+    ) -> NavigationViewController {
         let navigationController = NavigationViewController()
         navigationController.modalPresentationStyle = .fullScreen
         navigationController.isModalInPresentation = true
@@ -469,17 +471,32 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
             text: text,
             tags: tags,
             title: title,
-            libraryId: libraryId,
+            library: library,
             readOnly: readOnly,
             save: save,
             navigationController: navigationController,
-            controllers: self.controllers
+            controllers: controllers
         )
         coordinator.parentCoordinator = self
-        self.childCoordinators.append(coordinator)
+        childCoordinators.append(coordinator)
         coordinator.start(animated: false)
 
-        self.navigationController?.present(navigationController, animated: true, completion: nil)
+        return navigationController
+    }
+
+    func showNote(with text: String, tags: [Tag], title: NoteEditorState.TitleData?, key: String?, library: Library, readOnly: Bool, save: @escaping (String, [Tag]) -> Void) {
+        if let key {
+            DDLogInfo("DetailCoordinator: show note \(key)")
+        } else {
+            DDLogInfo("DetailCoordinator: show note creation")
+        }
+
+        if let presentedViewController = navigationController.presentedViewController {
+            guard let window = presentedViewController.view.window else { return }
+            show(controller: controller, by: navigationController, in: window, animated: false)
+            return
+        }
+        navigationController.present(controller, animated: true)
     }
 
     func showItemDetail(for type: ItemDetailState.DetailType, library: Library, scrolledToKey childKey: String?, animated: Bool) {

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -63,12 +63,6 @@ protocol DetailNoteEditorCoordinatorDelegate: AnyObject {
     func pushTagPicker(libraryId: LibraryIdentifier, selected: Set<String>, picked: @escaping ([Tag]) -> Void)
 }
 
-protocol DetailItemActionSheetCoordinatorDelegate: AnyObject {
-    func showNoteCreation(title: NoteEditorState.TitleData?, libraryId: LibraryIdentifier, save: @escaping (String, [Tag]) -> Void)
-    func showAttachmentPicker(save: @escaping ([URL]) -> Void)
-    func showItemCreation(library: Library, collectionKey: String?)
-}
-
 protocol DetailCitationCoordinatorDelegate: AnyObject {
     func showLocatorPicker(for values: [SinglePickerModel], selected: String, picked: @escaping (String) -> Void)
     func showCitationPreview(errorMessage: String)
@@ -370,7 +364,7 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
         }))
 
         controller.addAction(UIAlertAction(title: L10n.Items.new, style: .default, handler: { [weak self, weak viewModel] _ in
-            guard let self = self, let viewModel = viewModel else { return }
+            guard let self, let viewModel else { return }
             let collectionKey: String?
             switch viewModel.state.collection.identifier {
             case .collection(let key):
@@ -379,15 +373,17 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
             case .search, .custom:
                 collectionKey = nil
             }
-            self.showItemCreation(library: viewModel.state.library, collectionKey: collectionKey)
+            showTypePicker(selected: "") { [weak self] type in
+                self?.showItemDetail(for: .creation(type: type, child: nil, collectionKey: collectionKey), library: viewModel.state.library, scrolledToKey: nil, animated: true)
+            }
         }))
 
         controller.addAction(UIAlertAction(title: L10n.Items.newNote, style: .default, handler: { [weak self, weak viewModel] _ in
-            guard let self = self, let viewModel = viewModel else { return }
+            guard let self, let viewModel else { return }
             let key = KeyGenerator.newKey
-            self.showNoteCreation(title: nil, libraryId: viewModel.state.library.identifier, save: { [weak viewModel] text, tags in
+            showNote(with: "", tags: [], title: nil, key: nil, libraryId: viewModel.state.library.identifier, readOnly: false) { [weak viewModel] text, tags in
                 viewModel?.process(action: .saveNote(key, text, tags))
-            })
+            }
         }))
 
         controller.addAction(UIAlertAction(title: L10n.Items.newFile, style: .default, handler: { [weak self, weak viewModel] _ in
@@ -691,11 +687,7 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
     }
 }
 
-extension DetailCoordinator: DetailItemActionSheetCoordinatorDelegate {
-    func showNoteCreation(title: NoteEditorState.TitleData?, libraryId: LibraryIdentifier, save: @escaping (String, [Tag]) -> Void) {
-        self.showNote(with: "", tags: [], title: title, key: nil, libraryId: libraryId, readOnly: false, save: save)
-    }
-
+extension DetailCoordinator: DetailItemDetailCoordinatorDelegate {
     func showAttachmentPicker(save: @escaping ([URL]) -> Void) {
         guard let navigationController else { return }
         let controller = DocumentPickerViewController(forOpeningContentTypes: [.pdf, .png, .jpeg], asCopy: true)
@@ -709,14 +701,6 @@ extension DetailCoordinator: DetailItemActionSheetCoordinatorDelegate {
         navigationController.present(controller, animated: true, completion: nil)
     }
 
-    func showItemCreation(library: Library, collectionKey: String?) {
-        self.showTypePicker(selected: "") { [weak self] type in
-            self?.showItemDetail(for: .creation(type: type, child: nil, collectionKey: collectionKey), library: library, scrolledToKey: nil, animated: true)
-        }
-    }
-}
-
-extension DetailCoordinator: DetailItemDetailCoordinatorDelegate {
     func showAttachmentError(_ error: Error) {
         let (message, additionalActions) = self.attachmentMessageAndActions(for: error)
         let controller = UIAlertController(title: L10n.error, message: message, preferredStyle: .alert)

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -127,6 +127,7 @@ final class DetailCoordinator: Coordinator {
             syncScheduler: userControllers.syncScheduler,
             citationController: userControllers.citationController,
             fileCleanupController: userControllers.fileCleanupController,
+            openItemsController: userControllers.openItemsController,
             itemsTagFilterDelegate: self.itemsTagFilterDelegate,
             htmlAttributedStringConverter: self.controllers.htmlAttributedStringConverter
         )
@@ -143,6 +144,7 @@ final class DetailCoordinator: Coordinator {
         syncScheduler: SynchronizationScheduler,
         citationController: CitationController,
         fileCleanupController: AttachmentFileCleanupController,
+        openItemsController: OpenItemsController,
         itemsTagFilterDelegate: ItemsTagFilterDelegate?,
         htmlAttributedStringConverter: HtmlAttributedStringConverter
     ) -> ItemsViewController {
@@ -161,7 +163,8 @@ final class DetailCoordinator: Coordinator {
             downloadBatchData: downloadBatchData,
             remoteDownloadBatchData: remoteDownloadBatchData,
             identifierLookupBatchData: identifierLookupBatchData,
-            error: nil
+            error: nil,
+            openItemsCount: openItemsController.items.count
         )
         let handler = ItemsActionHandler(
             dbStorage: dbStorage,
@@ -293,6 +296,7 @@ final class DetailCoordinator: Coordinator {
         self.childCoordinators.append(coordinator)
         coordinator.start(animated: false)
 
+        controllers.userControllers?.openItemsController.open(.pdf(library: library, key: key, url: url))
         self.navigationController?.present(navigationController, animated: true, completion: nil)
     }
 

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -287,19 +287,32 @@ final class DetailCoordinator: Coordinator {
         navigationController.present(controller, animated: true, completion: nil)
     }
 
-    private func showPdf(at url: URL, key: String, library: Library) {
+    func createPDFController(key: String, library: Library, url: URL, page: Int? = nil, preselectedAnnotationKey: String? = nil) -> NavigationViewController {
         let navigationController = NavigationViewController()
         navigationController.modalPresentationStyle = .fullScreen
-
-        let coordinator = PDFCoordinator(key: key, library: library, url: url, page: nil, preselectedAnnotationKey: nil, navigationController: navigationController, controllers: self.controllers)
+        
+        let coordinator = PDFCoordinator(
+            key: key,
+            library: library,
+            url: url,
+            page: page,
+            preselectedAnnotationKey: preselectedAnnotationKey,
+            navigationController: navigationController,
+            controllers: controllers
+        )
         coordinator.parentCoordinator = self
-        self.childCoordinators.append(coordinator)
+        childCoordinators.append(coordinator)
         coordinator.start(animated: false)
-
-        controllers.userControllers?.openItemsController.open(.pdf(library: library, key: key, url: url))
-        self.navigationController?.present(navigationController, animated: true, completion: nil)
+        
+        return navigationController
     }
-
+    
+    private func showPdf(at url: URL, key: String, library: Library) {
+        let controller = createPDFController(key: key, library: library, url: url)
+        controllers.userControllers?.openItemsController.open(.pdf(library: library, collection: collection, key: key))
+        navigationController?.present(controller, animated: true, completion: nil)
+    }
+    
     private func showWebView(for url: URL) {
         guard let currentNavigationController = self.navigationController else { return }
         let controller = WebViewController(url: url)

--- a/Zotero/Scenes/Detail/ItemDetail/Models/ItemDetailAction.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/Models/ItemDetailAction.swift
@@ -26,7 +26,7 @@ enum ItemDetailAction {
     case openAttachment(String)
     case attachmentOpened(String)
     case reloadData
-    case saveNote(key: String, text: String, tags: [Tag])
+    case processNoteSaveResult(key: String?, result: NoteEditorSaveResult)
     case setFieldValue(id: String, value: String)
     case setTags([Tag])
     case setTitle(String)

--- a/Zotero/Scenes/Detail/ItemDetail/ViewModels/ItemDetailActionHandler.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/ViewModels/ItemDetailActionHandler.swift
@@ -332,8 +332,7 @@ struct ItemDetailActionHandler: ViewModelActionHandler, BackgroundDbProcessingAc
             }
         }
         switch result {
-        case .success((let key, let text, let tags)):
-            let note = Note(key: key, text: text, tags: tags)
+        case .success(let note):
             update(viewModel: viewModel) { state in
                 if let oldIndex {
                     state.notes[oldIndex] = note

--- a/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailViewController.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailViewController.swift
@@ -129,7 +129,7 @@ final class ItemDetailViewController: UIViewController {
                 tags: (note?.tags ?? []),
                 title: title,
                 key: note?.key,
-                libraryId: library.identifier,
+                library: library,
                 readOnly: !library.metadataEditable,
                 save: { [weak self] text, tags in
                     self?.viewModel.process(action: .saveNote(key: key, text: text, tags: tags))

--- a/Zotero/Scenes/Detail/Items/Models/ItemsAction.swift
+++ b/Zotero/Scenes/Detail/Items/Models/ItemsAction.swift
@@ -49,5 +49,5 @@ enum ItemsAction {
     case quickCopyBibliography(Set<String>, LibraryIdentifier, WKWebView)
     case startSync
     case emptyTrash
-    case updateOpenItems(items: [OpenItemsController.Item])
+    case updateOpenItems(items: [OpenItem])
 }

--- a/Zotero/Scenes/Detail/Items/Models/ItemsAction.swift
+++ b/Zotero/Scenes/Detail/Items/Models/ItemsAction.swift
@@ -28,7 +28,7 @@ enum ItemsAction {
     case observingFailed
     case removeDownloads(Set<String>)
     case restoreItems(Set<String>)
-    case saveNote(String, String, [Tag])
+    case processNoteSaveResult(NoteEditorSaveResult)
     case search(String)
     case selectItem(String)
     case setSortField(ItemsSortType.Field)

--- a/Zotero/Scenes/Detail/Items/Models/ItemsAction.swift
+++ b/Zotero/Scenes/Detail/Items/Models/ItemsAction.swift
@@ -49,4 +49,5 @@ enum ItemsAction {
     case quickCopyBibliography(Set<String>, LibraryIdentifier, WKWebView)
     case startSync
     case emptyTrash
+    case updateOpenItems(items: [OpenItemsController.Item])
 }

--- a/Zotero/Scenes/Detail/Items/Models/ItemsState.swift
+++ b/Zotero/Scenes/Detail/Items/Models/ItemsState.swift
@@ -24,6 +24,7 @@ struct ItemsState: ViewModelState {
         static let filters = Changes(rawValue: 1 << 5)
         static let webViewCleanup = Changes(rawValue: 1 << 6)
         static let batchData = Changes(rawValue: 1 << 7)
+        static let openItems = Changes(rawValue: 1 << 8)
     }
 
     struct DownloadBatchData: Equatable {
@@ -112,6 +113,7 @@ struct ItemsState: ViewModelState {
     var itemTitleFont: UIFont {
         return UIFont.preferredFont(for: .headline, weight: .regular)
     }
+    var openItemsCount: Int
 
     var tagsFilter: Set<String>? {
         let tagFilter = self.filters.first(where: { filter in
@@ -134,7 +136,8 @@ struct ItemsState: ViewModelState {
         downloadBatchData: DownloadBatchData?,
         remoteDownloadBatchData: DownloadBatchData?,
         identifierLookupBatchData: IdentifierLookupBatchData,
-        error: ItemsError?
+        error: ItemsError?,
+        openItemsCount: Int
     ) {
         self.collection = collection
         self.library = library
@@ -153,6 +156,7 @@ struct ItemsState: ViewModelState {
         self.searchTerm = searchTerm
         self.processingBibliography = false
         self.itemTitles = [:]
+        self.openItemsCount = openItemsCount
     }
 
     mutating func cleanup() {

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
@@ -203,6 +203,14 @@ struct ItemsActionHandler: ViewModelActionHandler, BackgroundDbProcessingActionH
             self.update(viewModel: viewModel) { state in
                 state.itemTitles = [:]
             }
+            
+        case .updateOpenItems(let items):
+            update(viewModel: viewModel) { state in
+                if state.openItemsCount != items.count {
+                    state.openItemsCount = items.count
+                    state.changes = .openItems
+                }
+            }
         }
     }
 

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -48,10 +48,15 @@ final class ItemsViewController: UIViewController {
     private weak var webView: WKWebView?
     weak var tagFilterDelegate: ItemsTagFilterDelegate?
 
-    private weak var coordinatorDelegate: DetailItemsCoordinatorDelegate?
+    private weak var coordinatorDelegate: (DetailItemsCoordinatorDelegate & DetailNoteEditorCoordinatorDelegate)?
     private weak var presenter: OpenItemsPresenter?
 
-    init(viewModel: ViewModel<ItemsActionHandler>, controllers: Controllers, coordinatorDelegate: DetailItemsCoordinatorDelegate, presenter: OpenItemsPresenter) {
+    init(
+        viewModel: ViewModel<ItemsActionHandler>,
+        controllers: Controllers,
+        coordinatorDelegate: (DetailItemsCoordinatorDelegate & DetailNoteEditorCoordinatorDelegate),
+        presenter: OpenItemsPresenter
+    ) {
         self.viewModel = viewModel
         self.controllers = controllers
         self.coordinatorDelegate = coordinatorDelegate
@@ -253,17 +258,9 @@ final class ItemsViewController: UIViewController {
             guard let note = Note(item: item) else { return }
             let tags = Array(item.tags.map({ Tag(tag: $0) }))
             let library = self.viewModel.state.library
-            self.coordinatorDelegate?.showNote(
-                with: note.text,
-                tags: tags,
-                title: nil,
-                key: note.key,
-                library: library,
-                readOnly: !library.metadataEditable,
-                save: { [weak self] newText, newTags in
-                    self?.viewModel.process(action: .saveNote(note.key, newText, newTags))
-                }
-            )
+            self.coordinatorDelegate?.showNote(library: library, kind: .edit(key: note.key), text: note.text, tags: tags, title: nil) { [weak self] result in
+                self?.viewModel.process(action: .processNoteSaveResult(result))
+            }
         }
     }
 

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -653,8 +653,8 @@ final class ItemsViewController: UIViewController {
                 image = UIImage(systemName: "0.square")
                 accessibilityLabel = L10n.Items.restoreOpen
                 action = { [weak self] _ in
-                    guard let self, let presenter, let controller = controllers.userControllers?.openItemsController else { return }
-                    controller.restoreMostRecentlyOpenedItem(using: presenter)
+                    guard let self, let presenter, let controller = controllers.userControllers?.openItemsController, let sessionIdentifier = view.scene?.session.persistentIdentifier else { return }
+                    controller.restoreMostRecentlyOpenedItem(using: presenter, sessionIdentifier: sessionIdentifier)
                 }
             }
             
@@ -718,8 +718,8 @@ final class ItemsViewController: UIViewController {
     }
     
     private func setupOpenItemsObserving() {
-        guard let controller = controllers.userControllers?.openItemsController else { return }
-        controller.observable
+        guard let controller = controllers.userControllers?.openItemsController, let sessionIdentifier = view.scene?.session.persistentIdentifier else { return }
+        controller.observable(for: sessionIdentifier)
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] items in
                 self?.viewModel.process(action: .updateOpenItems(items: items))

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -258,7 +258,7 @@ final class ItemsViewController: UIViewController {
                 tags: tags,
                 title: nil,
                 key: note.key,
-                libraryId: library.identifier,
+                library: library,
                 readOnly: !library.metadataEditable,
                 save: { [weak self] newText, newTags in
                     self?.viewModel.process(action: .saveNote(note.key, newText, newTags))

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -49,11 +49,13 @@ final class ItemsViewController: UIViewController {
     weak var tagFilterDelegate: ItemsTagFilterDelegate?
 
     private weak var coordinatorDelegate: DetailItemsCoordinatorDelegate?
+    private weak var presenter: OpenItemsPresenter?
 
-    init(viewModel: ViewModel<ItemsActionHandler>, controllers: Controllers, coordinatorDelegate: DetailItemsCoordinatorDelegate) {
+    init(viewModel: ViewModel<ItemsActionHandler>, controllers: Controllers, coordinatorDelegate: DetailItemsCoordinatorDelegate, presenter: OpenItemsPresenter) {
         self.viewModel = viewModel
         self.controllers = controllers
         self.coordinatorDelegate = coordinatorDelegate
+        self.presenter = presenter
         self.disposeBag = DisposeBag()
 
         super.init(nibName: "ItemsViewController", bundle: nil)
@@ -654,9 +656,8 @@ final class ItemsViewController: UIViewController {
                 image = UIImage(systemName: "0.square")
                 accessibilityLabel = L10n.Items.restoreOpen
                 action = { [weak self] _ in
-                    // TODO: Add action that restores open items via coordinator or delegate
-                    guard let self else { return }
-                    print("Restore Open Items")
+                    guard let self, let presenter, let controller = controllers.userControllers?.openItemsController else { return }
+                    controller.restoreMostRecentlyOpenedItem(using: presenter)
                 }
             }
             

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -526,7 +526,7 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
 }
 
 extension PDFCoordinator: OpenItemsPresenter {
-    func showPDF(at url: URL, key: String, library: Library) {
-        (parentCoordinator as? DetailCoordinator)?.showPDF(at: url, key: key, library: library)
+    func showItem(with presentation: ItemPresentation) {
+        (parentCoordinator as? OpenItemsPresenter)?.showItem(with: presentation)
     }
 }

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -524,3 +524,9 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
         self.navigationController?.present(navigationController, animated: true, completion: nil)
     }
 }
+
+extension PDFCoordinator: OpenItemsPresenter {
+    func showPDF(at url: URL, key: String, library: Library) {
+        (parentCoordinator as? DetailCoordinator)?.showPDF(at: url, key: key, library: library)
+    }
+}

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -77,7 +77,8 @@ final class PDFCoordinator: Coordinator {
         guard let dbStorage = self.controllers.userControllers?.dbStorage,
               let userId = self.controllers.sessionController.sessionData?.userId,
               !username.isEmpty,
-              let parentNavigationController = self.parentCoordinator?.navigationController
+              let parentNavigationController = self.parentCoordinator?.navigationController,
+              let openItemsController = controllers.userControllers?.openItemsController
         else { return }
 
         let settings = Defaults.shared.pdfSettings
@@ -104,7 +105,8 @@ final class PDFCoordinator: Coordinator {
         )
         let controller = PDFReaderViewController(
             viewModel: ViewModel(initialState: state, handler: handler),
-            compactSize: UIDevice.current.isCompactWidth(size: parentNavigationController.view.frame.size)
+            compactSize: UIDevice.current.isCompactWidth(size: parentNavigationController.view.frame.size),
+            openItemsController: openItemsController
         )
         controller.coordinatorDelegate = self
         handler.delegate = controller

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -23,8 +23,8 @@ protocol PDFReaderContainerDelegate: AnyObject {
 
 class PDFReaderViewController: UIViewController {
     private enum NavigationBarButton: Int {
-        case share
-        case sidebar
+        case share = 1
+        case sidebar = 7
     }
 
     private struct ToolbarState: Codable {

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -94,6 +94,7 @@ class PDFReaderViewController: UIViewController {
         return self.navigationController?.navigationBar.frame.height ?? 0.0
     }
 
+    private unowned let openItemsController: OpenItemsController
     weak var coordinatorDelegate: (PdfReaderCoordinatorDelegate & PdfAnnotationsCoordinatorDelegate)?
 
     private lazy var shareButton: UIBarButtonItem = {
@@ -172,11 +173,12 @@ class PDFReaderViewController: UIViewController {
         return barButton
     }()
 
-    init(viewModel: ViewModel<PDFReaderActionHandler>, compactSize: Bool) {
+    init(viewModel: ViewModel<PDFReaderActionHandler>, compactSize: Bool, openItemsController: OpenItemsController) {
         self.viewModel = viewModel
         self.isSidebarTransitioning = false
         self.isCompactWidth = compactSize
         self.isCurrentlyVisible = false
+        self.openItemsController = openItemsController
         self.disposeBag = DisposeBag()
         self.didAppear = false
         self.previewDashColor = Asset.Colors.zoteroBlueWithDarkMode.color.withAlphaComponent(0.5)
@@ -205,7 +207,7 @@ class PDFReaderViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.set(userActivity: .pdfActivity(for: self.viewModel.state.key, libraryId: self.viewModel.state.library.identifier, collectionId: Defaults.shared.selectedCollectionId))
+        self.set(userActivity: .pdfActivity(with: openItemsController.items, libraryId: self.viewModel.state.library.identifier, collectionId: Defaults.shared.selectedCollectionId))
 
         self.view.backgroundColor = .systemGray6
         self.setupViews()

--- a/Zotero/Scenes/General/Models/NoteEditorAction.swift
+++ b/Zotero/Scenes/General/Models/NoteEditorAction.swift
@@ -12,4 +12,5 @@ enum NoteEditorAction {
     case save
     case setTags([Tag])
     case setText(String)
+    case updateOpenItems(items: [OpenItem])
 }

--- a/Zotero/Scenes/General/Models/NoteEditorState.swift
+++ b/Zotero/Scenes/General/Models/NoteEditorState.swift
@@ -8,7 +8,26 @@
 
 import Foundation
 
+typealias NoteEditorKind = NoteEditorState.Kind
+
 struct NoteEditorState: ViewModelState {
+    enum Kind {
+        case itemCreation(parentKey: String)
+        case standaloneCreation(collection: Collection)
+        case edit(key: String)
+        case readOnly(key: String)
+
+        var readOnly: Bool {
+            switch self {
+            case .readOnly:
+                return true
+
+            default:
+                return false
+            }
+        }
+    }
+
     struct Changes: OptionSet {
         typealias RawValue = UInt8
 
@@ -23,24 +42,28 @@ struct NoteEditorState: ViewModelState {
         let title: String
     }
 
-    let title: TitleData?
-    let libraryId: LibraryIdentifier
-    let readOnly: Bool
+    enum Error: Swift.Error {
+        case cantSaveReadonlyNote
+    }
 
+    let library: Library
+    let title: TitleData?
+
+    var kind: Kind
     var text: String
     var tags: [Tag]
     var changes: Changes
 
-    init(title: TitleData?, text: String, tags: [Tag], libraryId: LibraryIdentifier, readOnly: Bool) {
+    init(kind: Kind, library: Library, title: TitleData?, text: String, tags: [Tag]) {
+        self.kind = kind
         self.text = text
         self.tags = tags
+        self.library = library
         self.title = title
-        self.libraryId = libraryId
-        self.readOnly = readOnly
-        self.changes = []
+        changes = []
     }
 
     mutating func cleanup() {
-        self.changes = []
+        changes = []
     }
 }

--- a/Zotero/Scenes/General/Models/NoteEditorState.swift
+++ b/Zotero/Scenes/General/Models/NoteEditorState.swift
@@ -35,6 +35,7 @@ struct NoteEditorState: ViewModelState {
 
         static let tags = Changes(rawValue: 1 << 0)
         static let save = Changes(rawValue: 1 << 1)
+        static let openItems = Changes(rawValue: 1 << 2)
     }
 
     struct TitleData {
@@ -53,14 +54,16 @@ struct NoteEditorState: ViewModelState {
     var text: String
     var tags: [Tag]
     var changes: Changes
+    var openItemsCount: Int
 
-    init(kind: Kind, library: Library, title: TitleData?, text: String, tags: [Tag]) {
+    init(kind: Kind, library: Library, title: TitleData?, text: String, tags: [Tag], openItemsCount: Int) {
         self.kind = kind
         self.text = text
         self.tags = tags
         self.library = library
         self.title = title
         changes = []
+        self.openItemsCount = openItemsCount
     }
 
     mutating func cleanup() {

--- a/Zotero/Scenes/General/NoteEditorCoordinator.swift
+++ b/Zotero/Scenes/General/NoteEditorCoordinator.swift
@@ -35,6 +35,7 @@ final class NoteEditorCoordinator: NSObject, Coordinator {
     private let title: NoteEditorState.TitleData?
     private let library: Library
     private let saveCallback: NoteEditorSaveCallback
+    private let sessionIdentifier: String
     private unowned let controllers: Controllers
 
     init(
@@ -45,6 +46,7 @@ final class NoteEditorCoordinator: NSObject, Coordinator {
         title: NoteEditorState.TitleData?,
         saveCallback: @escaping NoteEditorSaveCallback,
         navigationController: NavigationViewController,
+        sessionIdentifier: String,
         controllers: Controllers
     ) {
         self.kind = kind
@@ -54,6 +56,7 @@ final class NoteEditorCoordinator: NSObject, Coordinator {
         self.library = library
         self.saveCallback = saveCallback
         self.navigationController = navigationController
+        self.sessionIdentifier = sessionIdentifier
         self.controllers = controllers
         childCoordinators = []
 
@@ -72,7 +75,7 @@ final class NoteEditorCoordinator: NSObject, Coordinator {
     func start(animated: Bool) {
         guard let dbStorage = controllers.userControllers?.dbStorage, let openItemsController = controllers.userControllers?.openItemsController else { return }
 
-        let state = NoteEditorState(kind: kind, library: library, title: title, text: initialText, tags: initialTags, openItemsCount: openItemsController.items.count)
+        let state = NoteEditorState(kind: kind, library: library, title: title, text: initialText, tags: initialTags, openItemsCount: openItemsController.getItems(for: sessionIdentifier).count)
         let handler = NoteEditorActionHandler(dbStorage: dbStorage, schemaController: controllers.schemaController, saveCallback: saveCallback)
         let viewModel = ViewModel(initialState: state, handler: handler)
         let controller = NoteEditorViewController(viewModel: viewModel, openItemsController: openItemsController)

--- a/Zotero/Scenes/General/NoteEditorCoordinator.swift
+++ b/Zotero/Scenes/General/NoteEditorCoordinator.swift
@@ -70,12 +70,12 @@ final class NoteEditorCoordinator: NSObject, Coordinator {
     }
 
     func start(animated: Bool) {
-        guard let dbStorage = controllers.userControllers?.dbStorage else { return }
+        guard let dbStorage = controllers.userControllers?.dbStorage, let openItemsController = controllers.userControllers?.openItemsController else { return }
 
-        let state = NoteEditorState(kind: kind, library: library, title: title, text: initialText, tags: initialTags)
+        let state = NoteEditorState(kind: kind, library: library, title: title, text: initialText, tags: initialTags, openItemsCount: openItemsController.items.count)
         let handler = NoteEditorActionHandler(dbStorage: dbStorage, schemaController: controllers.schemaController, saveCallback: saveCallback)
         let viewModel = ViewModel(initialState: state, handler: handler)
-        let controller = NoteEditorViewController(viewModel: viewModel)
+        let controller = NoteEditorViewController(viewModel: viewModel, openItemsController: openItemsController)
         controller.coordinatorDelegate = self
         navigationController?.setViewControllers([controller], animated: animated)
     }
@@ -111,5 +111,11 @@ extension NoteEditorCoordinator: NoteEditorCoordinatorDelegate {
         controller.transitioningDelegate = self.transitionDelegate
         transitionDelegate = nil
         navigationController.present(controller, animated: true, completion: nil)
+    }
+}
+
+extension NoteEditorCoordinator: OpenItemsPresenter {
+    func showItem(with presentation: ItemPresentation) {
+        (parentCoordinator as? OpenItemsPresenter)?.showItem(with: presentation)
     }
 }

--- a/Zotero/Scenes/General/NoteEditorCoordinator.swift
+++ b/Zotero/Scenes/General/NoteEditorCoordinator.swift
@@ -21,7 +21,7 @@ protocol NoteEditorCoordinatorDelegate: AnyObject {
 }
 
 final class NoteEditorCoordinator: NSObject, Coordinator {
-    typealias SaveResult = Result<(String, String, [Tag]), Error>
+    typealias SaveResult = Result<Note, Error>
     typealias SaveCallback = (SaveResult) -> Void
 
     weak var parentCoordinator: Coordinator?

--- a/Zotero/Scenes/General/ViewModels/NoteEditorActionHandler.swift
+++ b/Zotero/Scenes/General/ViewModels/NoteEditorActionHandler.swift
@@ -45,6 +45,14 @@ struct NoteEditorActionHandler: ViewModelActionHandler, BackgroundDbProcessingAc
                 state.tags = tags
                 state.changes = [.tags, .save]
             }
+
+        case .updateOpenItems(let items):
+            update(viewModel: viewModel) { state in
+                if state.openItemsCount != items.count {
+                    state.openItemsCount = items.count
+                    state.changes = .openItems
+                }
+            }
         }
 
         func save(viewModel: ViewModel<NoteEditorActionHandler>) {

--- a/Zotero/Scenes/General/ViewModels/NoteEditorActionHandler.swift
+++ b/Zotero/Scenes/General/ViewModels/NoteEditorActionHandler.swift
@@ -8,28 +8,121 @@
 
 import Foundation
 
-struct NoteEditorActionHandler: ViewModelActionHandler {
+import CocoaLumberjackSwift
+
+struct NoteEditorActionHandler: ViewModelActionHandler, BackgroundDbProcessingActionHandler {
     typealias Action = NoteEditorAction
     typealias State = NoteEditorState
+    typealias SaveResult = NoteEditorSaveResult
+    typealias SaveCallback = NoteEditorSaveCallback
 
-    let saveAction: (String, [Tag]) -> Void
+    unowned let dbStorage: DbStorage
+    unowned let schemaController: SchemaController
+    let saveCallback: SaveCallback
+    let backgroundQueue: DispatchQueue
+
+    init(dbStorage: DbStorage, schemaController: SchemaController, saveCallback: @escaping SaveCallback) {
+        self.dbStorage = dbStorage
+        self.schemaController = schemaController
+        self.saveCallback = saveCallback
+        backgroundQueue = DispatchQueue(label: "org.zotero.Zotero.NoteEditorActionHandler.queue", qos: .userInteractive)
+    }
 
     func process(action: Action, in viewModel: ViewModel<NoteEditorActionHandler>) {
         switch action {
         case .save:
-            self.saveAction(viewModel.state.text, viewModel.state.tags)
+            save(viewModel: viewModel)
 
         case .setText(let text):
             guard text != viewModel.state.text else { return }
-            self.update(viewModel: viewModel) { state in
+            update(viewModel: viewModel) { state in
                 state.text = text
                 state.changes = .save
             }
 
         case .setTags(let tags):
-            self.update(viewModel: viewModel) { state in
+            update(viewModel: viewModel) { state in
                 state.tags = tags
                 state.changes = [.tags, .save]
+            }
+        }
+
+        func save(viewModel: ViewModel<NoteEditorActionHandler>) {
+            let kind = viewModel.state.kind
+            let library = viewModel.state.library
+            let text = viewModel.state.text
+            let tags = viewModel.state.tags
+
+            switch kind {
+            case .itemCreation(let parentKey):
+                createItemNote(library: library, parentKey: parentKey, text: text, tags: tags)
+
+            case .standaloneCreation(let collection):
+                createStandaloneNote(library: library, collection: collection, text: text, tags: tags)
+
+            case .edit(let key):
+                updateExistingNote(library: library, key: key, text: text, tags: tags)
+
+            case .readOnly:
+                let error = State.Error.cantSaveReadonlyNote
+                DDLogError("NoteEditorActionHandler: can't update read only note: \(error)")
+                saveCallback(.failure(error))
+            }
+
+            func createItemNote(library: Library, parentKey: String, text: String, tags: [Tag]) {
+                let key = KeyGenerator.newKey
+                let note = Note(key: key, text: text, tags: tags)
+                let type = schemaController.localized(itemType: ItemTypes.note) ?? ItemTypes.note
+                let request = CreateNoteDbRequest(note: note, localizedType: type, libraryId: library.identifier, collectionKey: nil, parentKey: parentKey)
+                createNote(request: request, key: key, text: text, tags: tags)
+            }
+
+            func createStandaloneNote(library: Library, collection: Collection, text: String, tags: [Tag]) {
+                let key = KeyGenerator.newKey
+                let note = Note(key: key, text: text, tags: tags)
+                let type = schemaController.localized(itemType: ItemTypes.note) ?? ItemTypes.note
+                let collectionKey: String?
+
+                switch collection.identifier {
+                case .collection(let key):
+                    collectionKey = key
+
+                default:
+                    collectionKey = nil
+                }
+
+                let request = CreateNoteDbRequest(note: note, localizedType: type, libraryId: library.identifier, collectionKey: collectionKey, parentKey: nil)
+                createNote(request: request, key: key, text: text, tags: tags)
+            }
+
+            func createNote<Request: DbResponseRequest>(request: Request, key: String, text: String, tags: [Tag]) {
+                perform(request: request, invalidateRealm: true) { result in
+                    switch result {
+                    case .success:
+                        update(viewModel: viewModel) { state in
+                            state.kind = .edit(key: key)
+                        }
+                        saveCallback(.success((key, text, tags)))
+
+                    case .failure(let error):
+                        DDLogError("NoteEditorActionHandler: can't create item note: \(error)")
+                        saveCallback(.failure(error))
+                    }
+                }
+            }
+
+            func updateExistingNote(library: Library, key: String, text: String, tags: [Tag]) {
+                let note = Note(key: key, text: text, tags: tags)
+
+                let request = EditNoteDbRequest(note: note, libraryId: library.identifier)
+                perform(request: request) { error in
+                    if let error {
+                        DDLogError("NoteEditorActionHandler: can't update existing note: \(error)")
+                        saveCallback(.failure(error))
+                    } else {
+                        saveCallback(.success((key, text, tags)))
+                    }
+                }
             }
         }
     }

--- a/Zotero/Scenes/General/Views/NoteEditorViewController.swift
+++ b/Zotero/Scenes/General/Views/NoteEditorViewController.swift
@@ -81,7 +81,7 @@ final class NoteEditorViewController: UIViewController {
 
             func rightBarButtonItemTypes(for state: NoteEditorState) -> [RightBarButtonItem] {
                 var items: [RightBarButtonItem] = [.done]
-                if state.openItemsCount > 0 {
+                if state.openItemsCount > 1 {
                     items = [.restoreOpenItems] + items
                 }
                 return items

--- a/Zotero/Scenes/General/Views/NoteEditorViewController.swift
+++ b/Zotero/Scenes/General/Views/NoteEditorViewController.swift
@@ -25,7 +25,7 @@ final class NoteEditorViewController: UIViewController {
     weak var coordinatorDelegate: NoteEditorCoordinatorDelegate?
 
     private var htmlUrl: URL? {
-        if viewModel.state.readOnly {
+        if viewModel.state.kind.readOnly {
             return Bundle.main.url(forResource: "note", withExtension: "html")
         } else {
             return Bundle.main.url(forResource: "index", withExtension: "html", subdirectory: "tinymce")
@@ -137,9 +137,9 @@ final class NoteEditorViewController: UIViewController {
     }
 
     @IBAction private func changeTags() {
-        guard !viewModel.state.readOnly else { return }
+        guard !viewModel.state.kind.readOnly else { return }
         let selected = Set(viewModel.state.tags.map({ $0.name }))
-        coordinatorDelegate?.showTagPicker(libraryId: viewModel.state.libraryId, selected: selected, picked: { [weak self] tags in
+        coordinatorDelegate?.showTagPicker(libraryId: viewModel.state.library.identifier, selected: selected, picked: { [weak self] tags in
             self?.viewModel.process(action: .setTags(tags))
         })
     }

--- a/Zotero/Scenes/Main/Views/MainViewController.swift
+++ b/Zotero/Scenes/Main/Views/MainViewController.swift
@@ -24,6 +24,7 @@ protocol MainCoordinatorSyncToolbarDelegate: AnyObject {
 
 final class MainViewController: UISplitViewController {
     // Constants
+    private let sessionIdentifier: String
     private let controllers: Controllers
     private let disposeBag: DisposeBag
     // Variables
@@ -42,7 +43,8 @@ final class MainViewController: UISplitViewController {
 
     // MARK: - Lifecycle
 
-    init(controllers: Controllers) {
+    init(sessionIdentifier: String, controllers: Controllers) {
+        self.sessionIdentifier = sessionIdentifier
         self.controllers = controllers
         self.disposeBag = DisposeBag()
 
@@ -75,7 +77,7 @@ final class MainViewController: UISplitViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        self.set(userActivity: .mainActivity(with: controllers.userControllers?.openItemsController.items ?? []))
+        self.set(userActivity: .mainActivity(with: controllers.userControllers?.openItemsController.getItems(for: sessionIdentifier) ?? []))
         self.didAppear = true
     }
 
@@ -97,6 +99,7 @@ final class MainViewController: UISplitViewController {
             searchItemKeys: searchItemKeys,
             navigationController: navigationController,
             itemsTagFilterDelegate: tagFilterController,
+            sessionIdentifier: sessionIdentifier,
             controllers: self.controllers
         )
         coordinator.start(animated: false)

--- a/Zotero/Scenes/Main/Views/MainViewController.swift
+++ b/Zotero/Scenes/Main/Views/MainViewController.swift
@@ -14,12 +14,8 @@ import SwiftUI
 import CocoaLumberjackSwift
 import RxSwift
 
-protocol MainCoordinatorDelegate: SplitControllerDelegate {
-    func showItems(for collection: Collection, in library: Library, saveCollectionToDefaults: Bool)
-}
-
-protocol SplitControllerDelegate: AnyObject {
-    var isSplit: Bool { get }
+protocol MainCoordinatorDelegate: AnyObject {
+    func showItems(for collection: Collection, in library: Library)
 }
 
 protocol MainCoordinatorSyncToolbarDelegate: AnyObject {
@@ -130,12 +126,9 @@ extension MainViewController: UISplitViewControllerDelegate {
 }
 
 extension MainViewController: MainCoordinatorDelegate {
-    func showItems(for collection: Collection, in library: Library, saveCollectionToDefaults: Bool) {
-        if saveCollectionToDefaults {
-            Defaults.shared.selectedCollectionId = collection.identifier
-        }
-        guard !self.isSplit || self.detailCoordinator?.library != library || self.detailCoordinator?.collection.identifier != collection.identifier else { return }
-        self.showItems(for: collection, in: library, searchItemKeys: nil)
+    func showItems(for collection: Collection, in library: Library) {
+        guard isCollapsed || detailCoordinator?.library != library || detailCoordinator?.collection.identifier != collection.identifier else { return }
+        showItems(for: collection, in: library, searchItemKeys: nil)
     }
 }
 
@@ -161,11 +154,5 @@ extension MainViewController: MainCoordinatorSyncToolbarDelegate {
         } catch let error {
             DDLogError("MainViewController: can't load searched keys - \(error)")
         }
-    }
-}
-
-extension MainViewController: SplitControllerDelegate {
-    var isSplit: Bool {
-        return !self.isCollapsed
     }
 }

--- a/Zotero/Scenes/Main/Views/MainViewController.swift
+++ b/Zotero/Scenes/Main/Views/MainViewController.swift
@@ -75,7 +75,7 @@ final class MainViewController: UISplitViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        self.set(userActivity: .mainActivity)
+        self.set(userActivity: .mainActivity(with: controllers.userControllers?.openItemsController.items ?? []))
         self.didAppear = true
     }
 

--- a/Zotero/Scenes/Master/MasterCoordinator.swift
+++ b/Zotero/Scenes/Master/MasterCoordinator.swift
@@ -229,13 +229,9 @@ extension MasterCoordinator: MasterCollectionsCoordinatorDelegate {
         self.navigationController?.present(navigationController, animated: true, completion: nil)
     }
 
-    func showItems(for collection: Collection, in library: Library, saveCollectionToDefaults: Bool) {
+    func showItems(for collection: Collection, in library: Library) {
         self.visibleLibraryId = library.identifier
-        self.mainCoordinatorDelegate.showItems(for: collection, in: library, saveCollectionToDefaults: saveCollectionToDefaults)
-    }
-
-    var isSplit: Bool {
-        return self.mainCoordinatorDelegate.isSplit
+        self.mainCoordinatorDelegate.showItems(for: collection, in: library)
     }
 
     func showCiteExport(for itemIds: Set<String>, libraryId: LibraryIdentifier) {
@@ -270,7 +266,7 @@ extension MasterCoordinator: MasterCollectionsCoordinatorDelegate {
     func showDefaultCollection() {
         let library = Library(identifier: visibleLibraryId, name: "", metadataEditable: true, filesEditable: true)
         let collection = Collection(custom: .all)
-        showItems(for: collection, in: library, saveCollectionToDefaults: false)
+        showItems(for: collection, in: library)
     }
 }
 


### PR DESCRIPTION
Adds support for multiple open items.

- [x] Keep track of open items in order of most recently opened
- [x] Show in items navigation bar button that restores last item and shows count of currently open items
- [x] Save/restore state of open items
- [x] Add support for PDF items
- [x] Add support for note items
- [x] Show in presented item navigation bar button menu that allows to quickly switch to another open item 
- [ ] Allow user to change order of presented open items

In consideration
- [x] Support separate open items for multiple windows
- [ ] Opening an already opened item in another window, should switch to that