### PR TITLE
Fix WebDAV authentication and opening attachments

### DIFF
--- a/Zotero/Controllers/AttachmentCreator.swift
+++ b/Zotero/Controllers/AttachmentCreator.swift
@@ -49,16 +49,8 @@ struct AttachmentCreator {
         guard let (idx, contentType, linkMode, _, _) = attachmentData.first else { return nil }
         let rAttachment = item.children[idx]
         let linkType: Attachment.FileLinkType = linkMode == .importedFile ? .importedFile : .importedUrl
-        guard let libraryId = rAttachment.libraryId,
-              let type = importedType(
-                for: rAttachment,
-                contentType: contentType,
-                libraryId: libraryId,
-                fileStorage: fileStorage,
-                linkType: linkType,
-                compressed: rAttachment.fileCompressed
-              )
-        else { return nil }
+        guard let libraryId = rAttachment.libraryId else { return nil }
+        let type = importedType(for: rAttachment, contentType: contentType, libraryId: libraryId, fileStorage: fileStorage, linkType: linkType, compressed: rAttachment.fileCompressed)
         return Attachment(item: rAttachment, type: type)
     }
 
@@ -206,7 +198,7 @@ struct AttachmentCreator {
         fileStorage: FileStorage?,
         linkType: Attachment.FileLinkType,
         compressed: Bool
-    ) -> Attachment.Kind? {
+    ) -> Attachment.Kind {
         let filename = filename(for: item, ext: contentType.extensionFromMimeType)
         let file = Files.attachmentFile(in: libraryId, key: item.key, filename: filename, contentType: contentType)
         let location = location(for: item, file: file, fileStorage: fileStorage)

--- a/Zotero/Models/Attachment.swift
+++ b/Zotero/Models/Attachment.swift
@@ -91,7 +91,7 @@ struct Attachment: Identifiable, Equatable {
         case .file(let filename, let contentType, let oldLocation, let linkType, let oldCompressed):
             let compressed = compressed ?? oldCompressed
             if oldLocation == location && oldCompressed == compressed {
-                return self
+                return nil
             }
             return Attachment(
                 type: .file(filename: filename, contentType: contentType, location: location, linkType: linkType, compressed: compressed),

--- a/Zotero/Models/Attachment.swift
+++ b/Zotero/Models/Attachment.swift
@@ -86,10 +86,11 @@ struct Attachment: Identifiable, Equatable {
         }
     }
 
-    func changed(location: FileLocation) -> Attachment? {
+    func changed(location: FileLocation, compressed: Bool?) -> Attachment? {
         switch type {
-        case .file(let filename, let contentType, let oldLocation, let linkType, let compressed):
-            if oldLocation == location {
+        case .file(let filename, let contentType, let oldLocation, let linkType, let oldCompressed):
+            let compressed = compressed ?? oldCompressed
+            if oldLocation == location && oldCompressed == compressed {
                 return self
             }
             return Attachment(

--- a/Zotero/Scenes/Detail/ItemDetail/ViewModels/ItemDetailActionHandler.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/ViewModels/ItemDetailActionHandler.swift
@@ -603,8 +603,8 @@ struct ItemDetailActionHandler: ViewModelActionHandler, BackgroundDbProcessingAc
                 state.updateAttachmentKey = attachment.key
             }
 
-        case .ready:
-            guard let new = attachment.changed(location: .local) else { return }
+        case .ready(let compressed):
+            guard let new = attachment.changed(location: .local, compressed: compressed) else { return }
             self.update(viewModel: viewModel) { state in
                 state.attachments[index] = new
                 state.updateAttachmentKey = new.key

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
@@ -322,10 +322,10 @@ struct ItemsActionHandler: ViewModelActionHandler, BackgroundDbProcessingActionH
         }
 
         switch downloadUpdate.kind {
-        case .ready:
+        case .ready(let compressed):
             DDLogInfo("ItemsActionHandler: download update \(attachment.key); \(attachment.libraryId); kind \(downloadUpdate.kind)")
+            guard let updatedAttachment = attachment.changed(location: .local, compressed: compressed) else { return }
             updateViewModel { state in
-                guard let updatedAttachment = attachment.changed(location: .local) else { return }
                 state.itemAccessories[updateKey] = .attachment(attachment: updatedAttachment, parentKey: downloadUpdate.parentKey)
                 state.updateItemKey = updateKey
             }

--- a/Zotero/Scenes/Master/Settings/Sync/ViewModels/SyncSettingsActionHandler.swift
+++ b/Zotero/Scenes/Master/Settings/Sync/ViewModels/SyncSettingsActionHandler.swift
@@ -43,6 +43,7 @@ struct SyncSettingsActionHandler: ViewModelActionHandler {
             self.set(fileSyncType: type, in: viewModel)
 
         case .setScheme(let scheme):
+            guard scheme != viewModel.state.scheme else { break }
             self.update(viewModel: viewModel) { state in
                 state.scheme = scheme
                 state.webDavVerificationResult = nil
@@ -51,9 +52,11 @@ struct SyncSettingsActionHandler: ViewModelActionHandler {
             self.webDavController.resetVerification()
 
         case .setUrl(let url):
+            guard url != viewModel.state.url else { break }
             self.set(url: url, in: viewModel)
 
         case .setUsername(let username):
+            guard username != viewModel.state.username else { break }
             self.update(viewModel: viewModel) { state in
                 state.username = username
                 state.webDavVerificationResult = nil
@@ -62,6 +65,7 @@ struct SyncSettingsActionHandler: ViewModelActionHandler {
             self.webDavController.resetVerification()
 
         case .setPassword(let password):
+            guard password != viewModel.state.password else { break }
             self.update(viewModel: viewModel) { state in
                 state.password = password
                 state.webDavVerificationResult = nil


### PR DESCRIPTION
* Fixes WebDAV authentication regression. It happened because of a side-effect when dismissing the Account screen, that didn't affect the previous solution. Upon dismissal, if a text field still had first responder, it caused the WebDAV verification to be reset. However (a) the authentication header was set by alamofire and (b) the WebDAV server was checked if needed before each download, restoring the verification. New solution, stored also the WebDAV authentication header in the `ZoteroApiClient` instance, so these were lost upon Account screen dismissal, which are used directly when creating a `URLRequest`.
* Updates `Attachment` compressed status for local files, when these become ready. This may change in such a scenario:
  * user installs app and all items are created via Zotero API, assumed as not compressed
  * user switches storage to WebDAV
  * user downloads all attachments that are now compressed
  * if user hasn't changed e.g. the current Items screen, the `Attachment` item per row would still have `compressed = false`, resulting in opening a file that doesn't exist.