### PR TITLE
Fix initial caching of annotation comment not yet visible in the sidebar

### DIFF
--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -56,6 +56,7 @@ protocol PdfAnnotationsCoordinatorDelegate: AnyObject {
         userInterfaceStyle: UIUserInterfaceStyle,
         completed: @escaping (AnnotationsFilter?) -> Void
     )
+    func parseAndCacheIfNeededAttributedComment(viewModel: ViewModel<PDFReaderActionHandler>, annotation: PDFAnnotation) -> NSAttributedString?
 }
 
 final class PDFCoordinator: Coordinator {
@@ -184,7 +185,7 @@ extension PDFCoordinator: PdfReaderCoordinatorDelegate {
         navigationController.overrideUserInterfaceStyle = userInterfaceStyle
 
         let author = viewModel.state.library.identifier == .custom(.myLibrary) ? "" : annotation.author(displayName: viewModel.state.displayName, username: viewModel.state.username)
-        let comment = viewModel.state.comments[annotation.key] ?? NSAttributedString()
+        let comment = parseAndCacheIfNeededAttributedComment(viewModel: viewModel, annotation: annotation) ?? NSAttributedString()
         let editability = annotation.editability(currentUserId: viewModel.state.userId, library: viewModel.state.library)
 
         let data = AnnotationPopoverState.Data(
@@ -582,6 +583,18 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
         }
         
         self.navigationController?.present(navigationController, animated: true, completion: nil)
+    }
+
+    func parseAndCacheIfNeededAttributedComment(viewModel: ViewModel<PDFReaderActionHandler>, annotation: PDFAnnotation) -> NSAttributedString? {
+        let comment = annotation.comment
+        guard !comment.isEmpty else { return nil }
+
+        if let attributedComment = viewModel.state.comments[annotation.key] {
+            return attributedComment
+        }
+
+        viewModel.process(action: .parseAndCacheComment(key: annotation.key, comment: comment))
+        return viewModel.state.comments[annotation.key]
     }
 }
 

