### PR TITLE
Improve full sync fix

### DIFF
--- a/Zotero/Controllers/Controllers.swift
+++ b/Zotero/Controllers/Controllers.swift
@@ -411,6 +411,8 @@ final class UserControllers {
         if Defaults.shared.performFullSyncGuard < Defaults.currentPerformFullSyncGuard {
             Defaults.shared.didPerformFullSyncFix = false
             Defaults.shared.performFullSyncGuard = Defaults.currentPerformFullSyncGuard
+        } else {
+            Defaults.shared.didPerformFullSyncFix = true
         }
         // Observe sync to enable/disable the device falling asleep
         // Skip first value that is observed during syncScheduler initialization, to avoid reseting didPerformFullSyncFix before the actual first sync occurs

--- a/Zotero/Controllers/Controllers.swift
+++ b/Zotero/Controllers/Controllers.swift
@@ -408,12 +408,14 @@ final class UserControllers {
         // Enable idleTimerController before syncScheduler inProgress observation starts
         idleTimerController.enable()
         // Reset Defaults.shared.didPerformFullSyncFix if needed
+        DDLogInfo("Controllers: performFullSyncGuard: \(Defaults.shared.performFullSyncGuard); currentPerformFullSyncGuard: \(Defaults.currentPerformFullSyncGuard)")
         if Defaults.shared.performFullSyncGuard < Defaults.currentPerformFullSyncGuard {
             Defaults.shared.didPerformFullSyncFix = false
             Defaults.shared.performFullSyncGuard = Defaults.currentPerformFullSyncGuard
         } else {
             Defaults.shared.didPerformFullSyncFix = true
         }
+        DDLogInfo("Controllers: didPerformFullSyncFix: \(Defaults.shared.didPerformFullSyncFix)")
         // Observe sync to enable/disable the device falling asleep
         // Skip first value that is observed during syncScheduler initialization, to avoid reseting didPerformFullSyncFix before the actual first sync occurs
         syncScheduler.inProgress
@@ -426,6 +428,7 @@ final class UserControllers {
                     self?.idleTimerController.enable()
                     if !Defaults.shared.didPerformFullSyncFix {
                         Defaults.shared.didPerformFullSyncFix = true
+                        DDLogInfo("Controllers: didPerformFullSyncFix: \(Defaults.shared.didPerformFullSyncFix)")
                     }
                 }
             })


### PR DESCRIPTION
* Stores a value to `Defaults.shared.didPerformFullSyncFix` even when one is not triggered, so otherwise it is always assumed a new installation.
* Also improves related logging.