### PR TITLE
Fix PDF reader interface style initialization

### DIFF
--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -125,7 +125,7 @@ final class PDFCoordinator: Coordinator {
             userId: userId,
             username: username,
             displayName: Defaults.shared.displayName,
-            interfaceStyle: settings.appearanceMode.userInterfaceStyle
+            interfaceStyle: settings.appearanceMode == .automatic ? parentNavigationController.view.traitCollection.userInterfaceStyle : settings.appearanceMode.userInterfaceStyle
         )
         let controller = PDFReaderViewController(
             viewModel: ViewModel(initialState: state, handler: handler),


### PR DESCRIPTION
Fixes regression that draws highlight annotations using the light color when dark mode should be deduced by automatic appearance mode (reported in this forum [post](https://forums.zotero.org/discussion/112571/ios-text-color-changes-instead-of-background-highlight)).