### PR TITLE
Fix CI MARKETING_VERSION

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -77,5 +77,4 @@ esac
 
 # Update Info.plist files
 echo "Setting version to $newVersionString"
-/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $newVersionString" ../Zotero/Info.plist
-/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $newVersionString" ../ZShare/Info.plist
+sed -i "" -e "s/MARKETING_VERSION \= [^\;]*\;/MARKETING_VERSION = $newVersionString;/" ../Zotero.xcodeproj/project.pbxproj


### PR DESCRIPTION
Update MARKETING_VERSION instead of CFBundleShortVersionString in CI post clone script, as the latter is also used for tagging the commit used in the build.