### PR TITLE
Add collection remove downloads action

### DIFF
--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -533,6 +533,7 @@
 "accessibility.items.restore" = "Restore selected items";
 "accessibility.items.duplicate" = "Duplicate selected item";
 "accessibility.items.share" = "Share selected items";
+"accessibility.items.remove_downloads" = "Remove downloads for selected items";
 "accessibility.item_detail.download_and_open" = "Double tap to download and open";
 "accessibility.item_detail.open" = "Double tap to open";
 "accessibility.pdf.sidebar_open" = "Open sidebar";

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -533,6 +533,7 @@
 "accessibility.items.restore" = "Restore selected items";
 "accessibility.items.duplicate" = "Duplicate selected item";
 "accessibility.items.share" = "Share selected items";
+"accessibility.items.download_attachments" = "Download attachments for selected items";
 "accessibility.items.remove_downloads" = "Remove downloads for selected items";
 "accessibility.item_detail.download_and_open" = "Double tap to download and open";
 "accessibility.item_detail.open" = "Double tap to open";

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -98,6 +98,7 @@
 "collections.expand_all" = "Expand All";
 "collections.create_bibliography" = "Create Bibliography from Collection";
 "collections.download_attachments" = "Download Attachments";
+"collections.delete_attachment_files" = "Remove Downloads";
 
 "sync_toolbar.starting" = "Sync starting";
 "sync_toolbar.groups" = "Syncing groups";

--- a/Zotero/Controllers/AttachmentFileCleanupController.swift
+++ b/Zotero/Controllers/AttachmentFileCleanupController.swift
@@ -21,10 +21,17 @@ final class AttachmentFileCleanupController {
 
         var notification: AttachmentFileDeletedNotification {
             switch self {
-            case .all: return .all
-            case .library(let id): return .library(id)
-            case .allForItems(let keys, let libraryId): return .allForItems(keys: keys, libraryId: libraryId)
-            case .individual(let attachment, let parentKey): return .individual(key: attachment.key, parentKey: parentKey, libraryId: attachment.libraryId)
+            case .all:
+                return .all
+
+            case .library(let id):
+                return .library(id)
+
+            case .allForItems(let keys, let libraryId):
+                return .allForItems(keys: keys, libraryId: libraryId)
+
+            case .individual(let attachment, let parentKey):
+                return .individual(key: attachment.key, parentKey: parentKey, libraryId: attachment.libraryId)
             }
         }
     }
@@ -36,39 +43,30 @@ final class AttachmentFileCleanupController {
     private let disposeBag: DisposeBag
 
     init(fileStorage: FileStorage, dbStorage: DbStorage) {
-        let queue = DispatchQueue(label: "org.zotero.FileCleanupQueue", qos: .userInitiated)
         self.fileStorage = fileStorage
         self.dbStorage = dbStorage
-        self.scheduler = SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: "org.zotero.FileCleanupScheduler")
-        self.queue = queue
-        self.disposeBag = DisposeBag()
+        queue = DispatchQueue(label: "org.zotero.FileCleanupQueue", qos: .userInitiated)
+        scheduler = SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: "org.zotero.FileCleanupScheduler")
+        disposeBag = DisposeBag()
 
         NotificationCenter.default.rx
             .notification(.attachmentDeleted)
