### PR TITLE
Improve pdf document search

### DIFF
--- a/Zotero/Scenes/Detail/PDF/Views/PDFSearchViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFSearchViewController.swift
@@ -72,6 +72,8 @@ final class PDFSearchViewController: UIViewController {
             let searchBar = UISearchBar()
             searchBar.translatesAutoresizingMaskIntoConstraints = false
             searchBar.placeholder = L10n.Pdf.Search.title
+            // Set search bar delegate before reactive extension, otherwise reactive will be overwritten.
+            searchBar.delegate = self
             searchBar.rx
                 .text
                 .observe(on: MainScheduler.instance)
@@ -200,5 +202,11 @@ extension PDFSearchViewController: TextSearchDelegate {
 
     func didCancel(_ textSearch: TextSearch, term searchTerm: String, isFullSearch: Bool) {
         searchBar.isLoading = false
+    }
+}
+
+extension PDFSearchViewController: UISearchBarDelegate {
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
     }
 }

--- a/Zotero/Scenes/Detail/PDF/Views/PDFSearchViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFSearchViewController.swift
@@ -64,7 +64,7 @@ final class PDFSearchViewController: UIViewController {
             tableView.translatesAutoresizingMaskIntoConstraints = false
             tableView.dataSource = self
             tableView.delegate = self
-            tableView.keyboardDismissMode = UIDevice.current.userInterfaceIdiom == .pad ? .none : .interactive
+            tableView.keyboardDismissMode = UIDevice.current.userInterfaceIdiom == .pad ? .none : .onDrag
             tableView.register(UINib(nibName: "PDFSearchCell", bundle: nil), forCellReuseIdentifier: PDFSearchViewController.cellId)
             view.addSubview(tableView)
             self.tableView = tableView


### PR DESCRIPTION
From app store screenshot feedback, the bottom document search results on iPhone may be hidden by the keyboard.
While there was already available the `interactive` keyboard dismiss mode, it's not very intuitive for this use case, and a bit cumbersome to accomplish without dismissing the whole screen. Changed it to the `onDrag` mode, and also added dismissal of the keyboard when the search button is tapped.

![image](https://github.com/zotero/zotero-ios/assets/617841/10eca54d-6c3f-4375-9a6f-f087b0a46abe)
