### PR TITLE
Show formatted text in annotations sidebar

### DIFF
--- a/Zotero/Controllers/PlaceholderTextViewDelegate.swift
+++ b/Zotero/Controllers/PlaceholderTextViewDelegate.swift
@@ -34,15 +34,27 @@ final class PlaceholderTextViewDelegate: NSObject {
     init(placeholder: String, menuItems: [UIMenuItem]?, textView: UITextView) {
         self.menuItems = menuItems
         self.placeholder = placeholder
-        self.placeholderLayer = CATextLayer()
+        placeholderLayer = CATextLayer()
 
         super.init()
 
-        self.setup(placeholder: placeholder, textView: textView)
+        setup(placeholder: placeholder, textView: textView)
+
+        func setup(placeholder: String, textView: UITextView) {
+            placeholderLayer.string = placeholder
+            placeholderLayer.font = textView.font
+            placeholderLayer.fontSize = textView.font?.pointSize ?? 0
+            placeholderLayer.foregroundColor = UIColor.placeholderText.cgColor
+            placeholderLayer.contentsScale = UIScreen.main.scale
+
+            textView.layer.addSublayer(placeholderLayer)
+
+            layoutPlaceholder(in: textView)
+        }
     }
 
     func set(text: String, to textView: UITextView) {
-        self.placeholderLayer.isHidden = !text.isEmpty
+        placeholderLayer.isHidden = !text.isEmpty
 
         let oldRange = textView.selectedRange
         let isSameLengthText = text.count == textView.text.count
@@ -56,7 +68,7 @@ final class PlaceholderTextViewDelegate: NSObject {
     }
 
     func set(text: NSAttributedString, to textView: UITextView) {
-        self.placeholderLayer.isHidden = !text.string.isEmpty
+        placeholderLayer.isHidden = !text.string.isEmpty
 
         let oldRange = textView.selectedRange
         let isSameLengthText = text.string.count == textView.attributedText.string.count
@@ -70,51 +82,39 @@ final class PlaceholderTextViewDelegate: NSObject {
     }
 
     func set(placeholderColor: UIColor) {
-        self.placeholderLayer.foregroundColor = placeholderColor.cgColor
+        placeholderLayer.foregroundColor = placeholderColor.cgColor
     }
 
     func layoutPlaceholder(in textView: UITextView) {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
-        self.placeholderLayer.frame = textView.bounds
+        placeholderLayer.frame = textView.bounds
         CATransaction.commit()
-    }
-
-    private func setup(placeholder: String, textView: UITextView) {
-        self.placeholderLayer.string = placeholder
-        self.placeholderLayer.font = textView.font
-        self.placeholderLayer.fontSize = textView.font?.pointSize ?? 0
-        self.placeholderLayer.foregroundColor = UIColor.placeholderText.cgColor
-        self.placeholderLayer.contentsScale = UIScreen.main.scale
-
-        textView.layer.addSublayer(self.placeholderLayer)
-
-        self.layoutPlaceholder(in: textView)
     }
 }
 
 extension PlaceholderTextViewDelegate: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
-        if let menuItems = self.menuItems {
+        if let menuItems {
             UIMenuController.shared.menuItems = menuItems
         }
-        self.placeholderLayer.foregroundColor = UIColor.placeholderText.cgColor
-        self.didBecomeActiveObserver?.on(.next(()))
+        placeholderLayer.foregroundColor = UIColor.placeholderText.cgColor
+        didBecomeActiveObserver?.on(.next(()))
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
-        self.placeholderLayer.isHidden = !textView.text.isEmpty
+        placeholderLayer.isHidden = !textView.text.isEmpty
     }
 
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         if textView.text.isEmpty && !text.isEmpty {
-            self.placeholderLayer.isHidden = true
+            placeholderLayer.isHidden = true
         }
         return true
     }
 
     func textViewDidChange(_ textView: UITextView) {
-        self.textObserver?.on(.next(textView.text))
-        self.textChanged?(textView.text)
+        textObserver?.on(.next(textView.text))
+        textChanged?(textView.text)
     }
 }

