### PR TITLE
Improve text conversion for copying and highlighting from PDF documents

### DIFF
--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		61ABA7512A6137D1002A4219 /* ShareableImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61ABA7502A6137D1002A4219 /* ShareableImage.swift */; };
 		61BD13952A5831EF008A0704 /* TextKit1TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BD13942A5831EF008A0704 /* TextKit1TextView.swift */; };
 		61C817F22A49B5D30085B1E6 /* CollectionResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1EDEE250242E700D8BC1E /* CollectionResponseSpec.swift */; };
+		61FA14CE2B05081D00E7D423 /* TextConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FA14CD2B05081D00E7D423 /* TextConverter.swift */; };
 		B300B33324291C8D00C1FE1E /* RTranslatorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = B300B33224291C8D00C1FE1E /* RTranslatorMetadata.swift */; };
 		B300B3352429222B00C1FE1E /* TranslatorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = B300B3342429222B00C1FE1E /* TranslatorMetadata.swift */; };
 		B300B3362429234C00C1FE1E /* TranslatorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = B300B3342429222B00C1FE1E /* TranslatorMetadata.swift */; };
@@ -1202,6 +1203,7 @@
 		614D65842A7BCC22007CF449 /* ci_post_clone.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_clone.sh; sourceTree = "<group>"; };
 		61ABA7502A6137D1002A4219 /* ShareableImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableImage.swift; sourceTree = "<group>"; };
 		61BD13942A5831EF008A0704 /* TextKit1TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextKit1TextView.swift; sourceTree = "<group>"; };
+		61FA14CD2B05081D00E7D423 /* TextConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextConverter.swift; sourceTree = "<group>"; };
 		B300B33224291C8D00C1FE1E /* RTranslatorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTranslatorMetadata.swift; sourceTree = "<group>"; };
 		B300B3342429222B00C1FE1E /* TranslatorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslatorMetadata.swift; sourceTree = "<group>"; };
 		B300B3372429254900C1FE1E /* SyncTranslatorsDbRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTranslatorsDbRequest.swift; sourceTree = "<group>"; };
@@ -2161,6 +2163,7 @@
 				B3593F172668E6A700FA4BB2 /* StyleParserDelegate.swift */,
 				B355B12B2850B6C400BAE2C5 /* TableViewDiffableDataSource.swift */,
 				B36BEC7224485FC700A60552 /* TagColorGenerator.swift */,
+				61FA14CD2B05081D00E7D423 /* TextConverter.swift */,
 				B36A988C2428E059005D5790 /* TranslatorsAndStylesController.swift */,
 				B3972688247D403200A8B469 /* UrlDetector.swift */,
 				B324276C25C81F2000567504 /* WebSocketController.swift */,
@@ -4631,6 +4634,7 @@
 				B34A4B7226E65FC200B3E993 /* LineWidthCell.swift in Sources */,
 				B30565CE23FC051E003304F2 /* StoreGroupDbRequest.swift in Sources */,
 				B3E8FE7C2714358E00F51458 /* GeneralSettingsViewModel.swift in Sources */,
+				61FA14CE2B05081D00E7D423 /* TextConverter.swift in Sources */,
 				B340868925D574D6000F4446 /* RestoreDeletionsSyncAction.swift in Sources */,
 				B330260D25DE9A1100742025 /* RPageIndex.swift in Sources */,
 				B3F0C400250A1DD7002D557A /* LibraryRow.swift in Sources */,

--- a/Zotero/Controllers/AnnotationConverter.swift
+++ b/Zotero/Controllers/AnnotationConverter.swift
@@ -18,15 +18,6 @@ struct AnnotationConverter {
         case zotero
     }
 
