### PR TITLE
Improve PDF reader annotation selection/deselection

### DIFF
--- a/Zotero/Scenes/Detail/Annotation Popover/AnnotationPopoverCoordinator.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/AnnotationPopoverCoordinator.swift
@@ -29,6 +29,7 @@ final class AnnotationPopoverCoordinator: NSObject, Coordinator {
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator]
     weak var navigationController: UINavigationController?
+    private var finishing: Bool
 
     var viewModelObservable: PublishSubject<AnnotationPopoverState>? {
         return (navigationController?.viewControllers.first as? AnnotationPopoverViewController)?.viewModel.stateObservable
@@ -44,12 +45,13 @@ final class AnnotationPopoverCoordinator: NSObject, Coordinator {
         self.controllers = controllers
         self.childCoordinators = []
         self.disposeBag = DisposeBag()
+        finishing = false
 
         super.init()
 
         navigationController.delegate = self
-        navigationController.dismissHandler = {
-            self.parentCoordinator?.childDidFinish(self)
+        navigationController.dismissHandler = { [weak self] in
+            self?.didFinish()
         }
     }
 
@@ -105,7 +107,9 @@ extension AnnotationPopoverCoordinator: AnnotationPopoverAnnotationCoordinatorDe
     }
 
     func didFinish() {
-        self.parentCoordinator?.childDidFinish(self)
+        guard !finishing else { return }
+        finishing = true
+        parentCoordinator?.childDidFinish(self)
     }
 }
 

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -196,7 +196,7 @@ extension PDFCoordinator: PdfReaderCoordinatorDelegate {
         DDLogInfo("PDFCoordinator: show annotation popover")
 
         if let coordinator = childCoordinators.last, coordinator is AnnotationPopoverCoordinator {
-            return nil
+            DDLogWarn("PDFCoordinator: another annotation popover is already showing, ignoring")
         }
 
         let navigationController = NavigationViewController()

--- a/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
@@ -965,12 +965,7 @@ extension PDFDocumentViewController: UIPencilInteractionDelegate {
     }
 }
 
-extension PDFDocumentViewController: UIPopoverPresentationControllerDelegate {
-    func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
-        guard let type = viewModel.state.selectedAnnotation?.type, type == .highlight || type == .underline else { return }
-        viewModel.process(action: .deselectSelectedAnnotation)
-    }
-}
+extension PDFDocumentViewController: UIPopoverPresentationControllerDelegate { }
 
 extension PDFDocumentViewController: AnnotationBoundingBoxConverter {
     /// Converts from database to PSPDFKit rect. Database stores rects in RAW PDF Coordinate space. PSPDFKit works with Normalized PDF Coordinate Space.


### PR DESCRIPTION
* Allows quicker annotation popover selection, as before closing e.g. a highlight annotation and selecting immediatelly another, is ignored.
* Fixes deselection of annotations, when there are more than one visible page views.