### PR TITLE
Fix share extension sync

### DIFF
--- a/ZShare/ViewModels/ExtensionViewModel.swift
+++ b/ZShare/ViewModels/ExtensionViewModel.swift
@@ -1133,8 +1133,7 @@ final class ExtensionViewModel {
 
                 do {
                     let request = MarkAttachmentUploadedDbRequest(libraryId: data.libraryId, key: data.attachment.key, version: version)
-                    let request2 = UpdateVersionsDbRequest(version: version, libraryId: data.libraryId, type: .object(.item))
-                    try dbStorage.perform(writeRequests: [request, request2], on: self.backgroundQueue)
+                    try dbStorage.perform(request: request, on: self.backgroundQueue)
                     return Single.just(())
                 } catch let error {
                     return Single.error(error)


### PR DESCRIPTION
Syncs item versions as well, when creating download actions for a collections only type of sync. Fixes the edge case mentioned in #882 