### PR TITLE
Improve full sync fix trigger

### DIFF
--- a/Zotero/Controllers/Controllers.swift
+++ b/Zotero/Controllers/Controllers.swift
@@ -405,20 +405,24 @@ final class UserControllers {
     fileprivate func enableSync(apiKey: String) {
         self.itemLocaleController.loadLocale()
 
+        // Enable idleTimerController before syncScheduler inProgress observation starts
+        idleTimerController.enable()
         // Observe sync to enable/disable the device falling asleep
-        self.syncScheduler.inProgress
+        // Skip first value that is observed during syncScheduler initialization, to avoid reseting didPerformFullSyncFix before the actual first sync occurs
+        syncScheduler.inProgress
+            .skip(1)
             .observe(on: MainScheduler.instance)
-            .subscribe(with: self, onNext: { `self`, inProgress in
+            .subscribe(onNext: { [weak self] inProgress in
                 if inProgress {
-                    self.idleTimerController.disable()
+                    self?.idleTimerController.disable()
                 } else {
-                    self.idleTimerController.enable()
+                    self?.idleTimerController.enable()
                     if !Defaults.shared.didPerformFullSyncFix {
                         Defaults.shared.didPerformFullSyncFix = true
                     }
                 }
             })
-            .disposed(by: self.disposeBag)
+            .disposed(by: disposeBag)
 
         // Observe local changes to start sync
         self.changeObserver.observable

--- a/Zotero/Controllers/Controllers.swift
+++ b/Zotero/Controllers/Controllers.swift
@@ -407,6 +407,11 @@ final class UserControllers {
 
         // Enable idleTimerController before syncScheduler inProgress observation starts
         idleTimerController.enable()
+        // Reset Defaults.shared.didPerformFullSyncFix if needed
+        if Defaults.shared.performFullSyncGuard < Defaults.currentPerformFullSyncGuard {
+            Defaults.shared.didPerformFullSyncFix = false
+            Defaults.shared.performFullSyncGuard = Defaults.currentPerformFullSyncGuard
+        }
         // Observe sync to enable/disable the device falling asleep
         // Skip first value that is observed during syncScheduler initialization, to avoid reseting didPerformFullSyncFix before the actual first sync occurs
         syncScheduler.inProgress

--- a/Zotero/Models/Defaults.swift
+++ b/Zotero/Models/Defaults.swift
@@ -151,7 +151,19 @@ final class Defaults {
     @UserDefault(key: "AskForSyncPermission", defaultValue: false)
     var askForSyncPermission: Bool
 
-    @UserDefault(key: "DidPerformFullSyncFix", defaultValue: false)
+    // Increment currentPerformFullSyncGuard by 1, whenever the upcoming release should trigger a full sync.
+    static let currentPerformFullSyncGuard = 1
+    @UserDefault(key: "PerformFullSyncGuard", defaultValue: {
+        if UserDefaults.zotero.object(forKey: "DidPerformFullSyncFix") != nil {
+            // Existing installation. Since this is the first use of this guard, we return the default value - 1, to be certain to trigger a full sync.
+            return currentPerformFullSyncGuard - 1
+        }
+        // New installation, no need for a full sync.
+        return currentPerformFullSyncGuard
+    }())
+    var performFullSyncGuard: Int
+
+    @UserDefault(key: "DidPerformFullSyncFix", defaultValue: true)
     var didPerformFullSyncFix: Bool
 
     // MARK: - Actions


### PR DESCRIPTION
* Fixes regression in `syncScheduler.inProgress` observer, that  observed `inProgress` initialiazation as well, reseting `Defaults.shared.didPerformFullSyncFix` before it was even used.
* Adds `Default.shared.performFullSyncGuard` & `Defaults.currentPerformFullSyncGuard` that are used to reset `Defaults.shared.didPerformFullSyncFix` to `false` when neeeded. Increment `Defaults.currentPerformFullSyncGuard` by `1`, to trigger a full sync in existing installations on an upcoming release. New installations don't trigger a full sync.