### PR TITLE
Fix note editor callback for new notes in item details

### DIFF
--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -367,7 +367,7 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
 
         controller.addAction(UIAlertAction(title: L10n.Items.newNote, style: .default, handler: { [weak self, weak viewModel] _ in
             guard let self, let viewModel else { return }
-            showNote(library: viewModel.state.library, kind: .standaloneCreation(collection: viewModel.state.collection)) { [weak viewModel] result in
+            showNote(library: viewModel.state.library, kind: .standaloneCreation(collection: viewModel.state.collection)) { [weak viewModel] _, result in
                 viewModel?.process(action: .processNoteSaveResult(result))
             }
         }))
@@ -895,7 +895,7 @@ extension DetailCoordinator: DetailNoteEditorCoordinatorDelegate {
         text: String = "",
         tags: [Tag] = [],
         title: NoteEditorState.TitleData? = nil,
-        saveCallback: @escaping NoteEditorSaveCallback = { _ in }
+        saveCallback: @escaping NoteEditorSaveCallback = { _, _  in }
     ) {
         guard let navigationController else { return }
         let controller = createNoteController(library: library, kind: kind, text: text, tags: tags, title: title, saveCallback: saveCallback)

--- a/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailViewController.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailViewController.swift
@@ -135,8 +135,8 @@ final class ItemDetailViewController: UIViewController {
                 text = note.text
                 tags = note.tags
             }
-            coordinatorDelegate?.showNote(library: library, kind: kind, text: text, tags: tags, title: title) { [weak self] result in
-                self?.viewModel.process(action: .processNoteSaveResult(key: note?.key, result: result))
+            coordinatorDelegate?.showNote(library: library, kind: kind, text: text, tags: tags, title: title) { [weak self] key, result in
+                self?.viewModel.process(action: .processNoteSaveResult(key: key, result: result))
             }
 
         case .openTagPicker:

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -212,7 +212,7 @@ final class ItemsViewController: UIViewController {
             guard let note = Note(item: item) else { return }
             let tags = Array(item.tags.map({ Tag(tag: $0) }))
             let library = self.viewModel.state.library
-            coordinatorDelegate?.showNote(library: library, kind: .edit(key: note.key), text: note.text, tags: tags, title: nil) { [weak self] result in
+            coordinatorDelegate?.showNote(library: library, kind: .edit(key: note.key), text: note.text, tags: tags, title: nil) { [weak self] _, result in
                 self?.viewModel.process(action: .processNoteSaveResult(result))
             }
         }

--- a/Zotero/Scenes/General/NoteEditorCoordinator.swift
+++ b/Zotero/Scenes/General/NoteEditorCoordinator.swift
@@ -22,7 +22,7 @@ protocol NoteEditorCoordinatorDelegate: AnyObject {
 
 final class NoteEditorCoordinator: NSObject, Coordinator {
     typealias SaveResult = Result<Note, Error>
-    typealias SaveCallback = (SaveResult) -> Void
+    typealias SaveCallback = (_ key: String?, _ result: SaveResult) -> Void
 
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator]

--- a/Zotero/Scenes/General/ViewModels/NoteEditorActionHandler.swift
+++ b/Zotero/Scenes/General/ViewModels/NoteEditorActionHandler.swift
@@ -63,10 +63,10 @@ struct NoteEditorActionHandler: ViewModelActionHandler, BackgroundDbProcessingAc
             case .edit(let key):
                 updateExistingNote(library: library, key: key, text: text, tags: tags)
 
-            case .readOnly:
+            case .readOnly(let key):
                 let error = State.Error.cantSaveReadonlyNote
                 DDLogError("NoteEditorActionHandler: can't update read only note: \(error)")
-                saveCallback(.failure(error))
+                saveCallback(key, .failure(error))
             }
 
             func createItemNote(library: Library, parentKey: String, text: String, tags: [Tag]) {
@@ -94,11 +94,11 @@ struct NoteEditorActionHandler: ViewModelActionHandler, BackgroundDbProcessingAc
                         update(viewModel: viewModel) { state in
                             state.kind = .edit(key: note.key)
                         }
-                        saveCallback(.success(note))
+                        saveCallback(note.key, .success(note))
 
                     case .failure(let error):
                         DDLogError("NoteEditorActionHandler: can't create item note: \(error)")
-                        saveCallback(.failure(error))
+                        saveCallback(note.key, .failure(error))
                     }
                 }
             }
@@ -109,9 +109,9 @@ struct NoteEditorActionHandler: ViewModelActionHandler, BackgroundDbProcessingAc
                 perform(request: request) { error in
                     if let error {
                         DDLogError("NoteEditorActionHandler: can't update existing note: \(error)")
-                        saveCallback(.failure(error))
+                        saveCallback(key, .failure(error))
                     } else {
-                        saveCallback(.success(note))
+                        saveCallback(key, .success(note))
                     }
                 }
             }


### PR DESCRIPTION
Fixes a regression where creating a new note in item details, doesn't use the new note key, so more than one rows, one for each update are shown. This may also leed to a crash if using keyboard validation, like in Japanese IME, that may create an update with the same key and text (reported in app store connect).