--- a/Zotero/Scenes/Detail/PDF/Models/AnnotationViewLayout.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/AnnotationViewLayout.swift
@@ -31,38 +31,38 @@ struct AnnotationViewLayout {
     let showDoneButton: Bool
 
     init(type: AnnotationView.Kind) {
-        self.horizontalInset = 16
-        self.pageLabelLeadingOffset = 8
-        self.highlightContentLeadingOffset = 8
-        self.highlightLineWidth = 3
-        self.highlightLineVerticalInsets = 8
+        horizontalInset = 16
+        pageLabelLeadingOffset = 8
+        highlightContentLeadingOffset = 8
+        highlightLineWidth = 3
+        highlightLineVerticalInsets = 8
 
         switch type {
         case .cell:
-            self.headerVerticalInsets = 9
-            self.buttonVerticalInset = 9
-            self.lineHeight = 20
-            self.verticalSpacerHeight = 12.5
-            self.font = .preferredFont(forTextStyle: .subheadline)
-            self.pageLabelFont = .preferredFont(for: .subheadline, weight: .bold)
-            self.showsContent = true
-            self.commentMinHeight = nil
-            self.scrollableBody = false
-            self.backgroundColor = .systemBackground
-            self.showDoneButton = false
+            headerVerticalInsets = 9
+            buttonVerticalInset = 9
+            lineHeight = 20
+            verticalSpacerHeight = 12.5
+            font = .preferredFont(forTextStyle: .subheadline)
+            pageLabelFont = .preferredFont(for: .subheadline, weight: .bold)
+            showsContent = true
+            commentMinHeight = nil
+            scrollableBody = false
+            backgroundColor = .systemBackground
+            showDoneButton = false
             
         case .popover:
-            self.headerVerticalInsets = 14
-            self.buttonVerticalInset = 11
-            self.lineHeight = 22
-            self.verticalSpacerHeight = 16
-            self.font = .preferredFont(forTextStyle: .body)
-            self.pageLabelFont = .preferredFont(for: .body, weight: .bold)
-            self.showsContent = false
-            self.commentMinHeight = self.lineHeight * 3
-            self.scrollableBody = true
-            self.backgroundColor = Asset.Colors.annotationPopoverBackground.color
-            self.showDoneButton = UIDevice.current.userInterfaceIdiom == .phone
+            headerVerticalInsets = 14
+            buttonVerticalInset = 11
+            lineHeight = 22
+            verticalSpacerHeight = 16
+            font = .preferredFont(forTextStyle: .body)
+            pageLabelFont = .preferredFont(for: .body, weight: .bold)
+            showsContent = false
+            commentMinHeight = lineHeight * 3
+            scrollableBody = true
+            backgroundColor = Asset.Colors.annotationPopoverBackground.color
+            showDoneButton = UIDevice.current.userInterfaceIdiom == .phone
         }
     }
 }

