### PR TITLE
Fix HtmlAttributedStringConverter emoji support

### DIFF
--- a/Zotero/Controllers/HtmlAttributedStringConverter.swift
+++ b/Zotero/Controllers/HtmlAttributedStringConverter.swift
@@ -21,10 +21,17 @@ final class HtmlAttributedStringConverter {
     func convert(attributedString: NSAttributedString) -> String {
         var attributes: [Attribute] = []
 
+        var previousRange: NSRange?
         attributedString.enumerateAttributes(in: NSRange(location: 0, length: attributedString.length), options: []) { nsAttributes, range, _ in
-            let attributedPrefix = attributedString.attributedSubstring(from: NSRange(location: 0, length: range.location))
-            let prefix = attributedPrefix.string
-            let prefixCount = prefix.count
+            let currentIndex: Int
+            if let previousRange {
+                let previousIndex = attributes.first.flatMap { $0.index } ?? 0
+                let previousAttributedSubstring = attributedString.attributedSubstring(from: previousRange)
+                let previousSubstring = previousAttributedSubstring.string
+                currentIndex = previousIndex + previousSubstring.count
+            } else {
+                currentIndex = 0
+            }
             // Currently active attributes
             let active = StringAttribute.attributes(from: nsAttributes)
             // Opened attributes so far
@@ -32,15 +39,16 @@ final class HtmlAttributedStringConverter {
             // Close opened attributes if they are not active anymore
             for openedAttribute in opened {
                 if !active.contains(openedAttribute) {
-                    attributes.insert(Attribute(type: openedAttribute, index: prefixCount, isClosing: true), at: 0)
+                    attributes.insert(Attribute(type: openedAttribute, index: currentIndex, isClosing: true), at: 0)
                 }
             }
             // Open new attributes
             for activeAttribute in active {
                 if !opened.contains(activeAttribute) {
-                    attributes.insert(Attribute(type: activeAttribute, index: prefixCount, isClosing: false), at: 0)
+                    attributes.insert(Attribute(type: activeAttribute, index: currentIndex, isClosing: false), at: 0)
                 }
             }
+            previousRange = range
         }
 
         // Close remaining attributes

--- a/Zotero/Controllers/HtmlAttributedStringConverter.swift
+++ b/Zotero/Controllers/HtmlAttributedStringConverter.swift
@@ -22,6 +22,9 @@ final class HtmlAttributedStringConverter {
         var attributes: [Attribute] = []
 
         attributedString.enumerateAttributes(in: NSRange(location: 0, length: attributedString.length), options: []) { nsAttributes, range, _ in
+            let attributedPrefix = attributedString.attributedSubstring(from: NSRange(location: 0, length: range.location))
+            let prefix = attributedPrefix.string
+            let prefixCount = prefix.count
             // Currently active attributes
             let active = StringAttribute.attributes(from: nsAttributes)
             // Opened attributes so far
@@ -29,13 +32,13 @@ final class HtmlAttributedStringConverter {
             // Close opened attributes if they are not active anymore
             for openedAttribute in opened {
                 if !active.contains(openedAttribute) {
-                    attributes.insert(Attribute(type: openedAttribute, index: range.location, isClosing: true), at: 0)
+                    attributes.insert(Attribute(type: openedAttribute, index: prefixCount, isClosing: true), at: 0)
                 }
             }
             // Open new attributes
             for activeAttribute in active {
                 if !opened.contains(activeAttribute) {
-                    attributes.insert(Attribute(type: activeAttribute, index: range.location, isClosing: false), at: 0)
+                    attributes.insert(Attribute(type: activeAttribute, index: prefixCount, isClosing: false), at: 0)
                 }
             }
         }

--- a/ZoteroTests/HtmlAttributedStringConverterSpec.swift
+++ b/ZoteroTests/HtmlAttributedStringConverterSpec.swift
@@ -180,7 +180,31 @@ final class HtmlAttributedStringConverterSpec: QuickSpec {
                     ([.bold, .italic], NSRange(location: 75, length: 17))
                 ]
                 let attributedString = NSMutableAttributedString(string: attributedStringRaw, attributes: [.font: font])
-                expect(attributedString.length).to(equal(attributedStringRaw.count))
+                expect(attributedString.string.count).to(equal(attributedStringRaw.count))
+                for (attributes, range) in attributesAndRanges {
+                    attributedString.addAttributes(StringAttribute.nsStringAttributes(from: attributes, baseFont: font), range: range)
+                }
+                let string = htmlConverter.convert(attributedString: attributedString)
+                expect(string).to(equal(htmlStringRaw))
+            }
+
+            it("converts attributed string with larger length than string count") {
+                let attributedStrintRawParts = [
+                    #"This is bold\nas is this. "#,
+                    #"Now it is not 😏😂😚👩🏿‍💻 but 2 lines down it is again\n\n"#,
+                    #"    here that is 😏😂😚👩🏼‍💻   . \nThe end."#
+                ]
+                let attributedStringRaw = attributedStrintRawParts.joined()
+                let htmlStringRaw = "<b>" + attributedStrintRawParts[0] + "</b>" + attributedStrintRawParts[1] + "<b>" + attributedStrintRawParts[2] + "</b>"
+                let attributesAndRanges: [([StringAttribute], NSRange)] = [
+                    ([.bold], NSRange(location: 0, length: NSAttributedString(string: attributedStrintRawParts[0]).length)),
+                    ([.bold], NSRange(
+                        location: NSAttributedString(string: attributedStrintRawParts[0] + attributedStrintRawParts[1]).length,
+                        length: NSAttributedString(string: attributedStrintRawParts[2]).length)
+                    )
+                ]
+                let attributedString = NSMutableAttributedString(string: attributedStringRaw, attributes: [.font: font])
+                expect(attributedString.string.count).to(equal(attributedStringRaw.count))
                 for (attributes, range) in attributesAndRanges {
                     attributedString.addAttributes(StringAttribute.nsStringAttributes(from: attributes, baseFont: font), range: range)
                 }


### PR DESCRIPTION
When emojis with a combined grapheme cluster are used, the conversion fails, because `NSAttributedString.length` doesn't take this into account. 
`AttributedString.characters.count` has the expected value, so we could also switch to that, if there is no other reason not to.