### PR TITLE
Fixed annotations data source crash

### DIFF
--- a/Zotero/Scenes/Detail/PDF/Views/PDFAnnotationsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFAnnotationsViewController.swift
@@ -229,6 +229,7 @@ final class PDFAnnotationsViewController: UIViewController {
 
         if state.changes.contains(.interfaceStyle) {
             var snapshot = self.dataSource.snapshot()
+            guard !snapshot.sectionIdentifiers.isEmpty else { return }
             snapshot.reloadSections([0])
             self.dataSource.apply(snapshot, animatingDifferences: false, completion: completion)
             return


### PR DESCRIPTION
There is a crash in `PDFAnnotationsViewController` when interface style changes before annotations are loaded.

https://forums.zotero.org/discussion/112601/ios-crash
https://forums.zotero.org/discussion/112583/ios-crash