### PR TITLE
Fix PDF document gaps for selection and highlight annotations

### DIFF
--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -6557,7 +6557,7 @@
 			repositoryURL = "https://github.com/PSPDFKit/PSPDFKit-SP";
 			requirement = {
 				kind = exactVersion;
-				version = 13.3.1;
+				version = 13.5.0;
 			};
 		};
 		B3D84BEE27919FDE005DDD7C /* XCRemoteSwiftPackageReference "Starscream" */ = {

--- a/Zotero.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Zotero.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PSPDFKit/PSPDFKit-SP",
       "state" : {
-        "revision" : "b70f8289374856d78b537454849cb9090fa4db8f",
-        "version" : "13.3.1"
+        "revision" : "c7d84dd85232e1ac723c4e6bb5d9c654df56de0e",
+        "version" : "13.5.0"
       }
     },
     {


### PR DESCRIPTION
@dstillman @michalrentka the latest release of PSDFKit (13.5.0) improves the highlight annotation gap issue (#880) , but doesn't resolve it completely. It still keeps some gaps between sentences. Should we go ahead and merge it, or stick with 13.3.1 until it's further resolved? (I've already replied in the original ticket we had with PSPDFKit)

Highlight 13.3.1:
<img width="312" alt="highlight 13 3 1" src="https://github.com/zotero/zotero-ios/assets/617841/4c31d268-f1eb-4eed-bdf2-b786cb89233e">
Selection 13.3.1:
<img width="311" alt="selection 13 3 1" src="https://github.com/zotero/zotero-ios/assets/617841/7a5e7461-4fb3-4047-a50d-8d6dd5c15776">
Highlight 13.5.0:
<img width="391" alt="highlight 13 5 0" src="https://github.com/zotero/zotero-ios/assets/617841/14f02a1d-5771-4dfc-bcd6-0f1801177646">
Selection 13.5.0:
<img width="399" alt="selection 13 5 0" src="https://github.com/zotero/zotero-ios/assets/617841/e9ce49f0-46ab-4a25-af57-adb34b1920bf">