-    private static var newlineExpression: NSRegularExpression? = {
-        do {
-            return try NSRegularExpression(pattern: #"(?<!\.)\s*[\n\r]+\s*"#)
-        } catch let error {
-            DDLogError("AnnotationConverter: can't create newline expression - \(error)")
-            return nil
-        }
-    }()
-
     // MARK: - Helpers
 
     /// Creates sort index from annotation and bounding box.
@@ -103,7 +94,7 @@ struct AnnotationConverter {
         } else if let annotation = annotation as? PSPDFKit.HighlightAnnotation {
             type = .highlight
             rects = self.rects(fromHighlightAnnotation: annotation)
-            text = self.removeNewlines(from: annotation.markedUpString)
+            text = TextConverter.convertTextForAnnotation(from: annotation.markedUpString)
             paths = []
             lineWidth = nil
         } else if let annotation = annotation as? PSPDFKit.SquareAnnotation {
@@ -138,19 +129,6 @@ struct AnnotationConverter {
             sortIndex: sortIndex,
             dateModified: date
         )
-    }
-
-    static func removeNewlines(from string: String) -> String {
-        guard let expression = self.newlineExpression else { return string }
-
-        let matches = expression.matches(in: string, options: [], range: NSRange(string.startIndex..., in: string))
-
-        var newString = string
-        for match in matches.reversed() {
-            guard let range = Range(match.range, in: newString) else { continue }
-            newString = newString.replacingCharacters(in: range, with: " ")
-        }
-        return newString.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     static func paths(from annotation: PSPDFKit.InkAnnotation) -> [[CGPoint]] {

--- a/Zotero/Controllers/TextConverter.swift
+++ b/Zotero/Controllers/TextConverter.swift
@@ -1,0 +1,78 @@
+//
+//  TextConverter.swift
+//  Zotero
+//
+//  Created by Miltiadis Vasilakis on 15/11/23.
+//  Copyright © 2023 Corporation for Digital Scholarship. All rights reserved.
+//
+
+import Foundation
+
+import CocoaLumberjackSwift
+
+struct TextConverter {
+    private static var hyphenAndNewlineExpression: NSRegularExpression? = {
+        do {
+            let pattern = #"[\x2D\u058A\u05BE\u1400\u1806\u2010-\u2015\u2E17\u2E1A\u2E3A\u2E3B\u301C\u3030\u30A0\uFE31\uFE32\uFE58\uFE63\uFF0D][\n\r]+"#
+            return try NSRegularExpression(pattern: pattern)
+        } catch let error {
+            DDLogError("CopiedTextConverter: can't create hyphen and newline expression - \(error)")
+            return nil
+        }
+    }()
+
+    private static var newlineExpression: NSRegularExpression? = {
+        do {
+            let pattern = #"[\n\r]+"#
+            return try NSRegularExpression(pattern: pattern)
+        } catch let error {
+            DDLogError("CopiedTextConverter: can't create newline expression - \(error)")
+            return nil
+        }
+    }()
+
+    private static var newlineOptionallySurroundedByWhitespaceExcludingEndingSentencesExpression: NSRegularExpression? = {
+        do {
+            let pattern = #"(?<!\.)\s*[\n\r]+\s*"#
+            return try NSRegularExpression(pattern: pattern)
+        } catch let error {
+            DDLogError("CopiedTextConverter: can't create newline optionally surrounded by whitespace excluding ending sentences expression - \(error)")
+            return nil
+        }
+    }()
+
+    private static func replaceMatches(of expression: NSRegularExpression, with replacement: String, in string: String) -> String {
+        let matches = expression.matches(in: string, options: [], range: NSRange(string.startIndex..., in: string))
+        var newString = string
+        for match in matches.reversed() {
+            guard let range = Range(match.range, in: newString) else { continue }
+            newString = newString.replacingCharacters(in: range, with: replacement)
+        }
+        return newString
+    }
+
+    static func removeHyphenAndNewlinePairs(from string: String) -> String {
+        guard let expression = hyphenAndNewlineExpression else { return string }
+        return replaceMatches(of: expression, with: "", in: string)
+    }
+
+    static func replaceNewlineOptionallySurroundedByWhitespaceExcludingEndingSentencesExpressionWithSingleSpace(from string: String) -> String {
+        guard let expression = newlineOptionallySurroundedByWhitespaceExcludingEndingSentencesExpression else { return string }
+        return replaceMatches(of: expression, with: " ", in: string)
+    }
+
+    static func replaceNewlinesWithSingleSpace(from string: String) -> String {
+        guard let expression = newlineExpression else { return string }
+        return replaceMatches(of: expression, with: " ", in: string)
+    }
+
+    static func convertTextForAnnotation(from string: String) -> String {
+        let stringWithoutHyphens = removeHyphenAndNewlinePairs(from: string)
+        return replaceNewlineOptionallySurroundedByWhitespaceExcludingEndingSentencesExpressionWithSingleSpace(from: stringWithoutHyphens).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func convertTextForCopying(from string: String) -> String {
+        let stringWithoutHyphens = removeHyphenAndNewlinePairs(from: string)
+        return replaceNewlinesWithSingleSpace(from: stringWithoutHyphens)
+    }
+}

--- a/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
@@ -620,7 +620,18 @@ extension PDFDocumentViewController: PDFViewControllerDelegate {
             forMenu: suggestedMenu,
             predicate: { menuId, action -> UIAction? in
                 switch menuId {
-                case .standardEdit, .PSPDFKit.accessibility:
+                case .standardEdit:
+                    switch action.identifier {
+                    case .PSPDFKit.copy:
+                        return action.replacing(title: L10n.copy, handler: { _ in
+                            UIPasteboard.general.string = TextConverter.convertTextForCopying(from: glyphs.text)
+                        })
+
+                    default:
+                        return action
+                    }
+
+                case .PSPDFKit.accessibility:
                     return action
 
                 case .share:


### PR DESCRIPTION
* Improves copied text from PDF documents by glueing hyphenated words in new lines and removing new lines.
* Improves annotation text by by glueing hyphenated before certain new lines are removed.

Improvement mentioned in this [forum discussion](https://forums.zotero.org/discussion/109222/ios-pdf-reader-improvement-request)
With some info from from https://github.com/zotero/zotero-ios/issues/308

~- [ ] Also add database migration for annotation text if needed.~