### PR TITLE
Fix AnnotationToolbarViewController value change

### DIFF
--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationToolOptionsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationToolOptionsViewController.swift
@@ -150,6 +150,7 @@ class AnnotationToolOptionsViewController: UIViewController {
         }
 
         func update(state: AnnotationToolOptionsState) {
+            valueChanged(state.colorHex, state.size)
             if state.changes.contains(.color) {
                 presentingViewController?.dismiss(animated: true)
             }
@@ -165,10 +166,5 @@ class AnnotationToolOptionsViewController: UIViewController {
             size.height += 2 * Self.verticalInset
             preferredContentSize = CGSize(width: Self.width, height: size.height)
         }
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        valueChanged(viewModel.state.colorHex, viewModel.state.size)
     }
 }


### PR DESCRIPTION
Issue reported in forum [post](https://forums.zotero.org/discussion/111633/mobile-drawing-tool-thickness-not-properly-updated/p1)

Will always pass any value change (color and/or size), and not wait for dismissal.
Since there is no cancel action, there is no reason not to simplify as such.