### PR TITLE
Improve URLSession HTTP download response handling

### DIFF
--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -381,6 +381,8 @@
 "errors.attachments.missing_webdav" = "The attached file is not available on the WebDAV server.";
 "errors.attachments.missing_additional" = "Please check that the file has synced on the device where it was added.";
 "errors.attachments.unauthorized_webdav" = "The WebDAV server did not accept the username and password you have saved in settings.";
+"errors.attachments.forbidden_webdav" = "You don't have permission to access %@ on the WebDAV server.";
+"errors.attachments.generic_filename" = "the file";
 "errors.login.invalid_password" = "Invalid password";
 "errors.login.invalid_username" = "Invalid username";
 "errors.login.invalid_credentials" = "Invalid username or password";

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -56,6 +56,7 @@
 "cancel_all" = "Cancel All";
 "back" = "Back";
 "forward" = "Forward";
+"go_to_settings" = "Go to Settings";
 
 "beta_wipe_title" = "Resync Required";
 "beta_wipe_message" = "Due to a beta update, your data must be redownloaded from zotero.org.";

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -379,6 +379,7 @@
 "errors.attachments.missing_zotero" = "The attached file is not available in the online library.";
 "errors.attachments.missing_webdav" = "The attached file is not available on the WebDAV server.";
 "errors.attachments.missing_additional" = "Please check that the file has synced on the device where it was added.";
+"errors.attachments.unauthorized_webdav" = "The WebDAV server did not accept the username and password you have saved in settings.";
 "errors.login.invalid_password" = "Invalid password";
 "errors.login.invalid_username" = "Invalid username";
 "errors.login.invalid_credentials" = "Invalid username or password";

