### PR TITLE
Performance improvements in PDF Viewer

### DIFF
--- a/Zotero/Controllers/AnnotationConverter.swift
+++ b/Zotero/Controllers/AnnotationConverter.swift
@@ -208,12 +208,17 @@ struct AnnotationConverter {
         library: Library,
         displayName: String,
         username: String,
+        documentPageCount: UInt,
         boundingBoxConverter: AnnotationBoundingBoxConverter
     ) -> [PSPDFKit.Annotation] {
         return items.compactMap({ item in
-            guard let annotation = PDFDatabaseAnnotation(item: item) else { return nil }
-            return self.annotation(
-                from: annotation,
+            guard let dbAnnotation = PDFDatabaseAnnotation(item: item) else { return nil }
+            guard dbAnnotation.page < documentPageCount else {
+                DDLogWarn("AnnotationConverter: annotation \(item.key) for item \(item.parent?.key ?? ""); \(item.parent?.libraryId ?? .custom(.myLibrary)) has incorrect page index - \(dbAnnotation.page) / \(documentPageCount)")
+                return nil
+            }
+            return annotation(
+                from: dbAnnotation,
                 type: type,
                 interfaceStyle: interfaceStyle,
                 currentUserId: currentUserId,

--- a/Zotero/Controllers/AnnotationConverter.swift
+++ b/Zotero/Controllers/AnnotationConverter.swift
@@ -298,7 +298,7 @@ struct AnnotationConverter {
             square = SquareAnnotation()
         }
 
-        square.boundingBox = annotation.boundingBox(boundingBoxConverter: boundingBoxConverter).rounded(to: 3)
+        square.boundingBox = annotation.boundingBox(boundingBoxConverter: boundingBoxConverter)
         square.borderColor = color
         square.lineWidth = AnnotationsConfig.imageAnnotationLineWidth
 
@@ -323,8 +323,8 @@ struct AnnotationConverter {
             highlight = HighlightAnnotation()
         }
 
-        highlight.boundingBox = annotation.boundingBox(boundingBoxConverter: boundingBoxConverter).rounded(to: 3)
-        highlight.rects = annotation.rects(boundingBoxConverter: boundingBoxConverter).map({ $0.rounded(to: 3) })
+        highlight.rects = annotation.rects(boundingBoxConverter: boundingBoxConverter)
+        highlight.boundingBox = annotation.boundingBox(rects: highlight.rects!)
         highlight.color = color
         highlight.alpha = alpha
 
@@ -343,7 +343,7 @@ struct AnnotationConverter {
             note = NoteAnnotation(contents: annotation.comment)
         }
 
-        let boundingBox = annotation.boundingBox(boundingBoxConverter: boundingBoxConverter).rounded(to: 3)
+        let boundingBox = annotation.boundingBox(boundingBoxConverter: boundingBoxConverter)
         note.boundingBox = CGRect(origin: boundingBox.origin, size: AnnotationsConfig.noteAnnotationSize)
         note.borderStyle = .dashed
         note.color = color
@@ -377,8 +377,8 @@ struct AnnotationConverter {
             underline = UnderlineAnnotation()
         }
 
-        underline.boundingBox = annotation.boundingBox(boundingBoxConverter: boundingBoxConverter).rounded(to: 3)
-        underline.rects = annotation.rects(boundingBoxConverter: boundingBoxConverter).map({ $0.rounded(to: 3) })
+        underline.rects = annotation.rects(boundingBoxConverter: boundingBoxConverter)
+        underline.boundingBox = annotation.boundingBox(rects: underline.rects!)
         underline.color = color
         underline.alpha = alpha
 
@@ -389,7 +389,7 @@ struct AnnotationConverter {
         let text = PSPDFKit.FreeTextAnnotation(contents: annotation.comment)
         text.color = color
         text.fontSize = CGFloat(annotation.fontSize ?? 0)
-        text.setBoundingBox(annotation.boundingBox(boundingBoxConverter: boundingBoxConverter).rounded(to: 3), transformSize: true)
+        text.setBoundingBox(annotation.boundingBox(boundingBoxConverter: boundingBoxConverter), transformSize: true)
         text.setRotation(annotation.rotation ?? 0, updateBoundingBox: true)
         return text
     }

--- a/Zotero/Controllers/AnnotationPreviewBoundingBoxCalculator.swift
+++ b/Zotero/Controllers/AnnotationPreviewBoundingBoxCalculator.swift
@@ -16,27 +16,27 @@ struct AnnotationPreviewBoundingBoxCalculator {
         let widthDifference = boundingBox.width - AnnotationPreviewBoundingBoxCalculator.inkMinWidth
         let heightDifference = boundingBox.height - AnnotationPreviewBoundingBoxCalculator.inkMinHeight
 
-        guard widthDifference < 0 || heightDifference < 0 else { return boundingBox.rounded(to: 3) }
+        guard widthDifference < 0 || heightDifference < 0 else { return boundingBox }
 
         if boundingBox.width == boundingBox.height {
             // If it's square, increase size to match min width.
-            return boundingBox.insetBy(dx: widthDifference / 2, dy: widthDifference / 2).rounded(to: 3)
+            return boundingBox.insetBy(dx: widthDifference / 2, dy: widthDifference / 2)
         }
 
         // Otherwise increase individual sizes to match their minimums
         var newBoundingBox = boundingBox
         if widthDifference < 0 {
-            newBoundingBox = newBoundingBox.insetBy(dx: widthDifference / 2, dy: 0).rounded(to: 3)
+            newBoundingBox = newBoundingBox.insetBy(dx: widthDifference / 2, dy: 0)
         }
         if heightDifference < 0 {
             // Narrow heights are lines. Lines usually want to highlight something above them. Move the preview bounding box above line.
             newBoundingBox.size.height -= heightDifference
         }
-        return newBoundingBox.rounded(to: 3)
+        return newBoundingBox
     }
 
     static func imagePreviewRect(from boundingBox: CGRect, lineWidth: CGFloat) -> CGRect {
-        return boundingBox.insetBy(dx: (lineWidth + 1), dy: (lineWidth + 1)).rounded(to: 3)
+        return boundingBox.insetBy(dx: (lineWidth + 1), dy: (lineWidth + 1))
     }
 
     static func freeTextPreviewRect(from boundingBox: CGRect, rotation: UInt) -> CGRect {

--- a/Zotero/Scenes/Detail/PDF/Models/PDFDatabaseAnnotation.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/PDFDatabaseAnnotation.swift
@@ -18,10 +18,11 @@ struct PDFDatabaseAnnotation {
 
     init?(item: RItem) {
         guard let type = AnnotationType(rawValue: item.annotationType) else {
-            DDLogWarn("DatabaseAnnotation: \(item.key) unknown annotation type \(item.annotationType)")
+            DDLogWarn("PDFDatabaseAnnotation: \(item.key) unknown annotation type \(item.annotationType)")
             return nil
         }
         guard AnnotationsConfig.supported.contains(type.kind) else {
+            DDLogWarn("PDFDatabaseAnnotation: \(item.key) unsupported annotation type \(type)")
             return nil
         }
         self.item = item
@@ -34,11 +35,11 @@ struct PDFDatabaseAnnotation {
 
     var _page: Int? {
         guard let rawValue = item.fieldValue(for: FieldKeys.Item.Annotation.Position.pageIndex) else {
-            DDLogError("DatabaseAnnotation: \(key) missing page!")
+            DDLogError("PDFDatabaseAnnotation: \(key) missing page!")
             return nil
         }
         guard let page = Int(rawValue) else {
-            DDLogError("DatabaseAnnotation: \(key) page incorrect format \(rawValue)")
+            DDLogError("PDFDatabaseAnnotation: \(key) page incorrect format \(rawValue)")
             // Page is not an int, try double or fail
             return Double(rawValue).flatMap(Int.init)
         }
@@ -47,7 +48,7 @@ struct PDFDatabaseAnnotation {
 
     var _pageLabel: String? {
         guard let label = item.fieldValue(for: FieldKeys.Item.Annotation.pageLabel) else {
-            DDLogError("DatabaseAnnotation: \(key) missing page label!")
+            DDLogError("PDFDatabaseAnnotation: \(key) missing page label!")
             return nil
         }
         return label
@@ -89,7 +90,7 @@ struct PDFDatabaseAnnotation {
 
     var _color: String? {
         guard let color = item.fieldValue(for: FieldKeys.Item.Annotation.color) else {
-            DDLogError("DatabaseAnnotation: \(key) missing color!")
+            DDLogError("PDFDatabaseAnnotation: \(key) missing color!")
             return nil
         }
         return color
@@ -187,7 +188,7 @@ extension RItem {
     fileprivate func fieldValue(for key: String) -> String? {
         let value = fields.filter(.key(key)).first?.value
         if value == nil {
-            DDLogError("DatabaseAnnotation: missing value for `\(key)`")
+            DDLogError("PDFDatabaseAnnotation: missing value for `\(key)`")
         }
         return value
     }

--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
@@ -2049,20 +2049,20 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
 
     private func update(document: PSPDFKit.Document, zoteroAnnotations: [PSPDFKit.Annotation], key: String, libraryId: LibraryIdentifier, isDark: Bool) {
         // Disable all non-zotero annotations, store previews if needed
-        let pdfAnnotations = document.allAnnotations(of: PSPDFKit.Annotation.Kind.all).values.flatMap({ $0 })
-        pdfAnnotations.forEach({ $0.flags.update(with: .locked) })
-        annotationPreviewController.store(annotations: pdfAnnotations, parentKey: key, libraryId: libraryId, isDark: isDark)
-        // Filter compatible zotero annotations
-        var filteredZoteroAnnotations: [PSPDFKit.Annotation] = []
-        for annotation in zoteroAnnotations {
-            guard annotation.pageIndex < document.pageCount else {
-                DDLogError("PDFReaderActionHandler: annotation \(annotation.key ?? "-") for item \(key); \(libraryId) has incorrect page index - \(annotation.pageIndex) / \(document.pageCount)")
-                continue
-            }
-            filteredZoteroAnnotations.append(annotation)
-        }
+//        let pdfAnnotations = document.allAnnotations(of: PSPDFKit.Annotation.Kind.all).values.flatMap({ $0 })
+//        pdfAnnotations.forEach({ $0.flags.update(with: .locked) })
+//        annotationPreviewController.store(annotations: pdfAnnotations, parentKey: key, libraryId: libraryId, isDark: isDark)
+//        // Filter compatible zotero annotations
+//        var filteredZoteroAnnotations: [PSPDFKit.Annotation] = []
+//        for annotation in zoteroAnnotations {
+//            guard annotation.pageIndex < document.pageCount else {
+//                DDLogError("PDFReaderActionHandler: annotation \(annotation.key ?? "-") for item \(key); \(libraryId) has incorrect page index - \(annotation.pageIndex) / \(document.pageCount)")
+//                continue
+//            }
+//            filteredZoteroAnnotations.append(annotation)
+//        }
         // Add zotero annotations to document
-        document.add(annotations: filteredZoteroAnnotations, options: [.suppressNotifications: true])
+        document.add(annotations: zoteroAnnotations, options: [.suppressNotifications: true])
     }
 
     // MARK: - Translate sync (db) changes to PDF document


### PR DESCRIPTION
I cleaned up loading of annotations for pdf viewer so that we don't go through all annotations multiple times, which leads to some small-ish performance improvements. If we want to improve loading further we'd probably have to load annotations in batches instead of all at once.