### PR TITLE
Set collections title line break mode to truncating tail

### DIFF
--- a/Zotero/Scenes/Master/Collections/Views/CollectionsViewController.swift
+++ b/Zotero/Scenes/Master/Collections/Views/CollectionsViewController.swift
@@ -178,6 +178,7 @@ final class CollectionsViewController: UICollectionViewController {
 
     private func setupTitleWithContextMenu(_ title: String) {
         var configuration = UIButton.Configuration.plain()
+        configuration.titleLineBreakMode = .byTruncatingTail
         configuration.attributedTitle = AttributedString(title, attributes: AttributeContainer([.font: UIFont.systemFont(ofSize: 17, weight: .semibold)]))
         configuration.baseForegroundColor = UIColor(dynamicProvider: { $0.userInterfaceStyle == .light ? .black : .white })
         configuration.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12)


### PR DESCRIPTION
Fixes issue reported in app store connect screenshot [feedback](https://appstoreconnect.apple.com/apps/1513554812/testflight/screenshots/AEnmfF7v9oFojGSaJCmHC04?appPlatform=IOS&sort=-timestamp)