-            .observe(on: self.scheduler)
-            .subscribe(onNext: { [weak self] notification in
-                if let file = notification.object as? File {
-                    self?.delete(file: file)
-                }
+            .observe(on: scheduler)
+            .subscribe(onNext: { [weak fileStorage] notification in
+                guard let fileStorage, let file = notification.object as? File else { return }
+                // Don't need to check for errors, the attachment doesn't have to have the file downloaded locally, so this will throw for all attachments
+                // without local files. If the file was not removed properly it can always be seen and done in settings.
+                try? fileStorage.remove(file)
             })
-            .disposed(by: self.disposeBag)
-    }
-
-    private func delete(file: File) {
-        // Don't need to check for errors, the attachment doesn't have to have the file downloaded locally, so this will throw for all attachments
-        // without local files. If the file was not removed properly it can always be seen and done in settings.
-        try? self.fileStorage.remove(file)
+            .disposed(by: disposeBag)
     }
 
     /// Delete attachments based on deletion type.
     /// - parameter type: Indicates which attachments should be deleted.
     /// - completed: Called on main queue when attachments are deleted. `true` if attachments were deleted, `false` in case of error.
-    func delete(_ type: DeletionType, completed: ((Bool) -> Void)?) {
-        self.queue.async {
-            let newTypes = self.delete(type)
-
-            guard !newTypes.isEmpty || completed != nil else { return }
-
+    func delete(_ type: DeletionType, completed: ((Bool) -> Void)? = nil) {
+        queue.async { [weak self] in
+            let newTypes = self?.delete(type) ?? []
             DispatchQueue.main.async {
                 for type in newTypes {
                     NotificationCenter.default.post(name: .attachmentFileDeleted, object: type.notification)
@@ -84,246 +82,239 @@ final class AttachmentFileCleanupController {
     private func delete(_ type: DeletionType) -> [DeletionType] {
         switch type {
         case .all:
-            return self.deleteAll()
+            return deleteAll()
 
         case .allForItems(let keys, let libraryId):
-            return self.deleteAttachments(for: keys, libraryId: libraryId).flatMap({ [$0] }) ?? []
+            return deleteAttachments(for: keys, libraryId: libraryId).flatMap({ [$0] }) ?? []
 
         case .library(let libraryId):
-            return self.delete(in: libraryId).flatMap({ [$0] }) ?? []
+            return delete(in: libraryId).flatMap({ [$0] }) ?? []
 
         case .individual(let attachment, _):
-            if self.delete(attachment: attachment) {
-                return [type]
-            }
-            return []
+            return delete(attachment: attachment) ? [type] : []
         }
-    }
 
-    /// Tries deleting all attachments.
-    /// - returns: Either `.all` deletion type if all attachments can be deleted. If only some can be deleted, it returns `.allForItems` for individual libraries. In case of error empty array is returned.
-    private func deleteAll() -> [DeletionType] {
-        do {
-            var libraryIds: [LibraryIdentifier] = []
-            var forUpload: [LibraryIdentifier: [String]] = [:]
+        /// Tries deleting all attachments.
+        /// - returns: Either `.all` deletion type if all attachments can be deleted. If only some can be deleted, it returns `.allForItems` for individual libraries. 
+        /// In case of error empty array is returned.
+        func deleteAll() -> [DeletionType] {
+            do {
+                var libraryIds: [LibraryIdentifier] = []
+                var forUpload: [LibraryIdentifier: [String]] = [:]
 
-            try self.dbStorage.perform(on: self.queue, with: { coordinator in
-                let groups = try coordinator.perform(request: ReadAllGroupsDbRequest())
-                libraryIds = [.custom(.myLibrary)] + groups.map({ .group($0.identifier) })
+                try dbStorage.perform(on: queue, with: { coordinator in
+                    let groups = try coordinator.perform(request: ReadAllGroupsDbRequest())
+                    libraryIds = [.custom(.myLibrary)] + groups.map({ .group($0.identifier) })
 
-                for item in try coordinator.perform(request: ReadAllItemsForUploadDbRequest()) {
-                    guard let libraryId = item.libraryId else { continue }
+                    for item in try coordinator.perform(request: ReadAllItemsForUploadDbRequest()) {
+                        guard let libraryId = item.libraryId else { continue }
 
-                    if var keys = forUpload[libraryId] {
+                        var keys = forUpload[libraryId, default: []]
                         keys.append(item.key)
                         forUpload[libraryId] = keys
-                    } else {
-                        forUpload[libraryId] = [item.key]
                     }
+
+                    // TODO: - exclude those for upload
+                    try? coordinator.perform(request: MarkAllFilesAsNotDownloadedDbRequest())
+
+                    coordinator.invalidate()
+                })
+
+                let deletedIndividually = delete(downloadsIn: libraryIds, forUpload: forUpload)
+                // Annotations are not guaranteed to exist and they can be removed even if the parent PDF was not deleted due to upload state.
+                // These are generated on device, so they'll just be recreated.
+                try? fileStorage.remove(Files.annotationPreviews)
+                // Remove page thumbnails
+                try? fileStorage.remove(Files.pageThumbnails)
+                // When removing all local files clear cache as well.
+                try? fileStorage.remove(Files.cache)
+
+                if deletedIndividually.isEmpty {
+                    return [.all]
                 }
 
-                // TODO: - exclude those for upload
-                try? coordinator.perform(request: MarkAllFilesAsNotDownloadedDbRequest())
-
-                coordinator.invalidate()
-            })
-
-            let deletedIndividually = self.delete(downloadsIn: libraryIds, forUpload: forUpload)
-            // Annotations are not guaranteed to exist and they can be removed even if the parent PDF was not deleted due to upload state.
-            // These are generated on device, so they'll just be recreated.
-            try? self.fileStorage.remove(Files.annotationPreviews)
-            // Remove page thumbnails
-            try? self.fileStorage.remove(Files.pageThumbnails)
-            // When removing all local files clear cache as well.
-            try? self.fileStorage.remove(Files.cache)
-
-            if deletedIndividually.isEmpty {
-                return [.all]
-            }
-
-            return deletedIndividually.map { libraryId, keys in
-                return .allForItems(keys, libraryId)
-            }
-        } catch let error {
-            DDLogError("AttachmentFileCleanupController: can't remove download directory - \(error)")
-            return []
-        }
-    }
-
-    /// Tries deleting all attachments in given library.
-    /// - returns: Either `.library` deletion type if all attachments can be deleted. If only some can be deleted, it returns `.allForItems` for given library. In case of error `nil` is returned.
-    private func delete(in libraryId: LibraryIdentifier) -> DeletionType? {
-        do {
-            var forUpload: [String] = []
-
-            try self.dbStorage.perform(on: self.queue, with: { coordinator in
-                let items = try coordinator.perform(request: ReadItemsForUploadDbRequest(libraryId: libraryId))
-                forUpload = Array(items.map({ $0.key }))
-
-                // TODO: - exclude those for upload
-                try? coordinator.perform(request: MarkLibraryFilesAsNotDownloadedDbRequest(libraryId: libraryId))
-
-                coordinator.invalidate()
-            })
-
-            let deletedIndividually = self.delete(downloadsIn: [libraryId], forUpload: [libraryId: forUpload])
-
-            // Annotations are not guaranteed to exist and they can be removed even if the parent PDF was not deleted due to upload state.
-            // These are generated on device, so they'll just be recreated.
-            try? self.fileStorage.remove(Files.annotationPreviews(for: libraryId))
-            // Cleanup page thumbnails
-            try? self.fileStorage.remove(Files.pageThumbnails(for: libraryId))
-
-            if let keys = deletedIndividually[libraryId], !keys.isEmpty {
-                return .allForItems(keys, libraryId)
-            }
-            return .library(libraryId)
-        } catch let error {
-            DDLogError("AttachmentFileCleanupController: can't remove library downloads - \(error)")
-            return nil
-        }
-    }
-
-    /// Deletes downloads in given libraries, but keeps files queued for upload intact.
-    /// - parameter libraries: Libraries to delete from.
-    /// - parameter forUpload: Keys of items which need upload for given libraries.
-    /// - returns: Returns individual keys for given libraries which were actually deleted. Some deletions are ignored if files are queued for upload.
-    private func delete(downloadsIn libraries: [LibraryIdentifier], forUpload: [LibraryIdentifier: [String]]) -> [LibraryIdentifier: Set<String>] {
-        var deletedIndividually: [LibraryIdentifier: Set<String>] = [:]
-
-        for libraryId in libraries {
-            guard let keysForUpload = forUpload[libraryId], !keysForUpload.isEmpty else {
-                // No items are queued for upload, just delete the whole directory. Ignore thrown error because some may not exist locally (user didn't download anything in given library yet).
-                try? self.fileStorage.remove(Files.downloads(for: libraryId))
-                continue
-            }
-
-            // If there are pending uploads, delete only directories with uploaded files. If no folders are stored locally just skip.
-            guard let contents: [File] = try? self.fileStorage.contentsOfDirectory(at: Files.downloads(for: libraryId)) else { continue }
-
-            let toDelete = contents.filter({ file in
-                // Check whether it's item folder and whether upload is pending for given item.
-                if file.relativeComponents.count == 3, let key = file.relativeComponents.last, key.count == KeyGenerator.length {
-                    return !keysForUpload.contains(key)
+                return deletedIndividually.map { libraryId, keys in
+                    return .allForItems(keys, libraryId)
                 }
-                // If it's something else, just delete it
-                return true
-            })
+            } catch let error {
+                DDLogError("AttachmentFileCleanupController: can't remove download directory - \(error)")
+                return []
+            }
+        }
 
-            var keys: Set<String> = []
-            for file in toDelete {
-                if file.relativeComponents.count == 3, let key = file.relativeComponents.last, key.count == KeyGenerator.length {
+        /// Tries deleting individual files from given library.
+        /// - parameter keys: Individual keys of files to delete.
+        /// - parameter libraryId: Library identifier from which files are deleted.
+        /// - returns: `nil` if no files could be deleted. `.allForItems` for actually deleted files.
+        func deleteAttachments(for keys: Set<String>, libraryId: LibraryIdentifier) -> DeletionType? {
+            guard !keys.isEmpty else { return nil }
+
+            do {
+                var toDelete: Set<String> = []
+                var toReport: Set<String> = []
+
+                try dbStorage.perform(on: queue, with: { coordinator in
+                    let items = try coordinator.perform(request: ReadItemsWithKeysDbRequest(keys: keys, libraryId: libraryId))
+
+                    for item in items {
+                        // Either the selected item was attachment
+                        if item.rawType == ItemTypes.attachment {
+                            // Don't delete attachments that need to sync
+                            guard !item.attachmentNeedsSync else { continue }
+                            toDelete.insert(item.key)
+                            toReport.insert(item.key)
+                            continue
+                        }
+
+                        // Or the item was a parent item and it may have multiple attachments
+                        for child in item.children.filter(.item(type: ItemTypes.attachment)) {
+                            // Don't delete attachments that need to sync
+                            guard !child.attachmentNeedsSync else { continue }
+                            // Always report parent key so that the originally requested key gets a report about deletion, even if a child was deleted.
+                            toReport.insert(item.key)
+                            toDelete.insert(child.key)
+                        }
+                    }
+
+                    try? coordinator.perform(request: MarkItemsFilesAsNotDownloadedDbRequest(keys: toDelete, libraryId: libraryId))
+
+                    coordinator.invalidate()
+                })
+
+                for key in toDelete {
+                    // Some files might not exist, just continue deleting
+                    try? removeFiles(for: key, libraryId: libraryId)
+                }
+
+                return toReport.isEmpty ? nil : .allForItems(toReport, libraryId)
+            } catch let error {
+                DDLogError("AttachmentFileCleanupController: can't remove attachments for item - \(error)")
+                return nil
+            }
+        }
+
+        /// Tries deleting all attachments in given library.
+        /// - returns: Either `.library` deletion type if all attachments can be deleted. If only some can be deleted, it returns `.allForItems` for given library. In case of error `nil` is returned.
+        func delete(in libraryId: LibraryIdentifier) -> DeletionType? {
+            do {
+                var forUpload: [String] = []
+
+                try dbStorage.perform(on: self.queue, with: { coordinator in
+                    let items = try coordinator.perform(request: ReadItemsForUploadDbRequest(libraryId: libraryId))
+                    forUpload = Array(items.map({ $0.key }))
+
+                    // TODO: - exclude those for upload
+                    try? coordinator.perform(request: MarkLibraryFilesAsNotDownloadedDbRequest(libraryId: libraryId))
+
+                    coordinator.invalidate()
+                })
+
+                let deletedIndividually = delete(downloadsIn: [libraryId], forUpload: [libraryId: forUpload])
+
+                // Annotations are not guaranteed to exist and they can be removed even if the parent PDF was not deleted due to upload state.
+                // These are generated on device, so they'll just be recreated.
+                try? fileStorage.remove(Files.annotationPreviews(for: libraryId))
+                // Cleanup page thumbnails
+                try? fileStorage.remove(Files.pageThumbnails(for: libraryId))
+
+                if let keys = deletedIndividually[libraryId], !keys.isEmpty {
+                    return .allForItems(keys, libraryId)
+                }
+                return .library(libraryId)
+            } catch let error {
+                DDLogError("AttachmentFileCleanupController: can't remove library downloads - \(error)")
+                return nil
+            }
+        }
+
+        /// Tries deleting given attachment.
+        /// - parameter attachment: Attachment to delete.
+        /// - returns: `true` if file could be deleted, `false` otherwise.
+        func delete(attachment: Attachment) -> Bool {
+            do {
+                // Don't delete linked files
+                guard case .file(_, _, _, let linkType, _) = attachment.type, linkType != .linkedFile else { return false }
+
+                var canDelete: Bool = false
+
+                try dbStorage.perform(on: queue, with: { coordinator in
+                    let item = try coordinator.perform(request: ReadItemDbRequest(libraryId: attachment.libraryId, key: attachment.key))
+                    let attachmentNeedsSync = item.attachmentNeedsSync
+
+                    // Don't delete attachments that need to sync
+                    guard !attachmentNeedsSync else {
+                        canDelete = false
+                        return
+                    }
+
+                    try? coordinator.perform(request: MarkFileAsDownloadedDbRequest(key: attachment.key, libraryId: attachment.libraryId, downloaded: false))
+
+                    coordinator.invalidate()
+
+                    canDelete = true
+                })
+
+                if canDelete {
+                    try? removeFiles(for: attachment.key, libraryId: attachment.libraryId)
+                }
+
+                return canDelete
+            } catch let error {
+                DDLogError("AttachmentFileCleanupController: can't remove attachment file - \(error)")
+                return false
+            }
+        }
+
+        /// Deletes downloads in given libraries, but keeps files queued for upload intact.
+        /// - parameter libraries: Libraries to delete from.
+        /// - parameter forUpload: Keys of items which need upload for given libraries.
+        /// - returns: Returns individual keys for given libraries which were actually deleted. Some deletions are ignored if files are queued for upload.
+        func delete(downloadsIn libraries: [LibraryIdentifier], forUpload: [LibraryIdentifier: [String]]) -> [LibraryIdentifier: Set<String>] {
+            var deletedIndividually: [LibraryIdentifier: Set<String>] = [:]
+
+            for libraryId in libraries {
+                let keysForUpload = forUpload[libraryId, default: []]
+                if keysForUpload.isEmpty {
+                    // No items are queued for upload, just delete the whole directory. Ignore thrown error because some may not exist locally (user didn't download anything in given library yet).
+                    try? fileStorage.remove(Files.downloads(for: libraryId))
+                    continue
+                }
+
+                // If there are pending uploads, delete only directories with uploaded files. If no folders are stored locally just skip.
+                guard let contents: [File] = try? fileStorage.contentsOfDirectory(at: Files.downloads(for: libraryId)) else { continue }
+
+                var keys: Set<String> = []
+                let toDelete = contents.filter({ file in
+                    // Check whether it's item folder and whether upload is pending for given item.
+                    guard file.relativeComponents.count == 3, let key = file.relativeComponents.last, key.count == KeyGenerator.length else {
+                        // If it's something else, just delete it.
+                        return true
+                    }
+                    guard !keysForUpload.contains(key) else { return false }
+                    // Delete it and record it's key.
                     keys.insert(key)
-                }
-            }
-            deletedIndividually[libraryId] = keys
+                    return true
+                })
+                deletedIndividually[libraryId] = keys
 
-            for file in toDelete {
-                do {
-                    try self.fileStorage.remove(file)
-                } catch let error {
-                    DDLogError("AttachmentFileCleanupController: could not remove file \(file) - \(error)")
-                }
-            }
-        }
-
-        return deletedIndividually
-    }
-
-    /// Tries deleting given attachment.
-    /// - parameter attachment: Attachment to delete.
-    /// - returns: `true` if file could be deleted, `false` otherwise.
-    private func delete(attachment: Attachment) -> Bool {
-        do {
-            // Don't delete linked files
-            guard case .file(_, _, _, let linkType, _) = attachment.type, linkType != .linkedFile else { return false }
-
-            var canDelete: Bool = false
-
-            try self.dbStorage.perform(on: self.queue, with: { coordinator in
-                let item = try coordinator.perform(request: ReadItemDbRequest(libraryId: attachment.libraryId, key: attachment.key))
-                let attachmentNeedsSync = item.attachmentNeedsSync
-
-                // Don't delete attachments that need to sync
-                guard !attachmentNeedsSync else {
-                    canDelete = false
-                    return
-                }
-
-                try? coordinator.perform(request: MarkFileAsDownloadedDbRequest(key: attachment.key, libraryId: attachment.libraryId, downloaded: false))
-
-                coordinator.invalidate()
-
-                canDelete = true
-            })
-
-            if canDelete {
-                try? self.removeFiles(for: attachment.key, libraryId: attachment.libraryId)
-            }
-
-            return canDelete
-        } catch let error {
-            DDLogError("AttachmentFileCleanupController: can't remove attachment file - \(error)")
-            return false
-        }
-    }
-
-    /// Tries deleting individual files from given library.
-    /// - parameter keys: Individual keys of files to delete.
-    /// - parameter libraryId: Library identifier from which files are deleted.
-    /// - returns: `nil` if no files could be deleted. `.allForItems` for actually deleted files.
-    private func deleteAttachments(for keys: Set<String>, libraryId: LibraryIdentifier) -> DeletionType? {
-        guard !keys.isEmpty else { return nil }
-
-        do {
-            var toDelete: Set<String> = []
-            var toReport: Set<String> = []
-
-            try self.dbStorage.perform(on: self.queue, with: { coordinator in
-                let items = try coordinator.perform(request: ReadItemsWithKeysDbRequest(keys: keys, libraryId: libraryId))
-
-                for item in items {
-                    // Either the selected item was attachment
-                    if item.rawType == ItemTypes.attachment {
-                        // Don't delete attachments that need to sync
-                        guard !item.attachmentNeedsSync else { continue }
-                        toDelete.insert(item.key)
-                        toReport.insert(item.key)
-                        continue
-                    }
-
-                    // Or the item was a parent item and it may have multiple attachments
-                    for child in item.children.filter(.item(type: ItemTypes.attachment)) {
-                        // Don't delete attachments that need to sync
-                        guard !child.attachmentNeedsSync else { continue }
-                        // Always report parent key so that the originally requested key gets a report about deletion, even if a child was deleted.
-                        toReport.insert(item.key)
-                        toDelete.insert(child.key)
+                for file in toDelete {
+                    do {
+                        try fileStorage.remove(file)
+                    } catch let error {
+                        DDLogError("AttachmentFileCleanupController: could not remove file \(file) - \(error)")
                     }
                 }
-
-                try? coordinator.perform(request: MarkItemsFilesAsNotDownloadedDbRequest(keys: toDelete, libraryId: libraryId))
-
-                coordinator.invalidate()
-            })
-
-            for key in toDelete {
-                // Some files might not exist, just continue deleting
-                try? self.removeFiles(for: key, libraryId: libraryId)
             }
 
-            return toReport.isEmpty ? nil : .allForItems(toReport, libraryId)
-        } catch let error {
-            DDLogError("AttachmentFileCleanupController: can't remove attachments for item - \(error)")
-            return nil
+            return deletedIndividually
         }
-    }
 
-    private func removeFiles(for key: String, libraryId: LibraryIdentifier) throws {
-        try self.fileStorage.remove(Files.attachmentDirectory(in: libraryId, key: key))
-        // Annotations are not guaranteed to exist.
-        try? self.fileStorage.remove(Files.annotationPreviews(for: key, libraryId: libraryId))
-        // Cleanup page thumbnails
-        try? self.fileStorage.remove(Files.pageThumbnails(for: key, libraryId: libraryId))
+        func removeFiles(for key: String, libraryId: LibraryIdentifier) throws {
+            try fileStorage.remove(Files.attachmentDirectory(in: libraryId, key: key))
+            // Annotations are not guaranteed to exist.
+            try? fileStorage.remove(Files.annotationPreviews(for: key, libraryId: libraryId))
+            // Cleanup page thumbnails
+            try? fileStorage.remove(Files.pageThumbnails(for: key, libraryId: libraryId))
+        }
     }
 }

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -174,6 +174,8 @@ internal enum L10n {
       internal static let filterItems = L10n.tr("Localizable", "accessibility.items.filter_items", fallback: "Filter items")
       /// Open item info
       internal static let openItem = L10n.tr("Localizable", "accessibility.items.open_item", fallback: "Open item info")
+      /// Remove downloads for selected items
+      internal static let removeDownloads = L10n.tr("Localizable", "accessibility.items.remove_downloads", fallback: "Remove downloads for selected items")
       /// Remove selected items from collection
       internal static let removeFromCollection = L10n.tr("Localizable", "accessibility.items.remove_from_collection", fallback: "Remove selected items from collection")
       /// Restore selected items

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -343,6 +343,8 @@ internal enum L10n {
     internal static let createTitle = L10n.tr("Localizable", "collections.create_title", fallback: "Create Collection")
     /// Delete Collection
     internal static let delete = L10n.tr("Localizable", "collections.delete", fallback: "Delete Collection")
+    /// Remove Downloads
+    internal static let deleteAttachmentFiles = L10n.tr("Localizable", "collections.delete_attachment_files", fallback: "Remove Downloads")
     /// Delete Collection and Items
     internal static let deleteWithItems = L10n.tr("Localizable", "collections.delete_with_items", fallback: "Delete Collection and Items")
     /// Download Attachments

--- a/Zotero/Extensions/Localizable.swift
+++ b/Zotero/Extensions/Localizable.swift
@@ -168,6 +168,8 @@ internal enum L10n {
       internal static let delete = L10n.tr("Localizable", "accessibility.items.delete", fallback: "Delete selected items")
       /// Deselect All Items
       internal static let deselectAllItems = L10n.tr("Localizable", "accessibility.items.deselect_all_items", fallback: "Deselect All Items")
+      /// Download attachments for selected items
+      internal static let downloadAttachments = L10n.tr("Localizable", "accessibility.items.download_attachments", fallback: "Download attachments for selected items")
       /// Duplicate selected item
       internal static let duplicate = L10n.tr("Localizable", "accessibility.items.duplicate", fallback: "Duplicate selected item")
       /// Filter items

--- a/Zotero/Scenes/Detail/ItemDetail/ViewModels/ItemDetailActionHandler.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/ViewModels/ItemDetailActionHandler.swift
@@ -467,7 +467,7 @@ struct ItemDetailActionHandler: ViewModelActionHandler, BackgroundDbProcessingAc
     }
 
     private func deleteFile(of attachment: Attachment, in viewModel: ViewModel<ItemDetailActionHandler>) {
-        self.fileCleanupController.delete(.individual(attachment: attachment, parentKey: viewModel.state.key), completed: nil)
+        self.fileCleanupController.delete(.individual(attachment: attachment, parentKey: viewModel.state.key))
     }
 
     private func updateDeletedAttachmentFiles(_ notification: AttachmentFileDeletedNotification, in viewModel: ViewModel<ItemDetailActionHandler>) {

--- a/Zotero/Scenes/Detail/Items/Models/ItemAction.swift
+++ b/Zotero/Scenes/Detail/Items/Models/ItemAction.swift
@@ -95,7 +95,7 @@ struct ItemAction {
 
         case .removeDownload:
             self.title = L10n.Items.Action.removeDownload
-            self._image = .system("trash")
+            self._image = .system("arrow.down.circle.dotted")
         }
     }
 }

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
@@ -180,7 +180,7 @@ struct ItemsActionHandler: ViewModelActionHandler, BackgroundDbProcessingActionH
             self.downloadAttachments(for: keys, in: viewModel)
 
         case .removeDownloads(let ids):
-            self.fileCleanupController.delete(.allForItems(ids, viewModel.state.library.identifier), completed: nil)
+            self.fileCleanupController.delete(.allForItems(ids, viewModel.state.library.identifier))
 
         case .emptyTrash:
             self.emptyTrash(in: viewModel)

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
@@ -92,10 +92,10 @@ final class ItemsToolbarController {
             let items = actions.map({ action -> UIBarButtonItem in
                 let item = UIBarButtonItem(image: action.image, style: .plain, target: nil, action: nil)
                 switch action.type {
-                case .addToCollection, .trash, .delete, .removeFromCollection, .restore:
+                case .addToCollection, .trash, .delete, .removeFromCollection, .restore, .share:
                     item.tag = ToolbarItem.empty.tag
 
-                case .sort, .filter, .createParent, .copyCitation, .copyBibliography, .share, .removeDownload, .download, .duplicate:
+                case .sort, .filter, .createParent, .copyCitation, .copyBibliography, .removeDownload, .download, .duplicate:
                     break
                 }
                 switch action.type {

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
@@ -45,7 +45,7 @@ final class ItemsToolbarController {
         func createEditingActions(for state: ItemsState) -> [ItemAction] {
             var types: [ItemAction.Kind] = []
             if state.collection.identifier.isTrash && state.library.metadataEditable {
-                types.append(contentsOf: [.restore, .delete, .removeDownload])
+                types.append(contentsOf: [.restore, .delete, .download, .removeDownload])
             } else {
                 if state.library.metadataEditable {
                     types.append(contentsOf: [.addToCollection, .trash])
@@ -59,7 +59,7 @@ final class ItemsToolbarController {
                 case .custom, .search:
                     break
                 }
-                types.append(contentsOf: [.removeDownload, .share])
+                types.append(contentsOf: [.download, .removeDownload, .share])
             }
             return types.map { .init(type: $0) }
         }
@@ -92,10 +92,10 @@ final class ItemsToolbarController {
             let items = actions.map({ action -> UIBarButtonItem in
                 let item = UIBarButtonItem(image: action.image, style: .plain, target: nil, action: nil)
                 switch action.type {
-                case .addToCollection, .trash, .delete, .removeFromCollection, .restore, .share, .removeDownload:
+                case .addToCollection, .trash, .delete, .removeFromCollection, .restore, .share, .download, .removeDownload:
                     item.tag = ToolbarItem.empty.tag
 
-                case .sort, .filter, .createParent, .copyCitation, .copyBibliography, .download, .duplicate:
+                case .sort, .filter, .createParent, .copyCitation, .copyBibliography, .duplicate:
                     break
                 }
                 switch action.type {
@@ -117,10 +117,13 @@ final class ItemsToolbarController {
                 case .share:
                     item.accessibilityLabel = L10n.Accessibility.Items.share
 
+                case .download:
+                    item.accessibilityLabel = L10n.Accessibility.Items.downloadAttachments
+
                 case .removeDownload:
                     item.accessibilityLabel = L10n.Accessibility.Items.removeDownloads
 
-                case .sort, .filter, .createParent, .copyCitation, .copyBibliography, .download, .duplicate:
+                case .sort, .filter, .createParent, .copyCitation, .copyBibliography, .duplicate:
                     break
                 }
                 item.rx.tap.subscribe(onNext: { [weak self] _ in

--- a/Zotero/Scenes/Detail/Items/Views/ItemsTableViewHandler.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsTableViewHandler.swift
@@ -219,7 +219,11 @@ final class ItemsTableViewHandler: NSObject {
     }
 
     func reloadAllAttachments() {
-        self.tableView.reloadData()
+        if viewModel.state.isEditing && !viewModel.state.selectedItems.isEmpty, let indexPathsForSelectedRows = tableView.indexPathsForSelectedRows {
+            tableView.reconfigureRows(at: indexPathsForSelectedRows)
+        } else {
+            tableView.reloadData()
+        }
     }
 
     func reload(snapshot: Results<RItem>, modifications: [Int], insertions: [Int], deletions: [Int], completion: (() -> Void)? = nil) {

--- a/Zotero/Scenes/Master/Collections/Models/CollectionsAction.swift
+++ b/Zotero/Scenes/Master/Collections/Models/CollectionsAction.swift
@@ -21,4 +21,5 @@ enum CollectionsAction {
     case toggleCollapsed(Collection)
     case loadItemKeysForBibliography(Collection)
     case downloadAttachments(CollectionIdentifier)
+    case removeDownloads(CollectionIdentifier)
 }

--- a/Zotero/Scenes/Master/Collections/Views/ExpandableCollectionsCollectionViewHandler.swift
+++ b/Zotero/Scenes/Master/Collections/Views/ExpandableCollectionsCollectionViewHandler.swift
@@ -101,59 +101,69 @@ final class ExpandableCollectionsCollectionViewHandler: NSObject {
     }
 
     private func createContextMenu(for collection: Collection) -> UIMenu? {
+        var actions: [UIAction] = []
         switch collection.identifier {
         case .collection(let key):
-            var actions: [UIAction] = []
-
             if viewModel.state.library.metadataEditable {
-                let edit = UIAction(title: L10n.edit, image: UIImage(systemName: "pencil")) { [weak self] _ in
-                    self?.viewModel.process(action: .startEditing(.edit(collection)))
+                let edit = UIAction(title: L10n.edit, image: UIImage(systemName: "pencil")) { [weak viewModel] _ in
+                    viewModel?.process(action: .startEditing(.edit(collection)))
                 }
-                let subcollection = UIAction(title: L10n.Collections.newSubcollection, image: UIImage(systemName: "folder.badge.plus")) { [weak self] _ in
-                    self?.viewModel.process(action: .startEditing(.addSubcollection(collection)))
+                let subcollection = UIAction(title: L10n.Collections.newSubcollection, image: UIImage(systemName: "folder.badge.plus")) { [weak viewModel] _ in
+                    viewModel?.process(action: .startEditing(.addSubcollection(collection)))
                 }
                 actions.append(contentsOf: [edit, subcollection])
             }
             
-            let createBibliography = UIAction(title: L10n.Collections.createBibliography, image: UIImage(systemName: "doc.on.doc")) { [weak self] _ in
-                self?.viewModel.process(action: .loadItemKeysForBibliography(collection))
+            let createBibliography = UIAction(title: L10n.Collections.createBibliography, image: UIImage(systemName: "doc.on.doc")) { [weak viewModel] _ in
+                viewModel?.process(action: .loadItemKeysForBibliography(collection))
             }
             actions.append(createBibliography)
 
             if viewModel.state.library.metadataEditable {
-                let delete = UIAction(title: L10n.delete, image: UIImage(systemName: "trash"), attributes: .destructive) { [weak self] _ in
-                    self?.viewModel.process(action: .deleteCollection(key))
+                let delete = UIAction(title: L10n.delete, image: UIImage(systemName: "trash"), attributes: .destructive) { [weak viewModel] _ in
+                    viewModel?.process(action: .deleteCollection(key))
                 }
                 actions.append(delete)
             }
 
             if collection.itemCount > 0 {
-                let downloadAttachments = UIAction(title: L10n.Collections.downloadAttachments, image: UIImage(systemName: "arrow.down.to.line.compact")) { [weak self] _ in
-                    self?.viewModel.process(action: .downloadAttachments(collection.identifier))
-                }
-                actions.insert(downloadAttachments, at: 0)
+                actions.insert(contentsOf: [downloadAttachmentsAction(for: collection.identifier, in: viewModel), removeDownloadsAction(for: collection.identifier, in: viewModel)], at: 0)
             }
 
-            return UIMenu(title: "", children: actions)
-
         case .custom(let type):
+            guard collection.itemCount > 0 else { break }
+            actions.append(removeDownloadsAction(for: collection.identifier, in: viewModel))
+
             switch type {
             case .trash:
-                guard self.viewModel.state.library.metadataEditable && collection.itemCount > 0 else { return nil }
-                let trash = UIAction(title: L10n.Collections.emptyTrash, image: UIImage(systemName: "trash"), attributes: .destructive) { [weak self] _ in
-                    self?.viewModel.process(action: .emptyTrash)
+                if viewModel.state.library.metadataEditable {
+                    let trash = UIAction(title: L10n.Collections.emptyTrash, image: UIImage(systemName: "trash"), attributes: .destructive) { [weak viewModel] _ in
+                        viewModel?.process(action: .emptyTrash)
+                    }
+                    actions.append(trash)
                 }
-                return UIMenu(title: "", children: [trash])
 
             case .publications, .all, .unfiled:
-                let downloadAttachments = UIAction(title: L10n.Collections.downloadAttachments, image: UIImage(systemName: "arrow.down.to.line.compact")) { [weak self] _ in
-                    self?.viewModel.process(action: .downloadAttachments(collection.identifier))
-                }
-                return UIMenu(title: "", children: [downloadAttachments])
+                actions.insert(downloadAttachmentsAction(for: collection.identifier, in: viewModel), at: 0)
             }
 
         case .search:
-            return nil
+            break
+        }
+
+        guard !actions.isEmpty else { return nil }
+        return UIMenu(children: actions)
+
+        func downloadAttachmentsAction(for identifier: CollectionIdentifier, in viewModel: ViewModel<CollectionsActionHandler>) -> UIAction {
+            UIAction(title: L10n.Collections.downloadAttachments, image: UIImage(systemName: "arrow.down.to.line.compact")) { [weak viewModel] _ in
+                viewModel?.process(action: .downloadAttachments(identifier))
+            }
+        }
+
+        func removeDownloadsAction(for identifier: CollectionIdentifier, in viewModel: ViewModel<CollectionsActionHandler>) -> UIAction {
+            UIAction(title: L10n.Collections.deleteAttachmentFiles, image: UIImage(systemName: "trash")) { [weak viewModel] _ in
+                viewModel?.process(action: .removeDownloads(identifier))
+            }
         }
     }
 

--- a/Zotero/Scenes/Master/Collections/Views/ExpandableCollectionsCollectionViewHandler.swift
+++ b/Zotero/Scenes/Master/Collections/Views/ExpandableCollectionsCollectionViewHandler.swift
@@ -161,7 +161,7 @@ final class ExpandableCollectionsCollectionViewHandler: NSObject {
         }
 
         func removeDownloadsAction(for identifier: CollectionIdentifier, in viewModel: ViewModel<CollectionsActionHandler>) -> UIAction {
-            UIAction(title: L10n.Collections.deleteAttachmentFiles, image: UIImage(systemName: "trash")) { [weak viewModel] _ in
+            UIAction(title: L10n.Collections.deleteAttachmentFiles, image: UIImage(systemName: "arrow.down.circle.dotted")) { [weak viewModel] _ in
                 viewModel?.process(action: .removeDownloads(identifier))
             }
         }

--- a/Zotero/Scenes/Master/MasterCoordinator.swift
+++ b/Zotero/Scenes/Master/MasterCoordinator.swift
@@ -66,7 +66,8 @@ final class MasterCoordinator: NSObject, Coordinator {
             selectedCollectionId: Defaults.shared.selectedCollectionId,
             dbStorage: userControllers.dbStorage,
             syncScheduler: userControllers.syncScheduler,
-            attachmentDownloader: userControllers.fileDownloader
+            attachmentDownloader: userControllers.fileDownloader,
+            fileCleanupController: userControllers.fileCleanupController
         )
         self.navigationController?.setViewControllers([librariesController, collectionsController], animated: animated)
     }
@@ -83,10 +84,11 @@ final class MasterCoordinator: NSObject, Coordinator {
         selectedCollectionId: CollectionIdentifier,
         dbStorage: DbStorage,
         syncScheduler: SynchronizationScheduler,
-        attachmentDownloader: AttachmentDownloader
+        attachmentDownloader: AttachmentDownloader,
+        fileCleanupController: AttachmentFileCleanupController
     ) -> CollectionsViewController {
         DDLogInfo("MasterTopCoordinator: show collections for \(selectedCollectionId.id); \(libraryId)")
-        let handler = CollectionsActionHandler(dbStorage: dbStorage, fileStorage: self.controllers.fileStorage, attachmentDownloader: attachmentDownloader)
+        let handler = CollectionsActionHandler(dbStorage: dbStorage, fileStorage: controllers.fileStorage, attachmentDownloader: attachmentDownloader, fileCleanupController: fileCleanupController)
         let state = CollectionsState(libraryId: libraryId, selectedCollectionId: selectedCollectionId)
         let viewModel = ViewModel(initialState: state, handler: handler)
         return CollectionsViewController(viewModel: viewModel, dragDropController: controllers.dragDropController, syncScheduler: syncScheduler, coordinatorDelegate: self)
@@ -120,7 +122,8 @@ extension MasterCoordinator: MasterLibrariesCoordinatorDelegate {
             selectedCollectionId: collectionId,
             dbStorage: userControllers.dbStorage,
             syncScheduler: userControllers.syncScheduler,
-            attachmentDownloader: userControllers.fileDownloader
+            attachmentDownloader: userControllers.fileDownloader,
+            fileCleanupController: userControllers.fileCleanupController
         )
 
         let animated: Bool
@@ -173,7 +176,8 @@ extension MasterCoordinator: MasterLibrariesCoordinatorDelegate {
             selectedCollectionId: collectionId,
             dbStorage: userControllers.dbStorage,
             syncScheduler: userControllers.syncScheduler,
-            attachmentDownloader: userControllers.fileDownloader
+            attachmentDownloader: userControllers.fileDownloader,
+            fileCleanupController: userControllers.fileCleanupController
         )
         self.navigationController?.pushViewController(controller, animated: true)
     }
@@ -190,7 +194,8 @@ extension MasterCoordinator: MasterLibrariesCoordinatorDelegate {
                 selectedCollectionId: collectionId,
                 dbStorage: userControllers.dbStorage,
                 syncScheduler: userControllers.syncScheduler,
-                attachmentDownloader: userControllers.fileDownloader
+                attachmentDownloader: userControllers.fileDownloader,
+                fileCleanupController: userControllers.fileCleanupController
             )
             navigationController.pushViewController(controller, animated: animated)
         } else if libraryId != self.visibleLibraryId {
@@ -200,7 +205,8 @@ extension MasterCoordinator: MasterLibrariesCoordinatorDelegate {
                 selectedCollectionId: collectionId,
                 dbStorage: userControllers.dbStorage,
                 syncScheduler: userControllers.syncScheduler,
-                attachmentDownloader: userControllers.fileDownloader
+                attachmentDownloader: userControllers.fileDownloader,
+                fileCleanupController: userControllers.fileCleanupController
             )
 
             var viewControllers = navigationController.viewControllers


### PR DESCRIPTION
* Adds `Remove Downloads` action in collection context menu, when the collection has items. Similar to `Download Attachments` action, it doesn't explicitely check if there are any attachments already downloaded, it just checks for collection items count. This action is placed 2nd in the menu, after `Download Attachments`. For `Trash` it is placed 1st, as non-destructive.
* Adds `Remove downloads for selected items` action in items toolbar. To differentiate from `Move selected items to trash` the icon  `arrow.down.circle.dotted` is used.

Perhaps we should consider using the same icon, either a system or a custom one, for all actions that remove downloads.
Additionally, since we allow to remove downloads for selected items, maybe we should also allow to download attachments for selected items? If the toolbar gets too populated though, maybe we should consider a more button that presents a menu with the additional actions.

Closes #981 