### PR TITLE
Fix Apple Pencil double-tap bug and add more tool switching functionality

### DIFF
--- a/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
@@ -830,6 +830,8 @@ extension PDFDocumentViewController: AnnotationStateManagerDelegate {
 
 extension PDFDocumentViewController: UIPencilInteractionDelegate {
     func pencilInteractionDidTap(_ interaction: UIPencilInteraction) {
+        guard self.parentDelegate?.isToolbarVisible == true else { return }
+    
         switch UIPencilInteraction.preferredTapAction {
         case .switchEraser:
             if let tool = self.pdfController?.annotationStateManager.state, tool != .eraser {

--- a/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
@@ -844,11 +844,9 @@ extension PDFDocumentViewController: UIPencilInteractionDelegate {
                     let color = self.viewModel.state.toolColors[previous]
                     self.toggle(annotationTool: previous, color: color, tappedWithStylus: true)
                 }
-            } else {
             }
 
         case .switchPrevious:
-            if let tool = self.pdfController?.annotationStateManager.state {
             let previous: Annotation.Tool
             if let tool = pdfController?.annotationStateManager.state {
                 // Find the most recent different tool – if it's the "nil tool", default to `tool` to unset current tool
@@ -859,8 +857,6 @@ extension PDFDocumentViewController: UIPencilInteractionDelegate {
             }
             let color = viewModel.state.toolColors[previous]
             toggle(annotationTool: previous, color: color, tappedWithStylus: true)
-            } else {
-            }
 
         case .showColorPalette, .showInkAttributes:
             self.parentDelegate?.showToolOptions()

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -15,6 +15,7 @@ import RxSwift
 
 protocol PDFReaderContainerDelegate: AnyObject {
     var isSidebarVisible: Bool { get }
+    var isToolbarVisible: Bool { get }
     var documentTopOffset: CGFloat { get }
 
     func showSearch(pdfController: PDFViewController, text: String?)
@@ -56,6 +57,7 @@ class PDFReaderViewController: UIViewController {
     }
     private var previousTraitCollection: UITraitCollection?
     var isSidebarVisible: Bool { return sidebarControllerLeft?.constant == 0 }
+    var isToolbarVisible: Bool { return toolbarState.visible }
     var key: String { return viewModel.state.key }
 
     weak var coordinatorDelegate: (PdfReaderCoordinatorDelegate & PdfAnnotationsCoordinatorDelegate)?


### PR DESCRIPTION
1.) Fixes a bug where double tapping on the Apple Pencil could activate annotation mode without any UI change, mentioned here:

https://forums.zotero.org/discussion/105598/bug-ipad-douple-tapping-apple-pencil-activates-annotation-tools-outside-of-annotation-mode

https://forums.zotero.org/discussion/115677/ios-apple-pencil-double-tap-and-annotation-panel

2.) Adds more annotation tools and functionality to the Apple Pencil "Switch Between Current Tool and Last Used" double-tap mode. Currently, this mode ignores the eraser and also has no way to switch tools *off*. I've found that other PDF readers interpret this mode to include "no tool" as a switchable state (PDF Expert) so that users can double tap to activate and deactivate tools. Other PDF readers have a designated "hand" tool (Notability) that serves this purpose, but I don't think PSPDFKit supports this. The proposed functionality adds both the eraser and the unset tool states as switchable.

This second commit also makes some adjustments to distinguish between unset tool states happening in the course of normal work and those happening immediately after reopening a PDF or reactivating annotation mode. This is to ensure that a user's tool history is not overwritten in these situations since it is not a meaningful/deliberate use of the unset state.

This is unsolicited, so I understand if it isn't a priority to consider at this time. These changes just seemed too minor and too niche to ask someone else to work on. Thank you for all the work you do on this program 🙏 