### PR TITLE
Improve PDF reader arrow key commands

### DIFF
--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -275,6 +275,8 @@
 "pdf.sidebar.no_annotations" = "No Annotations";
 "pdf.sidebar.no_outline" = "No Outline";
 "pdf.delete_annotation" = "Do you really want to delete annotation?";
+"pdf.previous_page" = "Previous Page";
+"pdf.next_page" = "Next Page";
 "pdf.previous_viewport" = "Previous Viewport";
 "pdf.next_viewport" = "Next Viewport";
 

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -933,8 +933,12 @@ internal enum L10n {
     internal static func lineWidthPoint(_ p1: Float) -> String {
       return L10n.tr("Localizable", "pdf.line_width_point", p1, fallback: "%0.1f pt")
     }
+    /// Next Page
+    internal static let nextPage = L10n.tr("Localizable", "pdf.next_page", fallback: "Next Page")
     /// Next Viewport
     internal static let nextViewport = L10n.tr("Localizable", "pdf.next_viewport", fallback: "Next Viewport")
+    /// Previous Page
+    internal static let previousPage = L10n.tr("Localizable", "pdf.previous_page", fallback: "Previous Page")
     /// Previous Viewport
     internal static let previousViewport = L10n.tr("Localizable", "pdf.previous_viewport", fallback: "Previous Viewport")
     internal enum AnnotationPopover {

--- a/Zotero/Extensions/PSPDFKitUI+Extensions.swift
+++ b/Zotero/Extensions/PSPDFKitUI+Extensions.swift
@@ -10,10 +10,89 @@ import PSPDFKitUI
 
 extension PSPDFKitUI.PDFViewController {
     open override var keyCommands: [UIKeyCommand]? {
-        []
+        var keyCommands: [UIKeyCommand] = []
+
+        let previousInput: String
+        let nextInput: String
+        switch configuration.scrollDirection {
+        case .horizontal:
+            previousInput = UIKeyCommand.inputLeftArrow
+            nextInput = UIKeyCommand.inputRightArrow
+
+        case .vertical:
+            previousInput = UIKeyCommand.inputUpArrow
+            nextInput = UIKeyCommand.inputDownArrow
+        }
+        let pageCommands: [UIKeyCommand] = [
+            .init(title: L10n.Pdf.previousPage, action: #selector(previousPageAction), input: previousInput),
+            .init(title: L10n.Pdf.nextPage, action: #selector(nextPageAction), input: nextInput)
+        ]
+        pageCommands.forEach { $0.wantsPriorityOverSystemBehavior = true }
+        let viewportCommands: [UIKeyCommand] = [
+            .init(title: L10n.Pdf.previousViewport, action: #selector(previousViewportAction), input: previousInput, modifierFlags: [.alternate]),
+            .init(title: L10n.Pdf.nextViewport, action: #selector(nextViewportAction), input: nextInput, modifierFlags: [.alternate])
+        ]
+        keyCommands += pageCommands + viewportCommands
+
+        return keyCommands
     }
 
     open override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        false
+        switch action {
+        case #selector(previousPageAction), #selector(nextPageAction), #selector(previousViewportAction), #selector(nextViewportAction):
+            return true
+
+        default:
+            return false
+        }
+    }
+
+    @objc private func previousPageAction() {
+        documentViewController?.scrollToPreviousPageMiddle(animated: true)
+    }
+
+    @objc private func nextPageAction() {
+        documentViewController?.scrollToNextPageMiddle(animated: true)
+    }
+
+    @objc private func previousViewportAction() {
+        documentViewController?.scrollToPreviousViewport(animated: true, fallbackToSpread: true)
+    }
+
+    @objc private func nextViewportAction() {
+        documentViewController?.scrollToNextViewport(animated: true, fallbackToSpread: true)
+    }
+}
+
+extension PSPDFKitUI.PDFDocumentViewController {
+    func scrollToPreviousPageMiddle(animated: Bool) {
+        let previousContinuousSpreadIndex = floor(continuousSpreadIndex - 1) + 0.5
+        guard previousContinuousSpreadIndex >= 0 else { return }
+        setContinuousSpreadIndex(previousContinuousSpreadIndex, animated: animated)
+    }
+
+    func scrollToNextPageMiddle(animated: Bool) {
+        let nextContinuousSpreadIndex = floor(continuousSpreadIndex + 1) + 0.5
+        setContinuousSpreadIndex(nextContinuousSpreadIndex, animated: animated)
+    }
+
+    @discardableResult
+    func scrollToPreviousViewport(animated: Bool, fallbackToSpread: Bool = true) -> Bool {
+        let scrolled = scrollToPreviousViewport(animated: animated)
+        guard !scrolled && fallbackToSpread else {
+            return scrolled
+        }
+        // Viewport didn't scroll, this may happen if the page is not zoomed. Scroll by spread instead.
+        return scrollToPreviousSpread(animated: animated)
+    }
+
+    @discardableResult
+    func scrollToNextViewport(animated: Bool, fallbackToSpread: Bool = true) -> Bool {
+        let scrolled = scrollToNextViewport(animated: animated)
+        guard !scrolled && fallbackToSpread else {
+            return scrolled
+        }
+        // Viewport didn't scroll, this may happen if page is not zoomed. Scroll by spread instead.
+        return scrollToNextSpread(animated: animated)
     }
 }

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -163,19 +163,6 @@ class PDFReaderViewController: UIViewController {
         var keyCommands: [UIKeyCommand] = [
             .init(title: L10n.Pdf.Search.title, action: #selector(search), input: "f", modifierFlags: [.command])
         ]
-        switch viewModel.state.settings.direction {
-        case .horizontal:
-            keyCommands += [
-                .init(title: L10n.Pdf.previousViewport, action: #selector(previousViewportAction), input: UIKeyCommand.inputLeftArrow, modifierFlags: [.alternate]),
-                .init(title: L10n.Pdf.nextViewport, action: #selector(nextViewportAction), input: UIKeyCommand.inputRightArrow, modifierFlags: [.alternate])
-            ]
-
-        case .vertical:
-            keyCommands += [
-                .init(title: L10n.Pdf.previousViewport, action: #selector(previousViewportAction), input: UIKeyCommand.inputUpArrow, modifierFlags: [.alternate]),
-                .init(title: L10n.Pdf.nextViewport, action: #selector(nextViewportAction), input: UIKeyCommand.inputDownArrow, modifierFlags: [.alternate])
-            ]
-        }
         if intraDocumentNavigationHandler?.showsBackButton == true {
             keyCommands += [
                 .init(title: L10n.back, action: #selector(performBackAction), input: "[", modifierFlags: [.command]),
@@ -191,7 +178,7 @@ class PDFReaderViewController: UIViewController {
             case #selector(UIResponderStandardEditActions.copy(_:)):
                 return selectedText != nil
 
-            case #selector(search), #selector(previousViewportAction), #selector(nextViewportAction), #selector(performBackAction):
+            case #selector(search), #selector(performBackAction):
                 return true
 
             case #selector(undo(_:)):
@@ -433,10 +420,6 @@ class PDFReaderViewController: UIViewController {
 
     override var prefersStatusBarHidden: Bool {
         return !statusBarVisible
-    }
-
-    override var canBecomeFirstResponder: Bool {
-        true
     }
 
     // MARK: - Actions
@@ -689,26 +672,6 @@ class PDFReaderViewController: UIViewController {
     @objc private func search() {
         guard let pdfController = documentController.pdfController else { return }
         showSearch(pdfController: pdfController, text: nil)
-    }
-
-    @objc private func previousViewportAction() {
-        guard let documentViewController = documentController.pdfController?.documentViewController else { return }
-        if documentViewController.scrollToPreviousViewport(animated: true) {
-            // Viewport scrolled, return.
-            return
-        }
-        // Viewport didn't scroll, this may happen if page is not zoomed. Scroll by spread instead.
-        documentViewController.scrollToPreviousSpread(animated: true)
-    }
-
-    @objc private func nextViewportAction() {
-        guard let documentViewController = documentController.pdfController?.documentViewController else { return }
-        if documentViewController.scrollToNextViewport(animated: true) {
-            // Viewport scrolled, return.
-            return
-        }
-        // Viewport didn't scroll, this may happen if page is not zoomed. Scroll by spread instead.
-        documentViewController.scrollToNextSpread(animated: true)
     }
 
     @objc private func performBackAction() {


### PR DESCRIPTION
* Moves arrow key command logic to PSPDFKitUI extensions
* Properly shows all arrow key commands in shortcuts HUD.
* Improves simple arrow key commands (i.e. w/o modifiers) to move to previous/next page middle.