### PR TITLE
Fix AttachmentDownloader URLSession memory leak

### DIFF
--- a/Zotero/Controllers/Attachment Downloader/AttachmentDownloader.swift
+++ b/Zotero/Controllers/Attachment Downloader/AttachmentDownloader.swift
@@ -581,7 +581,7 @@ final class AttachmentDownloader: NSObject {
         }
     }
 
-    func cancelAll() {
+    func cancelAll(invalidateSession: Bool = false) {
         DDLogInfo("AttachmentDownloader: stop all tasks")
 
         accessQueue.sync(flags: .barrier) { [weak self] in
@@ -613,6 +613,10 @@ final class AttachmentDownloader: NSObject {
             } catch let error {
                 DDLogError("AttachmentDownloader: can't delete all downloads - \(error)")
             }
+        }
+
+        if invalidateSession {
+            session?.invalidateAndCancel()
         }
     }
 

--- a/Zotero/Controllers/Controllers.swift
+++ b/Zotero/Controllers/Controllers.swift
@@ -265,7 +265,7 @@ final class Controllers {
         // Disable ongoing sync and unsubscribe from websocket
         controllers?.disableSync(apiKey: self.apiKey)
         // Cancel all downloads
-        controllers?.fileDownloader.cancelAll()
+        controllers?.fileDownloader.cancelAll(invalidateSession: true)
         // Cancel all identifier lookups
         controllers?.identifierLookupController.cancelAllLookups()
         // Cancel all remote downloads


### PR DESCRIPTION
If user signs out and signs in again, without terminating the app, their downloads are still handled by the leaked delegate, and cannot be finished. 