--- a/Zotero/Controllers/Attachment Downloader/AttachmentDownloader.swift
+++ b/Zotero/Controllers/Attachment Downloader/AttachmentDownloader.swift
@@ -802,6 +802,9 @@ extension AttachmentDownloader: URLSessionDownloadDelegate {
         case 401:
             error = createError(from: downloadTask, statusCode: 401, response: "Unauthorized")
 
+        case 403:
+            error = createError(from: downloadTask, statusCode: 403, response: "Forbidden")
+
         case 404:
             error = createError(from: downloadTask, statusCode: 404, response: "Not Found")
 

--- a/Zotero/Controllers/Attachment Downloader/AttachmentDownloader.swift
+++ b/Zotero/Controllers/Attachment Downloader/AttachmentDownloader.swift
@@ -784,6 +784,7 @@ final class AttachmentDownloader: NSObject {
 
 extension AttachmentDownloader: URLSessionDownloadDelegate {
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        let statusCode = (downloadTask.response as? HTTPURLResponse)?.statusCode ?? -1
         var download: Download?
         var activeDownload: ActiveDownload?
         accessQueue.sync { [weak self] in
@@ -796,7 +797,17 @@ extension AttachmentDownloader: URLSessionDownloadDelegate {
             return
         }
 
-        let error = checkFileResponse(for: Files.file(from: location), fileStorage: fileStorage, downloadTask: downloadTask)
+        let error: Swift.Error?
+        switch statusCode {
+        case 401:
+            error = createError(from: downloadTask, statusCode: 401, response: "Unauthorized")
+
+        case 404:
+            error = createError(from: downloadTask, statusCode: 404, response: "Not Found")
+
+        default:
+            error = checkFileResponse(for: Files.file(from: location), fileStorage: fileStorage, downloadTask: downloadTask)
+        }
         if let data = activeDownload.logData {
             logResponse(for: data, task: downloadTask, error: error)
         }
@@ -856,15 +867,19 @@ extension AttachmentDownloader: URLSessionDownloadDelegate {
         func checkFileResponse(for file: File, fileStorage: FileStorage, downloadTask: URLSessionDownloadTask) -> Swift.Error? {
             if fileStorage.isEmptyOrNotFoundResponse(file: file) {
                 try? fileStorage.remove(file)
-                return AFResponseError(
-                    url: downloadTask.currentRequest?.url,
-                    httpMethod: downloadTask.currentRequest?.httpMethod ?? "Unknown",
-                    error: .responseValidationFailed(reason: .unacceptableStatusCode(code: 404)),
-                    headers: (downloadTask.response as? HTTPURLResponse)?.allHeaderFields,
-                    response: "Not found"
-                )
+                return createError(from: downloadTask, statusCode: 404, response: "Not Found")
             }
             return nil
+        }
+
+        func createError(from downloadTask: URLSessionDownloadTask, statusCode: Int, response: String) -> AFResponseError {
+            return AFResponseError(
+                url: downloadTask.currentRequest?.url,
+                httpMethod: downloadTask.currentRequest?.httpMethod ?? "Unknown",
+                error: .responseValidationFailed(reason: .unacceptableStatusCode(code: statusCode)),
+                headers: (downloadTask.response as? HTTPURLResponse)?.allHeaderFields,
+                response: response
+            )
         }
     }
 

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -62,6 +62,8 @@ internal enum L10n {
   internal static func fullSyncDebug(_ p1: Any) -> String {
     return L10n.tr("Localizable", "full_sync_debug", String(describing: p1), fallback: "Full sync has finished. Please report Debug ID %@ in the Zotero Forums.")
   }
+  /// Go to Settings
+  internal static let goToSettings = L10n.tr("Localizable", "go_to_settings", fallback: "Go to Settings")
   /// Item Type
   internal static let itemType = L10n.tr("Localizable", "item_type", fallback: "Item Type")
   /// Keep

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -406,6 +406,12 @@ internal enum L10n {
       internal static let cantOpenAttachment = L10n.tr("Localizable", "errors.attachments.cant_open_attachment", fallback: "The attached file could not be found.")
       /// Unable to unzip snapshot
       internal static let cantUnzipSnapshot = L10n.tr("Localizable", "errors.attachments.cant_unzip_snapshot", fallback: "Unable to unzip snapshot")
+      /// You don't have permission to access %@ on the WebDAV server.
+      internal static func forbiddenWebdav(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "errors.attachments.forbidden_webdav", String(describing: p1), fallback: "You don't have permission to access %@ on the WebDAV server.")
+      }
+      /// the file
+      internal static let genericFilename = L10n.tr("Localizable", "errors.attachments.generic_filename", fallback: "the file")
       /// Linked files are not supported on iOS. You can open them using the Zotero desktop app.
       internal static let incompatibleAttachment = L10n.tr("Localizable", "errors.attachments.incompatible_attachment", fallback: "Linked files are not supported on iOS. You can open them using the Zotero desktop app.")
       /// Please check that the file has synced on the device where it was added.

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -412,6 +412,8 @@ internal enum L10n {
       internal static let missingWebdav = L10n.tr("Localizable", "errors.attachments.missing_webdav", fallback: "The attached file is not available on the WebDAV server.")
       /// The attached file is not available in the online library.
       internal static let missingZotero = L10n.tr("Localizable", "errors.attachments.missing_zotero", fallback: "The attached file is not available in the online library.")
+      /// The WebDAV server did not accept the username and password you have saved in settings.
+      internal static let unauthorizedWebdav = L10n.tr("Localizable", "errors.attachments.unauthorized_webdav", fallback: "The WebDAV server did not accept the username and password you have saved in settings.")
     }
     internal enum Citation {
       /// Could not generate bibliography.

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -724,26 +724,38 @@ extension DetailCoordinator: DetailItemDetailCoordinatorDelegate {
             switch responseError.error {
             case .responseValidationFailed(let reason):
                 switch reason {
-                case .unacceptableStatusCode(let code) where code == 404:
-                    let webDavEnabled = self.controllers.userControllers?.webDavController.sessionStorage.isEnabled ?? false
+                case .unacceptableStatusCode(let code):
+                    let webDavEnabled = controllers.userControllers?.webDavController.sessionStorage.isEnabled ?? false
+                    switch code {
+                    case 401:
+                        if webDavEnabled {
+                            return(L10n.Errors.Attachments.unauthorizedWebdav, [])
+                        }
 
-                    let messageStart: String
-                    if webDavEnabled {
-                        messageStart = L10n.Errors.Attachments.missingWebdav
-                    } else {
-                        messageStart = L10n.Errors.Attachments.missingZotero
+                    case 404:
+                        let messageStart: String
+                        if webDavEnabled {
+                            messageStart = L10n.Errors.Attachments.missingWebdav
+                        } else {
+                            messageStart = L10n.Errors.Attachments.missingZotero
+                        }
+
+                        let message = "\(messageStart) \(L10n.Errors.Attachments.missingAdditional)"
+                        let action = UIAlertAction(title: L10n.moreInformation, style: .default) { [weak self] _ in
+                            self?.showWeb(url: URL(string: "https://www.zotero.org/support/kb/files_not_syncing")!)
+                        }
+                        return (message, [action])
+
+                    default:
+                        break
                     }
 
-                    let message = "\(messageStart) \(L10n.Errors.Attachments.missingAdditional)"
-                    let action = UIAlertAction(title: L10n.moreInformation, style: .default) { [weak self] _ in
-                        self?.showWeb(url: URL(string: "https://www.zotero.org/support/kb/files_not_syncing")!)
-                    }
-                    return (message, [action])
-
-                default: break
+                default:
+                    break
                 }
 
-            default: break
+            default:
+                break
             }
         }
 

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -746,6 +746,12 @@ extension DetailCoordinator: DetailItemDetailCoordinatorDelegate {
                                 return(L10n.Errors.Attachments.unauthorizedWebdav, [action, cancelAction])
                             }
 
+                        case 403:
+                            if webDavEnabled {
+                                let message = L10n.Errors.Attachments.forbiddenWebdav(responseError.url?.lastPathComponent ?? L10n.Errors.Attachments.genericFilename)
+                                return(message, actions)
+                            }
+
                         case 404:
                             let messageStart: String
                             if webDavEnabled {

--- a/Zotero/Scenes/Master/MasterCoordinator.swift
+++ b/Zotero/Scenes/Master/MasterCoordinator.swift
@@ -206,9 +206,9 @@ extension MasterCoordinator: MasterLibrariesCoordinatorDelegate {
     func showSettings() {
         let navigationController = NavigationViewController()
         let containerController = ContainerViewController(rootViewController: navigationController)
-        let coordinator = SettingsCoordinator(startsWithExport: false, navigationController: navigationController, controllers: self.controllers)
+        let coordinator = SettingsCoordinator(navigationController: navigationController, controllers: controllers)
         coordinator.parentCoordinator = self
-        self.childCoordinators.append(coordinator)
+        childCoordinators.append(coordinator)
         coordinator.start(animated: false)
 
         self.navigationController?.present(containerController, animated: true, completion: nil)


### PR DESCRIPTION
Handles the edge case where an attachment download task will finish with status code 401, but it is masked by another error message. User case in this forum [comment](https://forums.zotero.org/discussion/comment/461352/#Comment_461352).

We may need to handle more specific status codes explicitly.