### PR TITLE
Improve annotation page label

### DIFF
--- a/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationPageLabelViewController.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationPageLabelViewController.swift
@@ -97,7 +97,7 @@ extension AnnotationPageLabelViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: section.cellId, for: indexPath)
 
         if let cell = cell as? TextFieldCell {
-            cell.setup(with: self.viewModel.state.label)
+            cell.setup(with: self.viewModel.state.label, delegate: self)
             cell.textObservable
                 .subscribe(onNext: { [weak self] text in
                     self?.viewModel.process(action: .setLabel(text))
@@ -113,5 +113,12 @@ extension AnnotationPageLabelViewController: UITableViewDataSource {
         }
 
         return cell
+    }
+}
+
+extension AnnotationPageLabelViewController: UITextFieldDelegate {
+    static let maxLength = 16
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        (textField.text?.count ?? 0) + string.count - range.length <= Self.maxLength
     }
 }

--- a/Zotero/Scenes/Detail/Annotation Popover/Views/TextFieldCell.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/Views/TextFieldCell.swift
@@ -22,7 +22,8 @@ final class TextFieldCell: RxTableViewCell {
         self.textField.becomeFirstResponder()
     }
 
-    func setup(with text: String) {
-        self.textField.text = text
+    func setup(with text: String, delegate: UITextFieldDelegate? = nil) {
+        textField.text = text
+        textField.delegate = delegate
     }
 }

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHeader.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHeader.swift
@@ -176,14 +176,14 @@ final class AnnotationViewHeader: UIView {
         shareButton.setImage(UIImage(systemName: "square.and.arrow.up"), for: .normal)
         shareButton.tintColor = Asset.Colors.zoteroBlueWithDarkMode.color
         shareButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: layout.horizontalInset, bottom: 0, right: (layout.horizontalInset / 2))
-        shareButton.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        shareButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         shareButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         
         let menuButton = UIButton()
         menuButton.setImage(UIImage(systemName: "ellipsis"), for: .normal)
         menuButton.tintColor = Asset.Colors.zoteroBlueWithDarkMode.color
         menuButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: (layout.horizontalInset / 2), bottom: 0, right: (layout.horizontalInset / 2))
-        menuButton.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        menuButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         menuButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
 
         var rightButtons: [UIView] = [shareButton, menuButton]
@@ -194,7 +194,7 @@ final class AnnotationViewHeader: UIView {
             doneButton.setTitleColor(Asset.Colors.zoteroBlueWithDarkMode.color, for: .normal)
             doneButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: (layout.horizontalInset / 2), bottom: 0, right: layout.horizontalInset)
             doneButton.titleLabel?.adjustsFontForContentSizeCategory = true
-            doneButton.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+            doneButton.setContentCompressionResistancePriority(.required, for: .horizontal)
             doneButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
             rightButtons.append(doneButton)
             self.doneButton = doneButton

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHeader.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHeader.swift
@@ -12,6 +12,8 @@ import RxCocoa
 import RxSwift
 
 final class AnnotationViewHeader: UIView {
+    let layout: AnnotationViewLayout
+    
     private weak var typeImageView: UIImageView!
     private weak var pageLabel: UILabel!
     private weak var authorLabel: UILabel!
@@ -21,6 +23,7 @@ final class AnnotationViewHeader: UIView {
     private weak var lockIcon: UIImageView?
     private weak var rightBarButtonsStackView: UIStackView!
 
+    private var pageTrailingToAuthor: NSLayoutConstraint!
     private var authorTrailingToContainer: NSLayoutConstraint!
     private var authorTrailingToButton: NSLayoutConstraint!
 
@@ -37,6 +40,7 @@ final class AnnotationViewHeader: UIView {
     }
 
     init(layout: AnnotationViewLayout) {
+        self.layout = layout
         super.init(frame: CGRect())
 
         self.translatesAutoresizingMaskIntoConstraints = false
@@ -102,6 +106,8 @@ final class AnnotationViewHeader: UIView {
         self.menuButton.isHidden = !showsMenuButton
         self.lockIcon?.isHidden = !showsLock
 
+        pageTrailingToAuthor.constant = author.isEmpty ? 0 : layout.horizontalInset
+        
         let hasRightItems = !self.rightBarButtonsStackView.arrangedSubviews.filter({ !$0.isHidden }).isEmpty
         self.authorTrailingToButton.isActive = hasRightItems
         self.authorTrailingToContainer.isActive = !hasRightItems
@@ -226,6 +232,7 @@ final class AnnotationViewHeader: UIView {
         self.addSubview(authorLabel)
         self.addSubview(rightBarButtons)
 
+        pageTrailingToAuthor = authorLabel.leadingAnchor.constraint(greaterThanOrEqualTo: pageLabel.trailingAnchor)
         self.authorTrailingToContainer = self.trailingAnchor.constraint(greaterThanOrEqualTo: authorLabel.trailingAnchor, constant: layout.horizontalInset)
         self.authorTrailingToButton = rightBarButtons.leadingAnchor.constraint(greaterThanOrEqualTo: authorLabel.trailingAnchor, constant: layout.horizontalInset)
         let authorCenter = authorLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor)
@@ -244,7 +251,7 @@ final class AnnotationViewHeader: UIView {
             typeImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: layout.horizontalInset),
             pageLabel.leadingAnchor.constraint(equalTo: typeImageView.trailingAnchor, constant: layout.pageLabelLeadingOffset),
             authorCenter,
-            authorLabel.leadingAnchor.constraint(greaterThanOrEqualTo: pageLabel.trailingAnchor, constant: layout.horizontalInset),
+            pageTrailingToAuthor,
             rightBarButtons.trailingAnchor.constraint(equalTo: self.trailingAnchor)
         ])
     }


### PR DESCRIPTION
Closes #781

The same annotation page label max length as in the macOS client is used, but since the API does allow a larger limit, we may want to revisit that.