### PR TITLE
Cache file MD5 and modification date by URL for app session

### DIFF
--- a/Zotero/Controllers/AttachmentCreator.swift
+++ b/Zotero/Controllers/AttachmentCreator.swift
@@ -273,7 +273,7 @@ struct AttachmentCreator {
         let webDavEnabled = Defaults.shared.webDavEnabled
 
         if fileStorage.has(file) || (webDavEnabled && fileStorage.has(file.copyWithExt("zip"))) {
-            if !item.backendMd5.isEmpty, let md5 = md5(from: file.createUrl()), item.backendMd5 != md5 {
+            if !item.backendMd5.isEmpty, let md5 = cachedMD5(from: file.createUrl(), using: fileStorage.fileManager), item.backendMd5 != md5 {
                 return .localAndChangedRemotely
             } else {
                 return .local

--- a/Zotero/Extensions/MD5+Url.swift
+++ b/Zotero/Extensions/MD5+Url.swift
@@ -53,7 +53,7 @@ func cachedMD5(from url: URL, using fileManager: FileManager) -> String? {
     } else {
         newModificationDate = .distantPast
     }
-    if let (cachedMd5, cachedModificationDate) = cachedMD5AndModificationDateByURL[url], newModificationDate <= cachedModificationDate {
+    if let (cachedMd5, cachedModificationDate) = cachedMD5AndModificationDateByURL[url], newModificationDate == cachedModificationDate {
         return cachedMd5
     }
     let md5 = md5(from: url)

--- a/Zotero/Extensions/MD5+Url.swift
+++ b/Zotero/Extensions/MD5+Url.swift
@@ -45,20 +45,24 @@ func md5(from url: URL) -> String? {
     }
 }
 
-var cachedMD5AndModificationDateByURL: [URL: (String, Date)] = [:]
+var cachedMD5AndModificationDateByURL: [URL: (String, Date, NSNumber)] = [:]
 func cachedMD5(from url: URL, using fileManager: FileManager) -> String? {
-    let newModificationDate: Date
-    if let attributes = try? fileManager.attributesOfItem(atPath: url.path), let modificationDate = attributes[.modificationDate] as? Date {
-        newModificationDate = modificationDate
-    } else {
-        newModificationDate = .distantPast
+    var newModificationDate: Date = .distantPast
+    var newSize: NSNumber = .init(value: 0)
+    if let attributes = try? fileManager.attributesOfItem(atPath: url.path) {
+        if let modificationDate = attributes[.modificationDate] as? Date {
+            newModificationDate = modificationDate
+        }
+        if let size = attributes[.size] as? NSNumber {
+            newSize = size
+        }
     }
-    if let (cachedMd5, cachedModificationDate) = cachedMD5AndModificationDateByURL[url], newModificationDate == cachedModificationDate {
+    if let (cachedMd5, cachedModificationDate, cachedSize) = cachedMD5AndModificationDateByURL[url], newModificationDate == cachedModificationDate, newSize == cachedSize {
         return cachedMd5
     }
     let md5 = md5(from: url)
     if let md5 {
-        cachedMD5AndModificationDateByURL[url] = (md5, newModificationDate)
+        cachedMD5AndModificationDateByURL[url] = (md5, newModificationDate, newSize)
     } else {
         cachedMD5AndModificationDateByURL[url] = nil
     }

--- a/Zotero/Extensions/MD5+Url.swift
+++ b/Zotero/Extensions/MD5+Url.swift
@@ -44,3 +44,23 @@ func md5(from url: URL) -> String? {
         return nil
     }
 }
+
+var cachedMD5AndModificationDateByURL: [URL: (String, Date)] = [:]
+func cachedMD5(from url: URL, using fileManager: FileManager) -> String? {
+    let newModificationDate: Date
+    if let attributes = try? fileManager.attributesOfItem(atPath: url.path), let modificationDate = attributes[.modificationDate] as? Date {
+        newModificationDate = modificationDate
+    } else {
+        newModificationDate = .distantPast
+    }
+    if let (cachedMd5, cachedModificationDate) = cachedMD5AndModificationDateByURL[url], newModificationDate <= cachedModificationDate {
+        return cachedMd5
+    }
+    let md5 = md5(from: url)
+    if let md5 {
+        cachedMD5AndModificationDateByURL[url] = (md5, newModificationDate)
+    } else {
+        cachedMD5AndModificationDateByURL[url] = nil
+    }
+    return md5
+}

--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
@@ -1823,7 +1823,10 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
 
         @discardableResult
         func checkWhetherMd5Changed(forItem item: RItem, andUpdateViewModel viewModel: ViewModel<PDFReaderActionHandler>, handler: PDFReaderActionHandler) -> Bool {
-            guard let documentURL = viewModel.state.document.fileURL, let md5 = md5(from: documentURL), !item.backendMd5.isEmpty, item.backendMd5 != md5 else { return false }
+            guard let documentURL = viewModel.state.document.fileURL,
+                    let md5 = cachedMD5(from: documentURL, using: fileStorage.fileManager),
+                    !item.backendMd5.isEmpty, item.backendMd5 != md5
+            else { return false }
             handler.update(viewModel: viewModel) { state in
                 state.changes = .md5
             }


### PR DESCRIPTION
There is a number of reported Hangs for version 1.0.39, when MD5 hashes are computed. These are re-computed every time a document appears as downloaded in a collection, or it is opened. Adding a simple session memory cache, can speed subsequent uses if the file has not been modified.