### PR TITLE
Improve annotation toolbar handler

### DIFF
--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarHandler.swift
@@ -261,11 +261,13 @@ final class AnnotationToolbarHandler: NSObject {
     func enableLeadingSafeConstraint() {
         toolbarLeading.isActive = false
         toolbarLeadingSafeArea.isActive = true
+        toolbarLeadingSafeArea.constant = toolbarLeading.constant
     }
 
     func disableLeadingSafeConstraint() {
         toolbarLeadingSafeArea.isActive = false
         toolbarLeading.isActive = true
+        toolbarLeading.constant = toolbarLeadingSafeArea.constant
     }
 
     func set(hidden: Bool, animated: Bool) {

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarHandler.swift
@@ -75,7 +75,6 @@ final class AnnotationToolbarHandler: NSObject {
     private weak var toolbarTrailingPreview: DashedView!
     private weak var toolbarTrailingPreviewHeight: NSLayoutConstraint!
 
-    var stateDidChange: ((State) -> Void)?
     var didHide: (() -> Void)?
 
     init(controller: AnnotationToolbarViewController, delegate: AnnotationToolbarHandlerDelegate) {

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarHandler.swift
@@ -66,14 +66,14 @@ final class AnnotationToolbarHandler: NSObject {
     private var toolbarTrailingSafeArea: NSLayoutConstraint!
     weak var dragHandleLongPressRecognizer: UILongPressGestureRecognizer!
     private weak var toolbarPreviewsOverlay: UIView!
-    private weak var toolbarLeadingPreview: DashedView!
+    private weak var toolbarPinnedPreview: DashedView!
+    private weak var toolbarPinnedPreviewHeight: NSLayoutConstraint!
     private weak var inbetweenTopDashedView: DashedView!
+    private weak var toolbarTopPreview: DashedView!
+    private weak var toolbarLeadingPreview: DashedView!
     private weak var toolbarLeadingPreviewHeight: NSLayoutConstraint!
     private weak var toolbarTrailingPreview: DashedView!
     private weak var toolbarTrailingPreviewHeight: NSLayoutConstraint!
-    private weak var toolbarTopPreview: DashedView!
-    private weak var toolbarPinnedPreview: DashedView!
-    private weak var toolbarPinnedPreviewHeight: NSLayoutConstraint!
 
     var stateDidChange: ((State) -> Void)?
     var didHide: (() -> Void)?
@@ -105,18 +105,14 @@ final class AnnotationToolbarHandler: NSObject {
             previewsOverlay.backgroundColor = .clear
             previewsOverlay.isHidden = true
 
-            let topPreview = DashedView(type: .partialStraight(sides: [.left, .right, .bottom]))
-            setup(toolbarPositionView: topPreview)
-            let inbetweenTopDash = DashedView(type: .partialStraight(sides: .bottom))
-            setup(toolbarPositionView: inbetweenTopDash)
             let pinnedPreview = DashedView(type: .partialStraight(sides: [.left, .right, .top]))
-            setup(toolbarPositionView: pinnedPreview)
+            let inbetweenTopDash = DashedView(type: .partialStraight(sides: .bottom))
+            let topPreview = DashedView(type: .partialStraight(sides: [.left, .right, .bottom]))
             let leadingPreview = DashedView(type: .rounded(cornerRadius: 8))
             leadingPreview.translatesAutoresizingMaskIntoConstraints = false
-            setup(toolbarPositionView: leadingPreview)
             let trailingPreview = DashedView(type: .rounded(cornerRadius: 8))
             trailingPreview.translatesAutoresizingMaskIntoConstraints = false
-            setup(toolbarPositionView: trailingPreview)
+            [pinnedPreview, inbetweenTopDash, topPreview, leadingPreview, trailingPreview].forEach({ setup(toolbarPositionView: $0) })
 
             let topPreviewContainer = UIStackView(arrangedSubviews: [pinnedPreview, inbetweenTopDash, topPreview])
             topPreviewContainer.translatesAutoresizingMaskIntoConstraints = false

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarViewController.swift
@@ -400,16 +400,6 @@ class AnnotationToolbarViewController: UIViewController {
         colorPickerButton.tintColor = activeColor
     }
 
-    func deselectActiveTool() {
-        for view in stackView.arrangedSubviews {
-            guard let checkbox = view as? CheckboxButton, checkbox.isSelected else { continue }
-            checkbox.isSelected = false
-            break
-        }
-        colorPickerButton.isHidden = true
-        (stackView.arrangedSubviews.last as? UIButton)?.menu = createHiddenToolsMenu()
-    }
-
     func set(selected: Bool, to tool: AnnotationTool, color: UIColor?) {
         guard let idx = toolButtons.firstIndex(where: { $0.type == tool }) else { return }
 

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarViewController.swift
@@ -17,10 +17,6 @@ struct AnnotationToolOptions: OptionSet {
 
     let rawValue: Int8
 
-    init(rawValue: Int8) {
-        self.rawValue = rawValue
-    }
-
     static let stylus = AnnotationToolOptions(rawValue: 1 << 0)
 }
 
@@ -50,7 +46,7 @@ class AnnotationToolbarViewController: UIViewController {
         let isHidden: Bool
 
         func copy(isHidden: Bool) -> ToolButton {
-            return ToolButton(type: self.type, title: self.title, accessibilityLabel: self.accessibilityLabel, image: self.image, isHidden: isHidden)
+            return ToolButton(type: type, title: title, accessibilityLabel: accessibilityLabel, image: image, isHidden: isHidden)
         }
     }
 
@@ -58,8 +54,9 @@ class AnnotationToolbarViewController: UIViewController {
     static let estimatedVerticalHeight: CGFloat = 500
     private static let buttonSpacing: CGFloat = UIDevice.current.userInterfaceIdiom == .phone ? 12 : 12
     private static let buttonCompactSpacing: CGFloat = 8
-    private static let buttonContentInsets: NSDirectionalEdgeInsets = UIDevice.current.userInterfaceIdiom == .pad ? NSDirectionalEdgeInsets(top: 4, leading: 4, bottom: 4, trailing: 4) :
-                                                                                                                    NSDirectionalEdgeInsets(top: 2, leading: 2, bottom: 2, trailing: 2)
+    private static let buttonContentInsets: NSDirectionalEdgeInsets = UIDevice.current.userInterfaceIdiom == .pad
+        ? NSDirectionalEdgeInsets(top: 4, leading: 4, bottom: 4, trailing: 4)
+        : NSDirectionalEdgeInsets(top: 2, leading: 2, bottom: 2, trailing: 2)
     private static let toolsToAdditionalFullOffset: CGFloat = 70
     private static let toolsToAdditionalCompactOffset: CGFloat = 20
     private let disposeBag: DisposeBag
@@ -94,18 +91,10 @@ class AnnotationToolbarViewController: UIViewController {
 
     init(tools: [AnnotationTool], undoRedoEnabled: Bool, size: CGFloat) {
         self.size = size
-        self.toolButtons = Self.createButtons(from: tools)
+        toolButtons = tools.map({ button(from: $0) })
         self.undoRedoEnabled = undoRedoEnabled
-        self.disposeBag = DisposeBag()
+        disposeBag = DisposeBag()
         super.init(nibName: nil, bundle: nil)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    private static func createButtons(from tools: [AnnotationTool]) -> [ToolButton] {
-        return tools.map({ button(from: $0) })
 
         func button(from tool: AnnotationTool) -> ToolButton {
             switch tool {
@@ -175,27 +164,187 @@ class AnnotationToolbarViewController: UIViewController {
         }
     }
 
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.view.backgroundColor = Asset.Colors.navbarBackground.color
-        self.view.addInteraction(UILargeContentViewerInteraction())
+        view.backgroundColor = Asset.Colors.navbarBackground.color
+        view.addInteraction(UILargeContentViewerInteraction())
 
-        self.setupViews()
+        setupViews()
+
+        func setupViews() {
+            view.translatesAutoresizingMaskIntoConstraints = false
+
+            let stackView = UIStackView(arrangedSubviews: createToolButtons(from: toolButtons))
+            stackView.showsLargeContentViewer = true
+            stackView.axis = .vertical
+            stackView.spacing = 0
+            stackView.distribution = .fill
+            stackView.translatesAutoresizingMaskIntoConstraints = false
+            stackView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+            stackView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+            stackView.setContentHuggingPriority(.required, for: .vertical)
+            stackView.setContentHuggingPriority(.required, for: .horizontal)
+            view.addSubview(stackView)
+
+            let picker = createColorPickerButton()
+            view.addSubview(picker)
+            colorPickerButton = picker
+
+            let additionalStackView = UIStackView(arrangedSubviews: createAdditionalItems())
+            additionalStackView.showsLargeContentViewer = true
+            additionalStackView.setContentCompressionResistancePriority(.required, for: .horizontal)
+            additionalStackView.setContentCompressionResistancePriority(.required, for: .vertical)
+            additionalStackView.setContentHuggingPriority(.required, for: .vertical)
+            additionalStackView.setContentHuggingPriority(.required, for: .horizontal)
+            additionalStackView.axis = .vertical
+            additionalStackView.spacing = 0
+            additionalStackView.distribution = .fill
+            additionalStackView.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview(additionalStackView)
+
+            let hairline = UIView()
+            hairline.translatesAutoresizingMaskIntoConstraints = false
+            hairline.backgroundColor = UIColor.separator
+            view.addSubview(hairline)
+            hairlineView = hairline
+
+            horizontalHeight = view.heightAnchor.constraint(equalToConstant: size)
+            horizontalHeight.priority = .required
+            containerBottom = view.bottomAnchor.constraint(equalTo: stackView.bottomAnchor, constant: 8)
+            containerTrailing = view.trailingAnchor.constraint(equalTo: stackView.trailingAnchor, constant: 8)
+            additionalTop = additionalStackView.topAnchor.constraint(equalTo: view.topAnchor, constant: 8)
+            additionalLeading = additionalStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 8)
+            containerToPickerVertical = picker.topAnchor.constraint(greaterThanOrEqualTo: stackView.bottomAnchor, constant: 0)
+            containerToPickerVertical.priority = .required
+            containerToPickerHorizontal = picker.leadingAnchor.constraint(equalTo: stackView.trailingAnchor)
+            containerToPickerHorizontal.priority = .required
+            colorPickerToAdditionalVertical = additionalStackView.topAnchor.constraint(equalTo: picker.bottomAnchor)
+            colorPickerToAdditionalHorizontal = additionalStackView.leadingAnchor.constraint(greaterThanOrEqualTo: picker.trailingAnchor, constant: 0)
+            colorPickerTop = picker.topAnchor.constraint(equalTo: view.topAnchor)
+            colorPickerBottom = view.bottomAnchor.constraint(equalTo: picker.bottomAnchor)
+            colorPickerLeading = picker.leadingAnchor.constraint(equalTo: view.leadingAnchor)
+            colorPickerTrailing = view.trailingAnchor.constraint(equalTo: picker.trailingAnchor)
+            let containerTop = stackView.topAnchor.constraint(equalTo: view.topAnchor, constant: 15)
+            let containerLeading = stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 15)
+            let additionalBottom = view.bottomAnchor.constraint(equalTo: additionalStackView.bottomAnchor, constant: 8)
+            let additionalTrailing = view.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: additionalStackView.trailingAnchor, constant: 8)
+            let hairlineHeight = hairline.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale)
+            let hairlineLeading = hairline.leadingAnchor.constraint(equalTo: view.leadingAnchor)
+            let hairlineTrailing = hairline.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            let hairlineBottom = hairline.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+
+            NSLayoutConstraint.activate([
+                containerTop,
+                containerLeading,
+                containerTrailing,
+                containerToPickerVertical,
+                colorPickerLeading,
+                colorPickerTrailing,
+                additionalBottom,
+                colorPickerToAdditionalVertical,
+                additionalTrailing,
+                additionalLeading,
+                hairlineHeight,
+                hairlineLeading,
+                hairlineTrailing,
+                hairlineBottom
+            ])
+
+            self.containerTop = containerTop
+            self.containerLeading = containerLeading
+            self.additionalTrailing = additionalTrailing
+            self.additionalBottom = additionalBottom
+            self.stackView = stackView
+            self.additionalStackView = additionalStackView
+
+            func createToolButtons(from tools: [ToolButton]) -> [UIView] {
+                var showMoreConfig = UIButton.Configuration.plain()
+                showMoreConfig.contentInsets = Self.buttonContentInsets
+                showMoreConfig.image = UIImage(systemName: "ellipsis")?.withRenderingMode(.alwaysTemplate)
+                let showMoreButton = UIButton(type: .custom)
+                showMoreButton.configuration = showMoreConfig
+                showMoreButton.translatesAutoresizingMaskIntoConstraints = false
+                showMoreButton.showsLargeContentViewer = true
+                showMoreButton.accessibilityLabel = L10n.Accessibility.Pdf.showMoreTools
+                showMoreButton.largeContentTitle = L10n.Accessibility.Pdf.showMoreTools
+                showMoreButton.setContentCompressionResistancePriority(.required, for: .vertical)
+                showMoreButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+                showMoreButton.tintColor = Asset.Colors.zoteroBlueWithDarkMode.color
+                showMoreButton.showsMenuAsPrimaryAction = true
+                showMoreButton.widthAnchor.constraint(equalTo: showMoreButton.heightAnchor).isActive = true
+
+                return tools.map { tool in
+                    let button = CheckboxButton(image: tool.image.withRenderingMode(.alwaysTemplate), contentInsets: Self.buttonContentInsets)
+                    button.translatesAutoresizingMaskIntoConstraints = false
+                    button.showsLargeContentViewer = true
+                    button.accessibilityLabel = tool.accessibilityLabel
+                    button.largeContentTitle = tool.title
+                    button.deselectedBackgroundColor = .clear
+                    button.deselectedTintColor = Asset.Colors.zoteroBlueWithDarkMode.color
+                    button.selectedBackgroundColor = Asset.Colors.zoteroBlue.color
+                    button.selectedTintColor = .white
+                    button.setContentCompressionResistancePriority(.required, for: .vertical)
+                    button.setContentCompressionResistancePriority(.required, for: .horizontal)
+                    button.isHidden = true
+                    button.widthAnchor.constraint(equalTo: button.heightAnchor).isActive = true
+                    button.setNeedsUpdateConfiguration()
+
+                    let recognizer = UITapGestureRecognizer()
+                    recognizer.delegate = self
+                    recognizer.rx.event
+                        .subscribe(onNext: { [weak self] _ in
+                            guard let self else { return }
+                            delegate?.toggle(tool: tool.type, options: currentAnnotationOptions)
+                        })
+                        .disposed(by: disposeBag)
+                    button.addGestureRecognizer(recognizer)
+
+                    return button
+                } + [showMoreButton]
+            }
+
+            func createColorPickerButton() -> UIButton {
+                var pickerConfig = UIButton.Configuration.plain()
+                pickerConfig.contentInsets = Self.buttonContentInsets
+                pickerConfig.image = UIImage(systemName: "circle.fill")?.applyingSymbolConfiguration(.init(scale: .large))
+                let picker = UIButton()
+                picker.configuration = pickerConfig
+                picker.showsLargeContentViewer = true
+                picker.translatesAutoresizingMaskIntoConstraints = false
+                picker.setContentCompressionResistancePriority(.required, for: .horizontal)
+                picker.setContentCompressionResistancePriority(.required, for: .vertical)
+                picker.widthAnchor.constraint(equalTo: picker.heightAnchor).isActive = true
+                picker.isHidden = true
+                picker.accessibilityLabel = L10n.Accessibility.Pdf.colorPicker
+                picker.largeContentTitle = L10n.Accessibility.Pdf.colorPicker
+                picker.rx.controlEvent(.touchUpInside)
+                    .subscribe(onNext: { [weak self] _ in
+                        guard let self else { return }
+                        delegate?.showToolOptions(sender: .view(colorPickerButton, nil))
+                    })
+                    .disposed(by: disposeBag)
+                return picker
+            }
+        }
     }
 
     // MARK: - Undo/Redo state
 
     func didChange(undoState undoEnabled: Bool, redoState redoEnabled: Bool) {
-        self.undoButton?.isEnabled = undoEnabled
-        self.redoButton?.isEnabled = redoEnabled
+        undoButton?.isEnabled = undoEnabled
+        redoButton?.isEnabled = redoEnabled
     }
 
     // MARK: - Layout
 
     func prepareForSizeChange() {
-        for (idx, view) in self.stackView.arrangedSubviews.enumerated() {
-            if idx == self.stackView.arrangedSubviews.count - 1 {
+        for (idx, view) in stackView.arrangedSubviews.enumerated() {
+            if idx == stackView.arrangedSubviews.count - 1 {
                 view.alpha = 1
                 view.isHidden = false
             } else {
@@ -206,171 +355,171 @@ class AnnotationToolbarViewController: UIViewController {
     }
 
     func sizeDidChange() {
-        guard self.stackView.arrangedSubviews.count == self.toolButtons.count + 1 else {
-            DDLogError("AnnotationToolbarViewController: too many views in stack view! Stack view views: \(self.stackView.arrangedSubviews.count). Tools: \(self.toolButtons.count)")
+        guard stackView.arrangedSubviews.count == toolButtons.count + 1 else {
+            DDLogError("AnnotationToolbarViewController: too many views in stack view! Stack view views: \(stackView.arrangedSubviews.count). Tools: \(toolButtons.count)")
             return
         }
-        guard let button = self.stackView.arrangedSubviews.last, let maxAvailableSize = self.delegate?.maxAvailableToolbarSize, maxAvailableSize > 0 else { return }
+        guard let button = stackView.arrangedSubviews.last, let maxAvailableSize = delegate?.maxAvailableToolbarSize, maxAvailableSize > 0 else { return }
 
-        let isHorizontal = self.view.frame.width > self.view.frame.height
+        let isHorizontal = view.frame.width > view.frame.height
         let buttonSize = isHorizontal ? button.frame.width : button.frame.height
 
         guard buttonSize > 0 else { return }
 
-        let stackViewOffset = isHorizontal ? self.containerLeading.constant : self.containerTop.constant
-        let additionalSize = isHorizontal ? self.additionalStackView.frame.width : self.additionalStackView.frame.height
-        let containerToPickerOffset = isHorizontal ? self.containerToPickerHorizontal.constant : self.containerToPickerVertical.constant
-        let pickerSize = isHorizontal ? self.colorPickerButton.frame.width : self.colorPickerButton.frame.height
-        let pickerToAdditionalOffset = isHorizontal ? self.colorPickerToAdditionalHorizontal.constant : self.colorPickerToAdditionalVertical.constant
-        let additionalOffset = isHorizontal ? self.additionalTrailing.constant : self.additionalBottom.constant
+        let stackViewOffset = isHorizontal ? containerLeading.constant : containerTop.constant
+        let additionalSize = isHorizontal ? additionalStackView.frame.width : additionalStackView.frame.height
+        let containerToPickerOffset = isHorizontal ? containerToPickerHorizontal.constant : containerToPickerVertical.constant
+        let pickerSize = isHorizontal ? colorPickerButton.frame.width : colorPickerButton.frame.height
+        let pickerToAdditionalOffset = isHorizontal ? colorPickerToAdditionalHorizontal.constant : colorPickerToAdditionalVertical.constant
+        let additionalOffset = isHorizontal ? additionalTrailing.constant : additionalBottom.constant
         let remainingSize = maxAvailableSize - stackViewOffset - containerToPickerOffset - pickerSize - pickerToAdditionalOffset - additionalSize - additionalOffset
-        let count = max(0, min(Int(floor(remainingSize / buttonSize)), self.toolButtons.count))
+        let count = max(0, min(Int(floor(remainingSize / buttonSize)), toolButtons.count))
 
         for idx in 0..<count {
-            guard idx < (count - 1) || count == self.toolButtons.count else { continue }
-            self.stackView.arrangedSubviews[idx].alpha = 1
-            self.stackView.arrangedSubviews[idx].isHidden = false
-            self.toolButtons[idx] = self.toolButtons[idx].copy(isHidden: false)
+            guard idx < (count - 1) || count == toolButtons.count else { continue }
+            stackView.arrangedSubviews[idx].alpha = 1
+            stackView.arrangedSubviews[idx].isHidden = false
+            toolButtons[idx] = toolButtons[idx].copy(isHidden: false)
         }
 
-        if count < self.toolButtons.count {
-            for idx in count..<self.toolButtons.count {
-                self.toolButtons[idx] = self.toolButtons[idx].copy(isHidden: true)
+        if count < toolButtons.count {
+            for idx in count..<toolButtons.count {
+                toolButtons[idx] = toolButtons[idx].copy(isHidden: true)
             }
         } else {
-            self.stackView.arrangedSubviews.last?.alpha = 0
-            self.stackView.arrangedSubviews.last?.isHidden = true
+            stackView.arrangedSubviews.last?.alpha = 0
+            stackView.arrangedSubviews.last?.isHidden = true
         }
 
-        if self.stackView.arrangedSubviews.last?.isHidden == false {
-            (self.stackView.arrangedSubviews.last as? UIButton)?.menu = self.createHiddenToolsMenu()
+        if stackView.arrangedSubviews.last?.isHidden == false {
+            (stackView.arrangedSubviews.last as? UIButton)?.menu = createHiddenToolsMenu()
         }
     }
 
     func set(activeColor: UIColor) {
-        self.colorPickerButton.tintColor = activeColor
+        colorPickerButton.tintColor = activeColor
     }
 
     func deselectActiveTool() {
-        for view in self.stackView.arrangedSubviews {
+        for view in stackView.arrangedSubviews {
             guard let checkbox = view as? CheckboxButton, checkbox.isSelected else { continue }
             checkbox.isSelected = false
             break
         }
-        self.colorPickerButton.isHidden = true
-        (self.stackView.arrangedSubviews.last as? UIButton)?.menu = self.createHiddenToolsMenu()
+        colorPickerButton.isHidden = true
+        (stackView.arrangedSubviews.last as? UIButton)?.menu = createHiddenToolsMenu()
     }
 
     func set(selected: Bool, to tool: AnnotationTool, color: UIColor?) {
-        guard let idx = self.toolButtons.firstIndex(where: { $0.type == tool }) else { return }
+        guard let idx = toolButtons.firstIndex(where: { $0.type == tool }) else { return }
 
-        (self.stackView.arrangedSubviews[idx] as? CheckboxButton)?.isSelected = selected
-        (self.stackView.arrangedSubviews.last as? UIButton)?.menu = self.createHiddenToolsMenu()
+        (stackView.arrangedSubviews[idx] as? CheckboxButton)?.isSelected = selected
+        (stackView.arrangedSubviews.last as? UIButton)?.menu = createHiddenToolsMenu()
 
-        self.colorPickerButton.isHidden = !selected
+        colorPickerButton.isHidden = !selected
 
         if selected {
-            self.colorPickerButton.tintColor = color ?? Asset.Colors.zoteroBlueWithDarkMode.color
+            colorPickerButton.tintColor = color ?? Asset.Colors.zoteroBlueWithDarkMode.color
 
             let imageName: String
             switch tool {
             case .ink, .image, .highlight, .note, .freeText, .underline:
                 imageName = "circle.fill"
-                
+
             default:
                 imageName = "circle"
             }
 
-            self.colorPickerButton.setImage(UIImage(systemName: imageName, withConfiguration: UIImage.SymbolConfiguration(scale: .large)), for: .normal)
+            colorPickerButton.setImage(UIImage(systemName: imageName, withConfiguration: UIImage.SymbolConfiguration(scale: .large)), for: .normal)
         }
     }
 
     func set(rotation: Rotation, isCompactSize: Bool) {
-        self.view.layer.cornerRadius = rotation == .vertical ? 8 : 0
-        self.view.layer.masksToBounds = false
+        view.layer.cornerRadius = rotation == .vertical ? 8 : 0
+        view.layer.masksToBounds = false
 
         switch rotation {
         case .vertical:
-            self.setVerticalLayout(isCompactSize: isCompactSize)
+            setVerticalLayout(isCompactSize: isCompactSize)
 
         case .horizontal:
-            self.setHorizontalLayout(isCompactSize: isCompactSize)
+            setHorizontalLayout(isCompactSize: isCompactSize)
         }
 
-        let inset: CGFloat = isCompactSize ? AnnotationToolbarViewController.buttonCompactSpacing : AnnotationToolbarViewController.buttonSpacing
-        self.stackView.spacing = inset
-        self.additionalStackView.spacing = inset
-    }
+        let inset: CGFloat = isCompactSize ? Self.buttonCompactSpacing : Self.buttonSpacing
+        stackView.spacing = inset
+        additionalStackView.spacing = inset
 
-    private func setVerticalLayout(isCompactSize: Bool) {
-        self.horizontalHeight.isActive = false
-        self.additionalTop.isActive = false
-        self.containerBottom.isActive = false
-        self.containerToPickerHorizontal.isActive = false
-        self.colorPickerToAdditionalHorizontal.isActive = false
-        self.colorPickerTop.isActive = false
-        self.colorPickerBottom.isActive = false
-        self.additionalLeading.isActive = true
-        self.containerTrailing.isActive = true
-        self.containerToPickerVertical.isActive = true
-        self.colorPickerToAdditionalVertical.isActive = true
-        self.colorPickerLeading.isActive = true
-        self.colorPickerTrailing.isActive = true
+        func setVerticalLayout(isCompactSize: Bool) {
+            horizontalHeight.isActive = false
+            additionalTop.isActive = false
+            containerBottom.isActive = false
+            containerToPickerHorizontal.isActive = false
+            colorPickerToAdditionalHorizontal.isActive = false
+            colorPickerTop.isActive = false
+            colorPickerBottom.isActive = false
+            additionalLeading.isActive = true
+            containerTrailing.isActive = true
+            containerToPickerVertical.isActive = true
+            colorPickerToAdditionalVertical.isActive = true
+            colorPickerLeading.isActive = true
+            colorPickerTrailing.isActive = true
 
-        self.stackView.axis = .vertical
-        self.additionalStackView.axis = .vertical
+            stackView.axis = .vertical
+            additionalStackView.axis = .vertical
 
-        self.additionalBottom.constant = 8
-        self.additionalTrailing.constant = 8
-        self.containerLeading.constant = 8
-        self.containerTop.constant = 15
-        self.colorPickerLeading.constant = 8
-        self.colorPickerTrailing.constant = 8
-        self.colorPickerToAdditionalVertical.constant = isCompactSize ? AnnotationToolbarViewController.toolsToAdditionalCompactOffset : AnnotationToolbarViewController.toolsToAdditionalFullOffset
-        self.containerToPickerVertical.constant = isCompactSize ? 4 : 8
-        self.hairlineView.isHidden = true
-    }
+            additionalBottom.constant = 8
+            additionalTrailing.constant = 8
+            containerLeading.constant = 8
+            containerTop.constant = 15
+            colorPickerLeading.constant = 8
+            colorPickerTrailing.constant = 8
+            colorPickerToAdditionalVertical.constant = isCompactSize ? Self.toolsToAdditionalCompactOffset : Self.toolsToAdditionalFullOffset
+            containerToPickerVertical.constant = isCompactSize ? 4 : 8
+            hairlineView.isHidden = true
+        }
 
-    private func setHorizontalLayout(isCompactSize: Bool) {
-        self.additionalLeading.isActive = false
-        self.containerTrailing.isActive = false
-        self.containerToPickerVertical.isActive = false
-        self.colorPickerToAdditionalVertical.isActive = false
-        self.colorPickerLeading.isActive = false
-        self.colorPickerTrailing.isActive = false
-        self.horizontalHeight.isActive = true
-        self.additionalTop.isActive = true
-        self.containerBottom.isActive = true
-        self.containerToPickerHorizontal.isActive = true
-        self.colorPickerToAdditionalHorizontal.isActive = true
-        self.colorPickerTop.isActive = true
-        self.colorPickerBottom.isActive = true
+        func setHorizontalLayout(isCompactSize: Bool) {
+            additionalLeading.isActive = false
+            containerTrailing.isActive = false
+            containerToPickerVertical.isActive = false
+            colorPickerToAdditionalVertical.isActive = false
+            colorPickerLeading.isActive = false
+            colorPickerTrailing.isActive = false
+            horizontalHeight.isActive = true
+            additionalTop.isActive = true
+            containerBottom.isActive = true
+            containerToPickerHorizontal.isActive = true
+            colorPickerToAdditionalHorizontal.isActive = true
+            colorPickerTop.isActive = true
+            colorPickerBottom.isActive = true
 
-        self.stackView.axis = .horizontal
-        self.additionalStackView.axis = .horizontal
+            stackView.axis = .horizontal
+            additionalStackView.axis = .horizontal
 
-        self.additionalBottom.constant = 8
-        self.additionalTrailing.constant = 15
-        self.containerLeading.constant = 20
-        self.containerTop.constant = 8
-        self.colorPickerToAdditionalHorizontal.constant = isCompactSize ? AnnotationToolbarViewController.toolsToAdditionalCompactOffset : AnnotationToolbarViewController.toolsToAdditionalFullOffset
-        self.containerToPickerHorizontal.constant = isCompactSize ? 4 : 8
-        self.colorPickerBottom.constant = 8
-        self.colorPickerTop.constant = 8
-        self.hairlineView.isHidden = false
+            additionalBottom.constant = 8
+            additionalTrailing.constant = 15
+            containerLeading.constant = 20
+            containerTop.constant = 8
+            colorPickerToAdditionalHorizontal.constant = isCompactSize ? Self.toolsToAdditionalCompactOffset : Self.toolsToAdditionalFullOffset
+            containerToPickerHorizontal.constant = isCompactSize ? 4 : 8
+            colorPickerBottom.constant = 8
+            colorPickerTop.constant = 8
+            hairlineView.isHidden = false
+        }
     }
 
     func updateAdditionalButtons() {
-        for view in self.additionalStackView.arrangedSubviews {
+        for view in additionalStackView.arrangedSubviews {
             view.removeFromSuperview()
         }
-        for view in self.createAdditionalItems() {
-            self.additionalStackView.addArrangedSubview(view)
+        for view in createAdditionalItems() {
+            additionalStackView.addArrangedSubview(view)
         }
     }
 
     private var currentAnnotationOptions: AnnotationToolOptions {
-        if self.lastGestureRecognizerTouch?.type == .stylus {
+        if lastGestureRecognizerTouch?.type == .stylus {
             return .stylus
         }
         return []
@@ -379,8 +528,8 @@ class AnnotationToolbarViewController: UIViewController {
     // MARK: - Setup
 
     private func createHiddenToolsMenu() -> UIMenu {
-        let children = self.toolButtons.filter({ $0.isHidden }).map({ tool in
-            let isActive = self.delegate?.activeAnnotationTool == tool.type
+        let children = toolButtons.filter({ $0.isHidden }).map({ tool in
+            let isActive = delegate?.activeAnnotationTool == tool.type
             return UIAction(
                 title: tool.title,
                 image: tool.image.withRenderingMode(.alwaysTemplate),
@@ -395,93 +544,49 @@ class AnnotationToolbarViewController: UIViewController {
         return UIMenu(children: children)
     }
 
-    private func createToolButtons(from tools: [ToolButton]) -> [UIView] {
-        var showMoreConfig = UIButton.Configuration.plain()
-        showMoreConfig.contentInsets = AnnotationToolbarViewController.buttonContentInsets
-        showMoreConfig.image = UIImage(systemName: "ellipsis")?.withRenderingMode(.alwaysTemplate)
-        let showMoreButton = UIButton(type: .custom)
-        showMoreButton.configuration = showMoreConfig
-        showMoreButton.translatesAutoresizingMaskIntoConstraints = false
-        showMoreButton.showsLargeContentViewer = true
-        showMoreButton.accessibilityLabel = L10n.Accessibility.Pdf.showMoreTools
-        showMoreButton.largeContentTitle = L10n.Accessibility.Pdf.showMoreTools
-        showMoreButton.setContentCompressionResistancePriority(.required, for: .vertical)
-        showMoreButton.setContentCompressionResistancePriority(.required, for: .horizontal)
-        showMoreButton.tintColor = Asset.Colors.zoteroBlueWithDarkMode.color
-        showMoreButton.showsMenuAsPrimaryAction = true
-        showMoreButton.widthAnchor.constraint(equalTo: showMoreButton.heightAnchor).isActive = true
-
-        return tools.map { tool in
-            let button = CheckboxButton(image: tool.image.withRenderingMode(.alwaysTemplate), contentInsets: AnnotationToolbarViewController.buttonContentInsets)
-            button.translatesAutoresizingMaskIntoConstraints = false
-            button.showsLargeContentViewer = true
-            button.accessibilityLabel = tool.accessibilityLabel
-            button.largeContentTitle = tool.title
-            button.deselectedBackgroundColor = .clear
-            button.deselectedTintColor = Asset.Colors.zoteroBlueWithDarkMode.color
-            button.selectedBackgroundColor = Asset.Colors.zoteroBlue.color
-            button.selectedTintColor = .white
-            button.setContentCompressionResistancePriority(.required, for: .vertical)
-            button.setContentCompressionResistancePriority(.required, for: .horizontal)
-            button.isHidden = true
-            button.widthAnchor.constraint(equalTo: button.heightAnchor).isActive = true
-            button.setNeedsUpdateConfiguration()
-
-            let recognizer = UITapGestureRecognizer()
-            recognizer.delegate = self
-            recognizer.rx.event.subscribe(onNext: { [weak self] _ in
-                guard let self else { return }
-                delegate?.toggle(tool: tool.type, options: currentAnnotationOptions)
-            }).disposed(by: disposeBag)
-            button.addGestureRecognizer(recognizer)
-
-            return button
-        } + [showMoreButton]
-    }
-
     private func createAdditionalItems() -> [UIView] {
         var items: [UIView] = []
 
-        if self.undoRedoEnabled {
+        if undoRedoEnabled {
             var undoConfig = UIButton.Configuration.plain()
-            undoConfig.contentInsets = AnnotationToolbarViewController.buttonContentInsets
+            undoConfig.contentInsets = Self.buttonContentInsets
             undoConfig.image = UIImage(systemName: "arrow.uturn.left")?.applyingSymbolConfiguration(.init(scale: .large))
             let undo = UIButton(type: .custom)
             undo.configuration = undoConfig
-            undo.isEnabled = self.delegate?.canUndo ?? false
+            undo.isEnabled = delegate?.canUndo ?? false
             undo.showsLargeContentViewer = true
             undo.accessibilityLabel = L10n.Accessibility.Pdf.undo
             undo.largeContentTitle = L10n.Accessibility.Pdf.undo
             undo.rx.controlEvent(.touchUpInside)
-                .subscribe(with: self, onNext: { `self`, _ in
-                    guard self.delegate?.canUndo == true else { return }
-                    self.delegate?.performUndo()
+                .subscribe(onNext: { [weak self] _ in
+                    guard let self, delegate?.canUndo == true else { return }
+                    delegate?.performUndo()
                 })
-                .disposed(by: self.disposeBag)
-            self.undoButton = undo
+                .disposed(by: disposeBag)
+            undoButton = undo
             items.append(undo)
 
             var redoConfig = UIButton.Configuration.plain()
-            redoConfig.contentInsets = AnnotationToolbarViewController.buttonContentInsets
+            redoConfig.contentInsets = Self.buttonContentInsets
             redoConfig.image = UIImage(systemName: "arrow.uturn.right")?.applyingSymbolConfiguration(.init(scale: .large))
             let redo = UIButton(type: .custom)
             redo.configuration = redoConfig
-            redo.isEnabled = self.delegate?.canRedo ?? false
+            redo.isEnabled = delegate?.canRedo ?? false
             redo.showsLargeContentViewer = true
             redo.accessibilityLabel = L10n.Accessibility.Pdf.redo
             redo.largeContentTitle = L10n.Accessibility.Pdf.redo
             redo.rx.controlEvent(.touchUpInside)
-                .subscribe(with: self, onNext: { `self`, _ in
-                    guard self.delegate?.canRedo == true else { return }
-                    self.delegate?.performRedo()
+                .subscribe(onNext: { [weak self] _ in
+                    guard let self, delegate?.canRedo == true else { return }
+                    delegate?.performRedo()
                 })
-                .disposed(by: self.disposeBag)
-            self.redoButton = redo
+                .disposed(by: disposeBag)
+            redoButton = redo
             items.append(redo)
         }
 
         var closeConfig = UIButton.Configuration.plain()
-        closeConfig.contentInsets = AnnotationToolbarViewController.buttonContentInsets
+        closeConfig.contentInsets = Self.buttonContentInsets
         closeConfig.image = UIImage(systemName: "xmark.circle")?.applyingSymbolConfiguration(.init(scale: .large))
         let close = UIButton(type: .custom)
         close.configuration = closeConfig
@@ -489,10 +594,10 @@ class AnnotationToolbarViewController: UIViewController {
         close.accessibilityLabel = L10n.close
         close.largeContentTitle = L10n.close
         close.rx.controlEvent(.touchUpInside)
-             .subscribe(with: self, onNext: { `self`, _ in
-                 self.delegate?.closeAnnotationToolbar()
-             })
-             .disposed(by: self.disposeBag)
+            .subscribe(onNext: { [weak self] _ in
+                self?.delegate?.closeAnnotationToolbar()
+            })
+            .disposed(by: disposeBag)
         items.append(close)
 
         let handle = UIImageView(image: UIImage(systemName: "line.3.horizontal")?.applyingSymbolConfiguration(.init(scale: .large)))
@@ -510,120 +615,11 @@ class AnnotationToolbarViewController: UIViewController {
 
         return items
     }
-
-    private func createColorPickerButton() -> UIButton {
-        var pickerConfig = UIButton.Configuration.plain()
-        pickerConfig.contentInsets = AnnotationToolbarViewController.buttonContentInsets
-        pickerConfig.image = UIImage(systemName: "circle.fill")?.applyingSymbolConfiguration(.init(scale: .large))
-        let picker = UIButton()
-        picker.configuration = pickerConfig
-        picker.showsLargeContentViewer = true
-        picker.translatesAutoresizingMaskIntoConstraints = false
-        picker.setContentCompressionResistancePriority(.required, for: .horizontal)
-        picker.setContentCompressionResistancePriority(.required, for: .vertical)
-        picker.widthAnchor.constraint(equalTo: picker.heightAnchor).isActive = true
-        picker.isHidden = true
-        picker.accessibilityLabel = L10n.Accessibility.Pdf.colorPicker
-        picker.largeContentTitle = L10n.Accessibility.Pdf.colorPicker
-        picker.rx.controlEvent(.touchUpInside)
-              .subscribe(with: self, onNext: { `self`, _ in
-                  self.delegate?.showToolOptions(sender: .view(self.colorPickerButton, nil))
-              })
-              .disposed(by: self.disposeBag)
-        return picker
-    }
-
-    private func setupViews() {
-        self.view.translatesAutoresizingMaskIntoConstraints = false
-
-        let stackView = UIStackView(arrangedSubviews: self.createToolButtons(from: self.toolButtons))
-        stackView.showsLargeContentViewer = true
-        stackView.axis = .vertical
-        stackView.spacing = 0
-        stackView.distribution = .fill
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        stackView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
-        stackView.setContentHuggingPriority(.required, for: .vertical)
-        stackView.setContentHuggingPriority(.required, for: .horizontal)
-        self.view.addSubview(stackView)
-
-        let picker = self.createColorPickerButton()
-        self.view.addSubview(picker)
-        self.colorPickerButton = picker
-
-        let additionalStackView = UIStackView(arrangedSubviews: self.createAdditionalItems())
-        additionalStackView.showsLargeContentViewer = true
-        additionalStackView.setContentCompressionResistancePriority(.required, for: .horizontal)
-        additionalStackView.setContentCompressionResistancePriority(.required, for: .vertical)
-        additionalStackView.setContentHuggingPriority(.required, for: .vertical)
-        additionalStackView.setContentHuggingPriority(.required, for: .horizontal)
-        additionalStackView.axis = .vertical
-        additionalStackView.spacing = 0
-        additionalStackView.distribution = .fill
-        additionalStackView.translatesAutoresizingMaskIntoConstraints = false
-        self.view.addSubview(additionalStackView)
-
-        let hairline = UIView()
-        hairline.translatesAutoresizingMaskIntoConstraints = false
-        hairline.backgroundColor = UIColor.separator
-        self.view.addSubview(hairline)
-        self.hairlineView = hairline
-
-        self.horizontalHeight = self.view.heightAnchor.constraint(equalToConstant: self.size)
-        self.horizontalHeight.priority = .required
-        self.containerBottom = self.view.bottomAnchor.constraint(equalTo: stackView.bottomAnchor, constant: 8)
-        self.containerTrailing = self.view.trailingAnchor.constraint(equalTo: stackView.trailingAnchor, constant: 8)
-        self.additionalTop = additionalStackView.topAnchor.constraint(equalTo: self.view.topAnchor, constant: 8)
-        self.additionalLeading = additionalStackView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 8)
-        self.containerToPickerVertical = picker.topAnchor.constraint(greaterThanOrEqualTo: stackView.bottomAnchor, constant: 0)
-        self.containerToPickerVertical.priority = .required
-        self.containerToPickerHorizontal = picker.leadingAnchor.constraint(equalTo: stackView.trailingAnchor)
-        self.containerToPickerHorizontal.priority = .required
-        self.colorPickerToAdditionalVertical = additionalStackView.topAnchor.constraint(equalTo: picker.bottomAnchor)
-        self.colorPickerToAdditionalHorizontal = additionalStackView.leadingAnchor.constraint(greaterThanOrEqualTo: picker.trailingAnchor, constant: 0)
-        self.colorPickerTop = picker.topAnchor.constraint(equalTo: self.view.topAnchor)
-        self.colorPickerBottom = self.view.bottomAnchor.constraint(equalTo: picker.bottomAnchor)
-        self.colorPickerLeading = picker.leadingAnchor.constraint(equalTo: self.view.leadingAnchor)
-        self.colorPickerTrailing = self.view.trailingAnchor.constraint(equalTo: picker.trailingAnchor)
-        let containerTop = stackView.topAnchor.constraint(equalTo: self.view.topAnchor, constant: 15)
-        let containerLeading = stackView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: 15)
-        let additionalBottom = self.view.bottomAnchor.constraint(equalTo: additionalStackView.bottomAnchor, constant: 8)
-        let additionalTrailing = self.view.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: additionalStackView.trailingAnchor, constant: 8)
-        let hairlineHeight = hairline.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale)
-        let hairlineLeading = hairline.leadingAnchor.constraint(equalTo: self.view.leadingAnchor)
-        let hairlineTrailing = hairline.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
-        let hairlineBottom = hairline.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
-
-        NSLayoutConstraint.activate([
-            containerTop,
-            containerLeading,
-            self.containerTrailing,
-            self.containerToPickerVertical,
-            self.colorPickerLeading,
-            self.colorPickerTrailing,
-            additionalBottom,
-            self.colorPickerToAdditionalVertical,
-            additionalTrailing,
-            self.additionalLeading,
-            hairlineHeight,
-            hairlineLeading,
-            hairlineTrailing,
-            hairlineBottom
-        ])
-
-        self.containerTop = containerTop
-        self.containerLeading = containerLeading
-        self.additionalTrailing = additionalTrailing
-        self.additionalBottom = additionalBottom
-        self.stackView = stackView
-        self.additionalStackView = additionalStackView
-    }
 }
 
 extension AnnotationToolbarViewController: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        self.lastGestureRecognizerTouch = touch
+        lastGestureRecognizerTouch = touch
         return true
     }
 }

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarViewController.swift
@@ -373,6 +373,9 @@ class AnnotationToolbarViewController: UIViewController {
         let pickerToAdditionalOffset = isHorizontal ? colorPickerToAdditionalHorizontal.constant : colorPickerToAdditionalVertical.constant
         let additionalOffset = isHorizontal ? additionalTrailing.constant : additionalBottom.constant
         let remainingSize = maxAvailableSize - stackViewOffset - containerToPickerOffset - pickerSize - pickerToAdditionalOffset - additionalSize - additionalOffset
+        if remainingSize < 0 {
+            DDLogWarn("AnnotationToolbarViewController: not enough \(isHorizontal ? "horizontal" : "vertical") minimum size")
+        }
         let count = max(0, min(Int(floor(remainingSize / buttonSize)), toolButtons.count))
 
         for idx in 0..<count {

--- a/Zotero/Scenes/Detail/PDF/Views/DashedView.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/DashedView.swift
@@ -37,76 +37,77 @@ class DashedView: UIView {
     private let type: Kind
 
     private var dashLayer: CAShapeLayer? {
-        return (self.layer.sublayers ?? []).compactMap({ $0 as? CAShapeLayer }).first
+        return (layer.sublayers ?? []).compactMap({ $0 as? CAShapeLayer }).first
     }
 
     var dashColor: UIColor {
         didSet {
-            guard let layer = self.dashLayer else { return }
-            layer.strokeColor = self.dashColor.cgColor
+            dashLayer?.strokeColor = dashColor.cgColor
         }
     }
 
     init(type: Kind) {
-        self.dashColor = .black
+        dashColor = .black
         self.type = type
         super.init(frame: CGRect())
         switch type {
         case .rounded(let cornerRadius):
-            self.layer.cornerRadius = cornerRadius
+            layer.cornerRadius = cornerRadius
             
         case .partialStraight:
             break
         }
-        self.addDashedBorder(color: .black)
+        addDashedBorder(color: dashColor)
     }
-
+    
     required init?(coder: NSCoder) {
-        self.dashColor = .black
-        self.type = .rounded(cornerRadius: 8)
+        dashColor = .black
+        let cornerRadius: CGFloat = 8
+        type = .rounded(cornerRadius: cornerRadius)
         super.init(coder: coder)
-        self.addDashedBorder(color: .black)
+        layer.cornerRadius = cornerRadius
+        addDashedBorder(color: dashColor)
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        guard let layer = self.dashLayer else { return }
+        guard let dashLayer else { return }
 
-        layer.frame = self.bounds
-        layer.path = self.createPath(forType: self.type)
+        dashLayer.frame = bounds
+        dashLayer.path = createPath(forType: type)
     }
 
     private func addDashedBorder(color: UIColor) {
         let shapeLayer = CAShapeLayer()
-        shapeLayer.frame = self.bounds
+        shapeLayer.frame = bounds
         shapeLayer.fillColor = UIColor.clear.cgColor
         shapeLayer.strokeColor = color.cgColor
-        shapeLayer.lineWidth = DashedView.dashWidth
+        shapeLayer.lineWidth = Self.dashWidth
         shapeLayer.lineJoin = CAShapeLayerLineJoin.round
         shapeLayer.lineDashPattern = [6, 3]
-        shapeLayer.path = self.createPath(forType: self.type)
-        self.layer.addSublayer(shapeLayer)
+        shapeLayer.path = createPath(forType: type)
+        layer.addSublayer(shapeLayer)
     }
 
     private func createPath(forType type: Kind) -> CGPath {
         switch type {
         case .rounded(let cornerRadius):
-            return UIBezierPath(roundedRect: self.bounds, cornerRadius: cornerRadius).cgPath
+            return UIBezierPath(roundedRect: bounds, cornerRadius: cornerRadius).cgPath
 
         case .partialStraight(let sides):
             let path = CGMutablePath()
             if sides.contains(.left) {
-                path.addLines(between: [CGPoint(x: self.bounds.minX, y: self.bounds.minY), CGPoint(x: self.bounds.minX, y: self.bounds.maxY)])
+                path.addLines(between: [CGPoint(x: bounds.minX, y: bounds.minY), CGPoint(x: bounds.minX, y: bounds.maxY)])
             }
             if sides.contains(.right) {
-                path.addLines(between: [CGPoint(x: self.bounds.maxX, y: self.bounds.minY), CGPoint(x: self.bounds.maxX, y: self.bounds.maxY)])
+                path.addLines(between: [CGPoint(x: bounds.maxX, y: bounds.minY), CGPoint(x: bounds.maxX, y: bounds.maxY)])
             }
             if sides.contains(.top) {
-                path.addLines(between: [CGPoint(x: self.bounds.minX, y: self.bounds.minY), CGPoint(x: self.bounds.maxX, y: self.bounds.minY)])
+                path.addLines(between: [CGPoint(x: bounds.minX, y: bounds.minY), CGPoint(x: bounds.maxX, y: bounds.minY)])
             }
             if sides.contains(.bottom) {
-                path.addLines(between: [CGPoint(x: self.bounds.minX, y: self.bounds.maxY), CGPoint(x: self.bounds.maxX, y: self.bounds.maxY)])
+                path.addLines(between: [CGPoint(x: bounds.minX, y: bounds.maxY), CGPoint(x: bounds.maxX, y: bounds.maxY)])
             }
             return path
         }

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -770,11 +770,14 @@ extension PDFReaderViewController: AnnotationToolbarDelegate {
             return isCompactWidth ? documentController.view.frame.size.width : (documentController.view.frame.size.width - (2 * AnnotationToolbarHandler.toolbarFullInset))
 
         case .trailing, .leading:
-            let window = (view.scene as? UIWindowScene)?.keyWindow
-            let topInset = window?.safeAreaInsets.top ?? 0
-            let bottomInset = window?.safeAreaInsets.bottom ?? 0
             let interfaceIsHidden = navigationController?.isNavigationBarHidden ?? false
-            return view.frame.size.height - (2 * AnnotationToolbarHandler.toolbarCompactInset) - (interfaceIsHidden ? 0 : (topInset + documentController.scrubberBarHeight)) - bottomInset
+            let documentAvailableHeight: CGFloat
+            if !interfaceIsHidden, let scrubberBarFrame = documentController.pdfController?.userInterfaceView.scrubberBar.frame {
+                documentAvailableHeight = scrubberBarFrame.minY
+            } else {
+                documentAvailableHeight = documentController.view.frame.height - documentController.view.safeAreaInsets.bottom
+            }
+            return documentAvailableHeight - (2 * AnnotationToolbarHandler.toolbarCompactInset)
         }
     }
 

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -691,10 +691,6 @@ extension PDFReaderViewController: AnnotationToolbarHandlerDelegate {
         return view
     }
 
-    var documentView: UIView {
-        return documentController.view
-    }
-
     func layoutIfNeeded() {
         view.layoutIfNeeded()
     }


### PR DESCRIPTION
Generalizes the architecture of the annotation toolbar handler, to allow for also handling a future open documents tab bar.

There are several (pre-existing) edge cases, when a phone device is rotated to landscape, which could be improved with some more streamlining, especially regarding the annotation toolbar view controller layout. I guess though, that those edge cases might not be ones users are partial to, otherwise we might have gotten relevant feedback.