### PR TITLE
Fix document search source when navigation bar is hidden

### DIFF
--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -188,7 +188,6 @@ extension PDFCoordinator: PdfReaderCoordinatorDelegate {
             }
 
             existing.overrideUserInterfaceStyle = userInterfaceStyle
-            existing.modalPresentationStyle = UIDevice.current.userInterfaceIdiom == .pad ? .popover : .formSheet
             setupPresentation(for: existing, with: sender)
             existing.text = text
 
@@ -213,7 +212,6 @@ extension PDFCoordinator: PdfReaderCoordinatorDelegate {
                     popoverPresentationController.barButtonItem = sender
                 }
                 popoverPresentationController.sourceView = nil
-                popoverPresentationController.sourceRect = .null
             } else {
                 if #available(iOS 17, *) {
                     popoverPresentationController.sourceItem = nil
@@ -221,8 +219,8 @@ extension PDFCoordinator: PdfReaderCoordinatorDelegate {
                     popoverPresentationController.barButtonItem = nil
                 }
                 popoverPresentationController.sourceView = navigationController?.view
-                popoverPresentationController.sourceRect = .zero
             }
+            popoverPresentationController.sourceRect = .zero
         }
     }
 

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -189,7 +189,7 @@ extension PDFCoordinator: PdfReaderCoordinatorDelegate {
 
             existing.overrideUserInterfaceStyle = userInterfaceStyle
             existing.modalPresentationStyle = UIDevice.current.userInterfaceIdiom == .pad ? .popover : .formSheet
-            existing.popoverPresentationController?.barButtonItem = sender
+            setupPresentation(for: existing, with: sender)
             existing.text = text
 
             self.navigationController?.present(existing, animated: true, completion: nil)
@@ -199,10 +199,31 @@ extension PDFCoordinator: PdfReaderCoordinatorDelegate {
         let viewController = PDFSearchViewController(controller: pdfController, text: text)
         viewController.delegate = delegate
         viewController.overrideUserInterfaceStyle = userInterfaceStyle
-        viewController.modalPresentationStyle = UIDevice.current.userInterfaceIdiom == .pad ? .popover : .formSheet
-        viewController.popoverPresentationController?.barButtonItem = sender
+        setupPresentation(for: viewController, with: sender)
         self.pdfSearchController = viewController
         self.navigationController?.present(viewController, animated: true, completion: nil)
+
+        func setupPresentation(for pdfSearchController: PDFSearchViewController, with sender: UIBarButtonItem) {
+            pdfSearchController.modalPresentationStyle = UIDevice.current.userInterfaceIdiom == .pad ? .popover : .formSheet
+            guard let popoverPresentationController = pdfSearchController.popoverPresentationController else { return }
+            if navigationController?.isNavigationBarHidden == false {
+                if #available(iOS 17, *) {
+                    popoverPresentationController.sourceItem = sender
+                } else {
+                    popoverPresentationController.barButtonItem = sender
+                }
+                popoverPresentationController.sourceView = nil
+                popoverPresentationController.sourceRect = .null
+            } else {
+                if #available(iOS 17, *) {
+                    popoverPresentationController.sourceItem = nil
+                } else {
+                    popoverPresentationController.barButtonItem = nil
+                }
+                popoverPresentationController.sourceView = navigationController?.view
+                popoverPresentationController.sourceRect = .zero
+            }
+        }
     }
 
     func share(url: URL, barButton: UIBarButtonItem) {


### PR DESCRIPTION
Fixes issue in https://forums.zotero.org/discussion/109983/ipados-17-2-zotero-beta-1-0-25-crash-when-searching-in-pdf-cmd-f

If the document screen is restored without a navigation bar, then the navigation item of the document view controller is not yet utilized by the navigaton controller. Hence, the bar button item used as the source for the search popover, is not part of the view hierarchy. Since search can be shown via external keyboard, with combination `command+F`, to be on the safe side, if the navigation bar is hidden, we use a source view and rect instead.