### PR TITLE
Add in PDF reader previous/next viewport key commands

### DIFF
--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -275,6 +275,8 @@
 "pdf.sidebar.no_annotations" = "No Annotations";
 "pdf.sidebar.no_outline" = "No Outline";
 "pdf.delete_annotation" = "Do you really want to delete annotation?";
+"pdf.previous_viewport" = "Previous Viewport";
+"pdf.next_viewport" = "Next Viewport";
 
 "settings.title" = "Settings";
 "settings.logout" = "Sign Out";

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -933,6 +933,10 @@ internal enum L10n {
     internal static func lineWidthPoint(_ p1: Float) -> String {
       return L10n.tr("Localizable", "pdf.line_width_point", p1, fallback: "%0.1f pt")
     }
+    /// Next Viewport
+    internal static let nextViewport = L10n.tr("Localizable", "pdf.next_viewport", fallback: "Next Viewport")
+    /// Previous Viewport
+    internal static let previousViewport = L10n.tr("Localizable", "pdf.previous_viewport", fallback: "Previous Viewport")
     internal enum AnnotationPopover {
       /// Delete Annotation
       internal static let delete = L10n.tr("Localizable", "pdf.annotation_popover.delete", fallback: "Delete Annotation")

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -161,6 +161,19 @@ class PDFReaderViewController: UIViewController {
         var keyCommands: [UIKeyCommand] = [
             .init(title: L10n.Pdf.Search.title, action: #selector(search), input: "f", modifierFlags: [.command])
         ]
+        switch viewModel.state.settings.direction {
+        case .horizontal:
+            keyCommands += [
+                .init(title: L10n.Pdf.previousViewport, action: #selector(previousViewportAction), input: UIKeyCommand.inputLeftArrow, modifierFlags: [.alternate]),
+                .init(title: L10n.Pdf.nextViewport, action: #selector(nextViewportAction), input: UIKeyCommand.inputRightArrow, modifierFlags: [.alternate])
+            ]
+
+        case .vertical:
+            keyCommands += [
+                .init(title: L10n.Pdf.previousViewport, action: #selector(previousViewportAction), input: UIKeyCommand.inputUpArrow, modifierFlags: [.alternate]),
+                .init(title: L10n.Pdf.nextViewport, action: #selector(nextViewportAction), input: UIKeyCommand.inputDownArrow, modifierFlags: [.alternate])
+            ]
+        }
         if intraDocumentNavigationHandler?.showsBackButton == true {
             keyCommands += [
                 .init(title: L10n.back, action: #selector(performBackAction), input: "[", modifierFlags: [.command]),
@@ -176,7 +189,7 @@ class PDFReaderViewController: UIViewController {
             case #selector(UIResponderStandardEditActions.copy(_:)):
                 return selectedText != nil
 
-            case #selector(search), #selector(performBackAction):
+            case #selector(search), #selector(previousViewportAction), #selector(nextViewportAction), #selector(performBackAction):
                 return true
 
             case #selector(undo(_:)):
@@ -674,6 +687,26 @@ class PDFReaderViewController: UIViewController {
     @objc private func search() {
         guard let pdfController = documentController.pdfController else { return }
         showSearch(pdfController: pdfController, text: nil)
+    }
+
+    @objc private func previousViewportAction() {
+        guard let documentViewController = documentController.pdfController?.documentViewController else { return }
+        if documentViewController.scrollToPreviousViewport(animated: true) {
+            // Viewport scrolled, return.
+            return
+        }
+        // Viewport didn't scroll, this may happen if page is not zoomed. Scroll by spread instead.
+        documentViewController.scrollToPreviousSpread(animated: true)
+    }
+
+    @objc private func nextViewportAction() {
+        guard let documentViewController = documentController.pdfController?.documentViewController else { return }
+        if documentViewController.scrollToNextViewport(animated: true) {
+            // Viewport scrolled, return.
+            return
+        }
+        // Viewport didn't scroll, this may happen if page is not zoomed. Scroll by spread instead.
+        documentViewController.scrollToNextSpread(animated: true)
     }
 
     @objc private func performBackAction() {


### PR DESCRIPTION
By default, as mentioned in this forum [post](https://forums.zotero.org/discussion/114937/ios-keyboard-navigation), keyboard navigation ignores that a page is zoomed in, and moves directly to the previous/next page, in the same zoom level. Additional key commands, allow to alternatively move to the previous/next viewport.