### PR TITLE
Add PDFReaderState change for selection deletion

### DIFF
--- a/Zotero/Scenes/Detail/PDF/Models/PDFReaderState.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/PDFReaderState.swift
@@ -48,6 +48,7 @@ struct PDFReaderState: ViewModelState {
         static let initialDataLoaded = Changes(rawValue: 1 << 11)
         static let visiblePageFromDocument = Changes(rawValue: 1 << 12)
         static let visiblePageFromThumbnailList = Changes(rawValue: 1 << 13)
+        static let selectionDeletion = Changes(rawValue: 1 << 14)
     }
 
     enum Error: Swift.Error {

--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
@@ -993,7 +993,6 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
         state.changes.insert(.selection)
 
         guard let key else {
-            state.changes.insert(.selectionDeletion)
             state.selectedAnnotationKey = nil
             return
         }
@@ -1990,6 +1989,7 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
             if let key = selectKey {
                 self._select(key: key, didSelectInDocument: true, state: &state)
             } else if selectionDeleted {
+                state.changes.insert(.selectionDeletion)
                 self._select(key: nil, didSelectInDocument: true, state: &state)
             }
 

--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
@@ -992,7 +992,8 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
 
         state.changes.insert(.selection)
 
-        guard let key = key else {
+        guard let key else {
+            state.changes.insert(.selectionDeletion)
             state.selectedAnnotationKey = nil
             return
         }

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -411,7 +411,7 @@ class PDFReaderViewController: UIViewController {
             viewModel.process(action: .loadDocumentData(boundingBoxConverter: documentController))
         }
 
-        if state.changes.contains(.annotations) && state.changes.contains(.selectionDeletion) {
+        if state.changes.contains(.selectionDeletion) {
             // Hide popover if annotation has been deleted
             if (presentedViewController as? UINavigationController)?.viewControllers.first is AnnotationPopover {
                 dismiss(animated: true, completion: nil)

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -411,9 +411,9 @@ class PDFReaderViewController: UIViewController {
             viewModel.process(action: .loadDocumentData(boundingBoxConverter: documentController))
         }
 
-        if state.changes.contains(.annotations) {
+        if state.changes.contains(.annotations) && state.changes.contains(.selectionDeletion) {
             // Hide popover if annotation has been deleted
-            if (presentedViewController as? UINavigationController)?.viewControllers.first is AnnotationPopover, let key = state.selectedAnnotationKey, !state.sortedKeys.contains(key) {
+            if (presentedViewController as? UINavigationController)?.viewControllers.first is AnnotationPopover {
                 dismiss(animated: true, completion: nil)
             }
         }


### PR DESCRIPTION
When annotation is deleted in its popover, it is not dismissed and deselected in the document.
Happens for both document and sidebar popovers.

Fixes https://github.com/zotero/zotero-ios/issues/873

