### PR TITLE
Improve master container bottom additional safe area inset

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         xcode: ["15.0.0"]
-        destination: 
-          - platform=iOS Simulator,OS=latest,name=iPhone 15
+        ios_version: ["17.0"]
+        device_name: ["iPhone 15"]
         
     steps:
       - name: Checkout
@@ -35,18 +35,10 @@ jobs:
         with:
           xcode-version: ${{ matrix.xcode }}
 
-      - name: Cache DerivedData
-        uses: actions/cache@v3
-        with:
-          path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ runner.os }}-iOS_derived_data-xcode_${{ matrix.xcode }}
-          restore-keys: |
-            ${{ runner.os }}-iOS_derived_data
-
-      - name: Build & Test
+      - name: Clean & Build & Test
         uses: sersoft-gmbh/xcodebuild-action@v3.1
         with:
           project: Zotero.xcodeproj
           scheme: Zotero
-          destination: ${{ matrix.destination }}
-          action: test
+          destination: platform=iOS Simulator,OS=${{ matrix.ios_version }},name=${{ matrix.device_name }}
+          action: clean test

--- a/Zotero/Scenes/Master/Collections/Views/CollectionsViewController.swift
+++ b/Zotero/Scenes/Master/Collections/Views/CollectionsViewController.swift
@@ -192,3 +192,5 @@ extension CollectionsViewController: UIContextMenuInteractionDelegate {
         })
     }
 }
+
+extension CollectionsViewController: BottomSheetObserver { }

--- a/Zotero/Scenes/Master/Libraries/Views/LibrariesViewController.swift
+++ b/Zotero/Scenes/Master/Libraries/Views/LibrariesViewController.swift
@@ -207,3 +207,5 @@ extension LibrariesViewController: UITableViewDataSource, UITableViewDelegate {
         }
     }
 }
+
+extension LibrariesViewController: BottomSheetObserver { }

--- a/Zotero/Scenes/Master/MasterContainerViewController.swift
+++ b/Zotero/Scenes/Master/MasterContainerViewController.swift
@@ -333,9 +333,6 @@ final class MasterContainerViewController: UINavigationController {
 
         set(bottomPosition: bottomPosition, containerHeight: size.height, keyboardHeight: keyboardHeight)
 
-        coordinator.animate(alongsideTransition: { _ in
-            self.view.layoutIfNeeded()
-        }, completion: nil)
         coordinator.animate { _ in
             self.view.layoutIfNeeded()
         } completion: { _ in


### PR DESCRIPTION
https://forums.zotero.org/discussion/108739/ios-tag-pane-prevents-scrolling-collections/

Adjusts additional safe area insets for interested view controllers, so they can always scroll to bottom of their content, regardless of the bottom sheet height.