### PR TITLE
Improve current scene key window detection

### DIFF
--- a/Zotero/Extensions/UIView+Extensions.swift
+++ b/Zotero/Extensions/UIView+Extensions.swift
@@ -12,4 +12,12 @@ extension UIView {
     static var nibName: String {
         return String(describing: self)
     }
+
+    @objc override var scene: UIScene? {
+        if let window {
+            window.windowScene
+        } else {
+            next?.scene
+        }
+    }
 }

--- a/Zotero/Extensions/UIViewController+Extensions.swift
+++ b/Zotero/Extensions/UIViewController+Extensions.swift
@@ -10,6 +10,12 @@ import UIKit
 
 import CocoaLumberjackSwift
 
+extension UIResponder {
+    @objc var scene: UIScene? {
+        nil
+    }
+}
+
 extension UIViewController {
     func showAlert(for error: Error, cancelled: @escaping () -> Void) {
         let controller = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
@@ -45,5 +51,19 @@ extension UIViewController {
             return viewController.view.window
         }
         return self.view.window
+    }
+
+    @objc override var scene: UIScene? {
+        // From https://stackoverflow.com/questions/56588843/uiapplication-shared-delegate-equivalent-for-scenedelegate-xcode11/56589151#56589151
+        // Traversing the responder chain to find the scene this view controller belongs to. Trying sibling(s).
+        if let scene = next?.scene {
+            return scene
+        }
+        // Sibling responder(s) didn't return a scene. Trying parent.
+        if let scene = parent?.scene {
+            return scene
+        }
+        // Parent also didn't return a scene. Trying presenting view controller.
+        return presentingViewController?.scene
     }
 }

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -1420,7 +1420,7 @@ extension PDFReaderViewController: AnnotationToolbarDelegate {
             return self.isCompactWidth ? documentController.view.frame.size.width : (documentController.view.frame.size.width - (2 * PDFReaderViewController.toolbarFullInsetInset))
 
         case .trailing, .leading:
-            let window = UIApplication.shared.windows.first(where: \.isKeyWindow)
+            let window = (view.scene as? UIWindowScene)?.windows.first(where: \.isKeyWindow)
             let topInset = window?.safeAreaInsets.top ?? 0
             let bottomInset = window?.safeAreaInsets.bottom ?? 0
             let interfaceIsHidden = self.navigationController?.isNavigationBarHidden ?? false


### PR DESCRIPTION
* Fixes warning due to deprecation
* Correctly detects key window if multiple scenes of Zotero are in the screen (e.g. in iPad side-by-side)

(Will also be useful for proper multiple open items logic in the side-by-side case)