### PR TITLE
Fix creation of download task for shared libraries

### DIFF
--- a/Zotero/Controllers/Attachment Downloader/AttachmentDownloader.swift
+++ b/Zotero/Controllers/Attachment Downloader/AttachmentDownloader.swift
@@ -694,7 +694,7 @@ final class AttachmentDownloader: NSObject {
         func createDownloadTask(from enqueuedDownload: EnqueuedDownload) -> (URLSessionTask, Download, ActiveDownload)? {
             do {
                 let request: URLRequest
-                if webDavController.sessionStorage.isEnabled {
+                if case .custom = enqueuedDownload.download.libraryId, webDavController.sessionStorage.isEnabled {
                     guard let url = webDavController.currentUrl?.appendingPathComponent("\(enqueuedDownload.download.key).zip") else { return nil }
                     let apiRequest = FileRequest(webDavUrl: url, destination: enqueuedDownload.file)
                     request = try webDavController.createURLRequest(from: apiRequest)


### PR DESCRIPTION
Fixes regression reported in [1](https://forums.zotero.org/discussion/112840/unable-to-display-document-on-shared-libraries-ios), [2](https://forums.zotero.org/discussion/112810/ios-unable-to-display-document)