### PR TITLE
Fixed CocoaLumberjack crashes on older iOSes

### DIFF
--- a/Zotero/Controllers/Debugging/ApiLogger.swift
+++ b/Zotero/Controllers/Debugging/ApiLogger.swift
@@ -55,8 +55,11 @@ struct ApiLogger {
         if startData.logParams.contains(.headers) {
             self.log(headers: headers ?? [:])
         }
-        if startData.logParams.contains(.response), let data = data, let string = String(data: data, encoding: .utf8) {
-            DDLogInfo(string)
+        if startData.logParams.contains(.response), let data = data, var string = String(data: data, encoding: .utf8) {
+            if string.count > 5000 {
+                string = String(string.prefix(5000))
+            }
+            DDLogInfo(DDLogMessageFormat(stringLiteral: string))
         }
     }
 
@@ -70,7 +73,7 @@ struct ApiLogger {
         if error.response.isEmpty || error.response == "No Response" {
             DDLogError("\(error.error)")
         } else {
-            DDLogError(error.response)
+            DDLogError(DDLogMessageFormat(stringLiteral: error.response))
         }
     }
 
@@ -84,7 +87,7 @@ struct ApiLogger {
         let method = urlRequest.httpMethod ?? "-"
         let url = urlRequest.url?.absoluteString ?? "-"
         let identifier = ApiLogger.identifier(method: method, url: url)
-        DDLogInfo(identifier)
+        DDLogInfo(DDLogMessageFormat(stringLiteral: identifier))
         return identifier
     }
 
@@ -103,7 +106,8 @@ struct ApiLogger {
         switch encoding {
         case .json, .array:
             if let data = urlRequest.httpBody, let string = String(data: data, encoding: .utf8) {
-                DDLogInfo(self.redact(parameters: string))
+                let message = DDLogMessageFormat(stringLiteral: self.redact(parameters: string))
+                DDLogInfo(message)
             }
 
         case .data:
@@ -119,7 +123,7 @@ struct ApiLogger {
         guard !headers.isEmpty,
               let data = try? JSONSerialization.data(withJSONObject: self.redact(headers: headers), options: .prettyPrinted),
               let string = String(data: data, encoding: .utf8) else { return }
-        DDLogInfo(string)
+        DDLogInfo(DDLogMessageFormat(stringLiteral: string))
     }
 
     // MARK: - Redacting

--- a/Zotero/Scenes/AppCoordinator.swift
+++ b/Zotero/Scenes/AppCoordinator.swift
@@ -163,8 +163,12 @@ final class AppCoordinator: NSObject {
             self.showItemDetail(key: key, library: library, selectChildKey: preselectedChildKey, animated: animated)
 
         case .pdfReader(let attachment, let library, let page, let annotation, let parentKey, let isAvailable):
-            DDLogInfo("AppCoordinator: show custom url - pdf reader; key=\(attachment.key); library=\(library.identifier); page=\(page.flatMap(String.init) ?? "nil");" +
-                      " annotation=\(annotation ?? "nil"); parentKey=\(parentKey ?? "nil")")
+            let message = DDLogMessageFormat(
+                stringLiteral:
+                    "AppCoordinator: show custom url - pdf reader; key=\(attachment.key); library=\(library.identifier);" +
+                    " page=\(page.flatMap(String.init) ?? "nil"); annotation=\(annotation ?? "nil"); parentKey=\(parentKey ?? "nil")"
+            )
+            DDLogInfo(message)
             if isAvailable {
                 self.open(attachment: attachment, library: library, on: page, annotation: annotation, parentKey: parentKey, animated: animated)
                 return


### PR DESCRIPTION
I was able to reproduce and fix the issue on iOS 15.5 simulator. Unfortunately it was issue in CocoaLumberjack, the crash pointed to `String(format: storage.format, arguments: storage.args)` `EXC_BAD_ACCESS (code=EXC_I386_GPFLT)`. So I just limited the size of string to 5k characters.

Fixes #785