### PR TITLE
Improve selected square annotation drawing

### DIFF
--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6135EF9A2C2ABCD7008DA17B /* SquareAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6135EF992C2ABCD7008DA17B /* SquareAnnotationView.swift */; };
+		6135EF9C2C2ABDD1008DA17B /* AnnotationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6135EF9B2C2ABDD1008DA17B /* AnnotationManager.swift */; };
 		61391B7E2B3C6ED9003B314A /* CopyBibliographyAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61391B7D2B3C6ED9003B314A /* CopyBibliographyAction.swift */; };
 		61391B802B3C6F22003B314A /* CopyBibliographyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61391B7F2B3C6F22003B314A /* CopyBibliographyState.swift */; };
 		61391B832B3C6F83003B314A /* CopyBibliographyActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61391B822B3C6F83003B314A /* CopyBibliographyActionHandler.swift */; };
@@ -1268,6 +1270,8 @@
 
 /* Begin PBXFileReference section */
 		611486502A9CD511002EEBEF /* ci_post_xcodebuild.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_xcodebuild.sh; sourceTree = "<group>"; };
+		6135EF992C2ABCD7008DA17B /* SquareAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SquareAnnotationView.swift; sourceTree = "<group>"; };
+		6135EF9B2C2ABDD1008DA17B /* AnnotationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationManager.swift; sourceTree = "<group>"; };
 		61391B7D2B3C6ED9003B314A /* CopyBibliographyAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyBibliographyAction.swift; sourceTree = "<group>"; };
 		61391B7F2B3C6F22003B314A /* CopyBibliographyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyBibliographyState.swift; sourceTree = "<group>"; };
 		61391B822B3C6F83003B314A /* CopyBibliographyActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyBibliographyActionHandler.swift; sourceTree = "<group>"; };
@@ -2937,6 +2941,7 @@
 				B31028042B1E012A00E41554 /* PDFThumbnailsViewController.swift */,
 				B3BD86BB258CBCD600EF6674 /* SearchBar.swift */,
 				B3A47C3329014F8F00E7D90D /* SearchBarCell.swift */,
+				6135EF992C2ABCD7008DA17B /* SquareAnnotationView.swift */,
 				B39AF553290033CD001F400F /* TableOfContentsViewController.swift */,
 				B3CCB8D929B73DED0097520B /* UnlockPDFViewController.swift */,
 			);
