### PR TITLE
Fix bugs

### DIFF
--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -587,6 +587,7 @@ final class ItemsViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         controller.obscuresBackgroundDuringPresentation = false
+        controller.delegate = self
         navigationItem.hidesSearchBarWhenScrolling = false
         navigationItem.searchController = controller
     }
@@ -656,5 +657,11 @@ extension ItemsViewController: TagFilterDelegate {
 
     func tagOptionsDidChange() {
         self.updateTagFilter(with: self.viewModel.state)
+    }
+}
+
+extension ItemsViewController: UISearchControllerDelegate {
+    func didDismissSearchController(_ searchController: UISearchController) {
+        viewModel.process(action: .search(""))
     }
 }

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -302,7 +302,11 @@ final class ItemsViewController: UIViewController {
             self.coordinatorDelegate?.showCiteExport(for: selectedKeys, libraryId: self.viewModel.state.library.identifier)
 
         case .copyBibliography:
-            coordinatorDelegate?.copyBibliography(using: self, for: selectedKeys, libraryId: viewModel.state.library.identifier, delegate: nil)
+            var presenter: UIViewController = self
+            if let searchController = navigationItem.searchController, searchController.isActive {
+                presenter = searchController
+            }
+            coordinatorDelegate?.copyBibliography(using: presenter, for: selectedKeys, libraryId: viewModel.state.library.identifier, delegate: nil)
 
         case .copyCitation:
             coordinatorDelegate?.showCitation(using: nil, for: selectedKeys, libraryId: viewModel.state.library.identifier, delegate: nil)


### PR DESCRIPTION
Fixes 2 issues reported in this forum [post](https://forums.zotero.org/discussion/111064/ios-beta-filter-bugs):
* Fixes copy bibliography regression when showing items search results.
* Resets items search results when search is dismissed by tapping the `Cancel` button.