### PR TITLE
Set correct parent key for standalone item accessory

### DIFF
--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
@@ -682,7 +682,7 @@ struct ItemsActionHandler: ViewModelActionHandler, BackgroundDbProcessingActionH
 
     private func accessory(for item: RItem) -> ItemAccessory? {
         if let attachment = AttachmentCreator.mainAttachment(for: item, fileStorage: self.fileStorage) {
-            return .attachment(attachment: attachment, parentKey: item.key)
+            return .attachment(attachment: attachment, parentKey: (item.key != attachment.key) ? item.key : nil)
         }
 
         if let urlString = item.urlString, self.urlDetector.isUrl(string: urlString), let url = URL(string: urlString) {


### PR DESCRIPTION
Standalone items use their key also as parent key, affecting e.g. PDF share menu.

Mentioned in forum [comment](https://forums.zotero.org/discussion/comment/473613/#Comment_473613)