@@ -3715,6 +3720,7 @@
 			isa = PBXGroup;
 			children = (
 				B3F49FB528B8C3F600A1F3E8 /* AnnotationEditability.swift */,
+				6135EF9B2C2ABDD1008DA17B /* AnnotationManager.swift */,
 				B36E9D4825E51B0E00CD1109 /* AnnotationPosition.swift */,
 				B30BE12A297AADB8000AED6A /* AnnotationToolOptionsAction.swift */,
 				B30BE128297AADAF000AED6A /* AnnotationToolOptionsState.swift */,
@@ -5067,6 +5073,7 @@
 				B3F4E4EE2A4DC39800820718 /* JSONSerialization+Utils.swift in Sources */,
 				B3CCB8DA29B73DED0097520B /* UnlockPDFViewController.swift in Sources */,
 				B331F9B12653F59C0099F6A6 /* RStyle.swift in Sources */,
+				6135EF9A2C2ABCD7008DA17B /* SquareAnnotationView.swift in Sources */,
 				B3AAB0F8283B9915008188D6 /* LookupItemCell.swift in Sources */,
 				B3F49FB628B8C3F600A1F3E8 /* AnnotationEditability.swift in Sources */,
 				B34C4108257122BF0057D5F5 /* AnnotationViewLayout.swift in Sources */,
@@ -5160,6 +5167,7 @@
 				B30566AB23FC051F003304F2 /* ItemTypes.swift in Sources */,
 				B3DCDF18240917500039ED0D /* ItemTypePickerViewModelCreator.swift in Sources */,
 				B3A2AECE26553DD8004BF3A4 /* NavigationViewController.swift in Sources */,
+				6135EF9C2C2ABDD1008DA17B /* AnnotationManager.swift in Sources */,
 				B358D3B4279590C200A67054 /* CheckAnyItemIsInTrashDbRequest.swift in Sources */,
 				B3866A582417C1BC006693C4 /* ViewModel.swift in Sources */,
 				B305669D23FC051F003304F2 /* RGroup.swift in Sources */,

--- a/Zotero/Controllers/AnnotationPreviewController.swift
+++ b/Zotero/Controllers/AnnotationPreviewController.swift
@@ -241,13 +241,7 @@ extension AnnotationPreviewController {
 
     /// Creates and enqueues a render request for PSPDFKit rendering engine.
     private func enqueue(data: EnqueuedData) {
-        var skipAnnotations = data.document.annotations(at: data.pageIndex)
-        if data.includeAnnotation {
-            skipAnnotations = skipAnnotations.filter({ $0.previewId != data.key })
-        }
-
         let options = RenderOptions()
-        options.skipAnnotationArray = skipAnnotations
         if data.isDark {
             options.invertRenderColor = true
             options.filters = [.colorCorrectInverted]
@@ -257,6 +251,7 @@ extension AnnotationPreviewController {
         request.pageIndex = data.pageIndex
         request.pdfRect = data.rect
         request.imageSize = data.imageSize
+        request.annotations = data.includeAnnotation ? data.document.annotations(at: data.pageIndex).filter({ $0.previewId == data.key }) : []
         request.imageScale = [1.0, 2.0, 3.0].contains(data.imageScale) ? data.imageScale : 0.0
         request.options = options
 

--- a/Zotero/Controllers/CommentIconDrawingController.swift
+++ b/Zotero/Controllers/CommentIconDrawingController.swift
@@ -20,6 +20,10 @@ struct CommentIconDrawingController {
 
         context.setAlpha(alpha)
         context.translateBy(x: origin.x, y: origin.y)
+        if context.ctm.d < 0 {
+            context.translateBy(x: 0, y: height)
+            context.scaleBy(x: 1, y: -1)
+        }
 
         let poly1: [(CGFloat, CGFloat)] = [(width / 2, 0), (width, 0), (width, height), (0, height), (0, height / 2)]
         let points1 = poly1.map { CGPoint(x: $0, y: $1) }

--- a/Zotero/Scenes/Detail/PDF/Models/AnnotationManager.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/AnnotationManager.swift
@@ -1,0 +1,20 @@
+//
+//  AnnotationManager.swift
+//  Zotero
+//
+//  Created by Miltiadis Vasilakis on 25/6/24.
+//  Copyright © 2024 Corporation for Digital Scholarship. All rights reserved.
+//
+
+import Foundation
+import PSPDFKit
+
+class AnnotationManager: PSPDFKit.AnnotationManager {
+    override func annotationViewClass(for annotation: Annotation) -> AnyClass? {
+        if annotation is SquareAnnotation {
+            // Use a custom annotation view subclass for square annotations.
+            return SquareAnnotationView.self
+        }
+        return super.annotationViewClass(for: annotation)
+    }
+}

--- a/Zotero/Scenes/Detail/PDF/Models/PDFReaderState.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/PDFReaderState.swift
@@ -141,6 +141,7 @@ struct PDFReaderState: ViewModelState {
         self.key = key
         self.parentKey = parentKey
         self.document = Document(url: url)
+        document.overrideClass(PSPDFKit.AnnotationManager.self, with: AnnotationManager.self)
         self.displayTitle = displayTitle
         self.previewCache = NSCache()
         self.commentFont = PDFReaderLayout.annotationLayout.font

--- a/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
@@ -550,6 +550,7 @@ final class PDFDocumentViewController: UIViewController {
             builder.overrideClass(PSPDFKit.SquareAnnotation.self, with: SquareAnnotation.self)
             builder.overrideClass(PSPDFKit.UnderlineAnnotation.self, with: UnderlineAnnotation.self)
             builder.overrideClass(FreeTextAnnotationView.self, with: CustomFreeTextAnnotationView.self)
+            builder.overrideClass(PSPDFKit.AnnotationManager.self, with: AnnotationManager.self)
         }
 
         let controller = PDFViewController(document: document, configuration: pdfConfiguration)

--- a/Zotero/Scenes/Detail/PDF/Views/SquareAnnotationView.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/SquareAnnotationView.swift
@@ -1,0 +1,51 @@
+//
+//  SquareAnnotationView.swift
+//  Zotero
+//
+//  Created by Miltiadis Vasilakis on 25/6/24.
+//  Copyright © 2024 Corporation for Digital Scholarship. All rights reserved.
+//
+
+import Foundation
+import PSPDFKitUI
+
+class SquareAnnotationView: PSPDFKitUI.HostingAnnotationView {
+    private var commentImageView: UIImageView?
+
+    override var annotationImageView: UIImageView? {
+        commentImageView?.removeFromSuperview()
+        commentImageView = nil
+        guard let annotationImageView = super.annotationImageView else {
+            return nil
+        }
+        guard let annotation, let comment = annotation.contents, !comment.isEmpty, !annotation.flags.contains(.hidden) else {
+            return annotationImageView
+        }
+        commentImageView = createCommentImageView(in: annotationImageView)
+        return annotationImageView
+
+        func createCommentImageView(in annotationImageView: UIImageView) -> UIImageView {
+            let width: CGFloat = 12
+            let height: CGFloat = 12
+            let alpha: CGFloat = 0.75
+            let size = CGSize(width: width, height: height)
+            let commentImage = UIGraphicsImageRenderer(size: size).image { context in
+                CommentIconDrawingController.draw(context: context.cgContext, origin: .zero, size: size, color: annotation.color ?? .black, alpha: alpha)
+            }
+            let commentImageView = UIImageView()
+            commentImageView.image = commentImage
+            commentImageView.contentMode = .scaleAspectFit
+            annotationImageView.addSubview(commentImageView)
+            commentImageView.translatesAutoresizingMaskIntoConstraints = false
+            let widthMultiplier = width / annotation.boundingBox.width
+            let heightMultiplier = height / annotation.boundingBox.height
+            NSLayoutConstraint.activate([
+                commentImageView.widthAnchor.constraint(equalTo: annotationImageView.widthAnchor, multiplier: widthMultiplier),
+                commentImageView.heightAnchor.constraint(equalTo: annotationImageView.heightAnchor, multiplier: heightMultiplier),
+                commentImageView.centerXAnchor.constraint(equalTo: annotationImageView.leadingAnchor),
+                commentImageView.centerYAnchor.constraint(equalTo: annotationImageView.topAnchor)
+            ])
+            return commentImageView
+        }
+    }
+}


### PR DESCRIPTION
Draws the comment icon, if needed, for a selected square annotation, as PSPDFKit ignores the overridden drawing in the `SquareAnnotation` class. The drawing is not exact, if you zoom it's obvious. On the other hand, even the selection itself moves the annotation square a little bit 🤷‍♂️