### PR TITLE
Fixed crash in item detail

### DIFF
--- a/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailViewController.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailViewController.swift
@@ -93,7 +93,7 @@ final class ItemDetailViewController: UIViewController {
         super.viewWillTransition(to: size, with: coordinator)
 
         coordinator.animate(alongsideTransition: { _ in
-            self.collectionView.reloadData()
+            self.collectionView?.reloadData()
         }, completion: nil)
     }
 


### PR DESCRIPTION
Appstore crash report pointed to a crash in this place, where it would try to unwrap optional and crash because `collectionView` was `nil`. I couldn't reproduce the issue, it was supposed to happen when opening a PDF from a link while another PDF is already opened. But this should at least avoid the crash.