### PR TITLE
Fixed missing dispose bag in AnnotationCell

### DIFF
--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
@@ -47,7 +47,7 @@ final class AnnotationView: UIView {
     private var tags: AnnotationViewText!
     private var scrollView: UIScrollView?
     private var scrollViewContent: UIView?
-    private(set) var disposeBag: CompositeDisposable!
+    private(set) var disposeBag: CompositeDisposable?
 
     var tagString: String? {
         return self.tags.textLabel.text

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationCell.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationCell.swift
@@ -18,7 +18,7 @@ final class AnnotationCell: UITableViewCell {
     var actionPublisher: PublishSubject<AnnotationView.Action> {
         return self.annotationView.actionPublisher
     }
-    var disposeBag: CompositeDisposable {
+    var disposeBag: CompositeDisposable? {
         return self.annotationView.disposeBag
     }
 
@@ -37,7 +37,7 @@ final class AnnotationCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         self.key = ""
-        disposeBag.dispose()
+        disposeBag?.dispose()
     }
 
     // MARK: - Actions

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationsViewController.swift
@@ -321,7 +321,7 @@ final class AnnotationsViewController: UIViewController {
         let actionSubscription = cell.actionPublisher.subscribe(onNext: { [weak self] action in
             self?.perform(action: action, annotation: annotation)
         })
-        _ = cell.disposeBag.insert(actionSubscription)
+        _ = cell.disposeBag?.insert(actionSubscription)
     }
 
     private func loadAttributedComment(for annotation: Annotation) -> NSAttributedString? {


### PR DESCRIPTION
We had some crashes in `AnnotationCell.prepareForReuse()` because the `disposeBag` was `nil`.