--- a/Zotero/Scenes/Detail/PDF/Models/PDFReaderAction.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/PDFReaderAction.swift
@@ -36,6 +36,7 @@ enum PDFReaderAction {
     case createNote(pageIndex: PageIndex, origin: CGPoint)
     case createImage(pageIndex: PageIndex, origin: CGPoint)
     case createHighlight(pageIndex: PageIndex, rects: [CGRect])
+    case parseAndCacheText(key: String, text: String)
     case parseAndCacheComment(key: String, comment: String)
     case setComment(key: String, comment: NSAttributedString)
     case setCommentActive(Bool)

--- a/Zotero/Scenes/Detail/PDF/Models/PDFReaderState.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/PDFReaderState.swift
@@ -69,6 +69,7 @@ struct PDFReaderState: ViewModelState {
     let document: PSPDFKit.Document
     let displayTitle: String?
     let previewCache: NSCache<NSString, UIImage>
+    let textFont: UIFont
     let commentFont: UIFont
     let userId: Int
     let username: String
@@ -82,6 +83,7 @@ struct PDFReaderState: ViewModelState {
     var itemToken: NotificationToken?
     var databaseAnnotations: Results<RItem>!
     var documentAnnotations: [String: PDFDocumentAnnotation]
+    var texts: [String: NSAttributedString]
     var comments: [String: NSAttributedString]
     var searchTerm: String?
     var filter: AnnotationsFilter?
@@ -144,12 +146,14 @@ struct PDFReaderState: ViewModelState {
         document.overrideClass(PSPDFKit.AnnotationManager.self, with: AnnotationManager.self)
         self.displayTitle = displayTitle
         self.previewCache = NSCache()
+        self.textFont = PDFReaderLayout.annotationLayout.font
         self.commentFont = PDFReaderLayout.annotationLayout.font
         self.userId = userId
         self.username = username
         self.displayName = displayName
         self.sortedKeys = []
         self.documentAnnotations = [:]
+        self.texts = [:]
         self.comments = [:]
         self.visiblePage = 0
         self.initialPage = initialPage

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationView.swift
@@ -92,6 +92,7 @@ final class AnnotationView: UIView {
 
     /// Setups up annotation view with given annotation and additional data.
     /// - parameter annotation: Annotation to show in view.
+    /// - parameter text: Text to show. If nil, text field is not shown.
     /// - parameter comment: Comment to show. If nil, comment field is not shown.
     /// - parameter preview: Preview image to show. If nil, no image is shown.
     /// - parameter selected: If true, selected state style is applied.
@@ -101,6 +102,7 @@ final class AnnotationView: UIView {
     /// - parameter state: State required for setting up share menu.
     func setup(
         with annotation: PDFAnnotation,
+        text: NSAttributedString?,
         comment: Comment?,
         preview: UIImage?,
         selected: Bool,
@@ -132,6 +134,7 @@ final class AnnotationView: UIView {
         )
         setupContent(
             for: annotation,
+            text: text,
             preview: preview,
             color: color,
             canEdit: canEdit,
@@ -156,6 +159,7 @@ final class AnnotationView: UIView {
 
     private func setupContent(
         for annotation: PDFAnnotation,
+        text: NSAttributedString?,
         preview: UIImage?,
         color: UIColor,
         canEdit: Bool,
@@ -177,7 +181,7 @@ final class AnnotationView: UIView {
             let bottomInset = inset(from: layout.highlightLineVerticalInsets, hasComment: !annotation.comment.isEmpty, selected: selected, canEdit: canEdit)
             highlightContent.isHidden = false
             imageContent.isHidden = true
-            highlightContent.setup(with: color, text: (annotation.text ?? ""), bottomInset: bottomInset, accessibilityType: accessibilityType)
+            highlightContent.setup(with: color, text: text ?? .init(), bottomInset: bottomInset, accessibilityType: accessibilityType)
 
         case .image, .ink, .freeText:
             highlightContent.isHidden = true

--- a/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHighlightContent.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/Annotation View/AnnotationViewHighlightContent.swift
@@ -37,21 +37,22 @@ final class AnnotationViewHighlightContent: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func setup(with color: UIColor, text: String, bottomInset: CGFloat, accessibilityType: AnnotationView.AccessibilityType) {
+    func setup(with color: UIColor, text: NSAttributedString, bottomInset: CGFloat, accessibilityType: AnnotationView.AccessibilityType) {
         let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.minimumLineHeight = self.layout.lineHeight
-        paragraphStyle.maximumLineHeight = self.layout.lineHeight
-        let attributedString = NSAttributedString(string: text, attributes: [.paragraphStyle: paragraphStyle, .font: self.layout.font, .foregroundColor: Asset.Colors.annotationText.color])
+        paragraphStyle.minimumLineHeight = layout.lineHeight
+        paragraphStyle.maximumLineHeight = layout.lineHeight
+        let attributedString = NSMutableAttributedString(attributedString: text)
+        attributedString.addAttributes([.paragraphStyle: paragraphStyle, .foregroundColor: Asset.Colors.annotationText.color], range: NSRange(location: 0, length: text.length))
 
-        self.lineView.backgroundColor = color
-        self.textLabel.attributedText = attributedString
-        self.bottomInsetConstraint.constant = bottomInset
+        lineView.backgroundColor = color
+        textLabel.attributedText = attributedString
+        bottomInsetConstraint.constant = bottomInset
 
 //        switch accessibilityType {
 //        case .cell:
-//            self.textLabel.isAccessibilityElement = false
+//            textLabel.isAccessibilityElement = false
 //        case .view:
-//            self.textLabel.accessibilityLabel = attributedString.string
+//            textLabel.accessibilityLabel = attributedString.string
 //        }
     }
 

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationCell.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationCell.swift
@@ -85,6 +85,7 @@ final class AnnotationCell: UITableViewCell {
 
     func setup(
         with annotation: PDFAnnotation,
+        text: NSAttributedString?,
         comment: AnnotationView.Comment?,
         preview: UIImage?,
         selected: Bool,
@@ -107,6 +108,7 @@ final class AnnotationCell: UITableViewCell {
         let availableWidth = availableWidth - (PDFReaderLayout.annotationLayout.horizontalInset * 2)
         annotationView.setup(
             with: annotation,
+            text: text,
             comment: comment,
             preview: preview,
             selected: selected,

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -857,6 +857,17 @@ extension PDFReaderViewController: SidebarDelegate {
 }
 
 extension PDFReaderViewController: AnnotationsDelegate {
+    func parseAndCacheIfNeededAttributedText(for annotation: any PDFAnnotation) -> NSAttributedString? {
+        guard let text = annotation.text, !text.isEmpty else { return nil }
+
+        if let attributedText = viewModel.state.texts[annotation.key] {
+            return attributedText
+        }
+
+        viewModel.process(action: .parseAndCacheText(key: annotation.key, text: text))
+        return viewModel.state.texts[annotation.key]
+    }
+
     func parseAndCacheIfNeededAttributedComment(for annotation: PDFAnnotation) -> NSAttributedString? {
         let comment = annotation.comment
         guard !comment.isEmpty else { return nil }


### PR DESCRIPTION
Coverts annotation text for highlight and underline annotations to attributed text, for proper read-only presentation in annotations sidebar. Caches attributed text in PDF reader state. Updates cache whenever annotation text changes.

A separate issue will be opened to add formatting for annotation edit as well, similar to annotation comment edit.