--- a/Zotero/Scenes/Detail/PDF/Views/PDFAnnotationsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFAnnotationsViewController.swift
@@ -297,7 +297,8 @@ final class PDFAnnotationsViewController: UIViewController {
 
         switch annotation.type {
         case .image:
-            comment = .init(attributedString: self.loadAttributedComment(for: annotation), isActive: state.selectedAnnotationCommentActive)
+            let attributedString = coordinatorDelegate?.parseAndCacheIfNeededAttributedComment(viewModel: viewModel, annotation: annotation) ?? NSAttributedString()
+            comment = .init(attributedString: attributedString, isActive: state.selectedAnnotationCommentActive)
             preview = loadPreview()
 
         case .ink:
@@ -305,7 +306,8 @@ final class PDFAnnotationsViewController: UIViewController {
             preview = loadPreview()
 
         case .note, .highlight:
-            comment = .init(attributedString: self.loadAttributedComment(for: annotation), isActive: state.selectedAnnotationCommentActive)
+            let attributedString = coordinatorDelegate?.parseAndCacheIfNeededAttributedComment(viewModel: viewModel, annotation: annotation) ?? NSAttributedString()
+            comment = .init(attributedString: attributedString, isActive: state.selectedAnnotationCommentActive)
             preview = nil
         }
 
@@ -329,19 +331,6 @@ final class PDFAnnotationsViewController: UIViewController {
             self?.perform(action: action, annotation: annotation)
         })
         _ = cell.disposeBag?.insert(actionSubscription)
-    }
-
-    private func loadAttributedComment(for annotation: PDFAnnotation) -> NSAttributedString? {
-        let comment = annotation.comment
-
-        guard !comment.isEmpty else { return nil }
-
-        if let attributedComment = self.viewModel.state.comments[annotation.key] {
-            return attributedComment
-        }
-
-        self.viewModel.process(action: .parseAndCacheComment(key: annotation.key, comment: comment))
-        return self.viewModel.state.comments[annotation.key]
     }
 
     private func showFilterPopup(from barButton: UIBarButtonItem) {

--- a/Zotero/Scenes/Detail/PDF/Views/PDFAnnotationsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFAnnotationsViewController.swift
@@ -15,6 +15,10 @@ import RxSwift
 
 typealias AnnotationsViewControllerAction = (AnnotationView.Action, Annotation, UIButton) -> Void
 
+protocol AnnotationsDelegate: AnyObject {
+    func parseAndCacheIfNeededAttributedComment(for annotation: PDFAnnotation) -> NSAttributedString?
+}
+
 final class PDFAnnotationsViewController: UIViewController {
     private static let cellId = "AnnotationCell"
     private unowned let viewModel: ViewModel<PDFReaderActionHandler>
@@ -32,7 +36,7 @@ final class PDFAnnotationsViewController: UIViewController {
     private var searchController: UISearchController!
     private var isVisible: Bool
 
-    weak var parentDelegate: (PDFReaderContainerDelegate & SidebarDelegate)?
+    weak var parentDelegate: (PDFReaderContainerDelegate & SidebarDelegate & AnnotationsDelegate)?
     weak var coordinatorDelegate: PdfAnnotationsCoordinatorDelegate?
     weak var boundingBoxConverter: AnnotationBoundingBoxConverter?
 
@@ -297,7 +301,7 @@ final class PDFAnnotationsViewController: UIViewController {
 
         switch annotation.type {
         case .image:
-            let attributedString = coordinatorDelegate?.parseAndCacheIfNeededAttributedComment(viewModel: viewModel, annotation: annotation) ?? NSAttributedString()
+            let attributedString = parentDelegate?.parseAndCacheIfNeededAttributedComment(for: annotation) ?? NSAttributedString()
             comment = .init(attributedString: attributedString, isActive: state.selectedAnnotationCommentActive)
             preview = loadPreview()
 
@@ -306,7 +310,7 @@ final class PDFAnnotationsViewController: UIViewController {
             preview = loadPreview()
 
         case .note, .highlight:
-            let attributedString = coordinatorDelegate?.parseAndCacheIfNeededAttributedComment(viewModel: viewModel, annotation: annotation) ?? NSAttributedString()
+            let attributedString = parentDelegate?.parseAndCacheIfNeededAttributedComment(for: annotation) ?? NSAttributedString()
             comment = .init(attributedString: attributedString, isActive: state.selectedAnnotationCommentActive)
             preview = nil
         }

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -756,6 +756,20 @@ extension PDFReaderViewController: SidebarDelegate {
     }
 }
 
+extension PDFReaderViewController: AnnotationsDelegate {
+    func parseAndCacheIfNeededAttributedComment(for annotation: PDFAnnotation) -> NSAttributedString? {
+        let comment = annotation.comment
+        guard !comment.isEmpty else { return nil }
+
+        if let attributedComment = viewModel.state.comments[annotation.key] {
+            return attributedComment
+        }
+
+        viewModel.process(action: .parseAndCacheComment(key: annotation.key, comment: comment))
+        return viewModel.state.comments[annotation.key]
+    }
+}
+
 extension PDFReaderViewController: PDFDocumentDelegate {
     func annotationTool(
         didChangeStateFrom oldState: PSPDFKit.Annotation.Tool?,

--- a/Zotero/Scenes/Detail/PDF/Views/PDFSidebarViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFSidebarViewController.swift
@@ -47,7 +47,7 @@ class PDFSidebarViewController: UIViewController {
     private weak var thumbnailsController: PDFThumbnailsViewController!
     private weak var annotationsController: PDFAnnotationsViewController!
     private weak var outlineController: TableOfContentsViewController!
-    weak var parentDelegate: (PDFReaderContainerDelegate & SidebarDelegate)?
+    weak var parentDelegate: (PDFReaderContainerDelegate & SidebarDelegate & AnnotationsDelegate)?
     weak var coordinatorDelegate: PdfAnnotationsCoordinatorDelegate?
     weak var boundingBoxConverter: AnnotationBoundingBoxConverter?
 


### PR DESCRIPTION
Fixes regression where only annotation comments in the visible cells of the sidebar, are initially cached.
This leads to opening an annotation popover not cached, without an empty comment value.