### PR TITLE
Auto release computed PNG data after caching

### DIFF
--- a/Zotero/Controllers/AnnotationPreviewController.swift
+++ b/Zotero/Controllers/AnnotationPreviewController.swift
@@ -306,15 +306,17 @@ extension AnnotationPreviewController {
     }
 
     private func cache(image: UIImage, key: String, pdfKey: String, libraryId: LibraryIdentifier, isDark: Bool) {
-        guard let data = image.pngData() else {
-            DDLogError("AnnotationPreviewController: can't create data from image")
-            return
-        }
-
-        do {
-            try fileStorage.write(data, to: Files.annotationPreview(annotationKey: key, pdfKey: pdfKey, libraryId: libraryId, isDark: isDark), options: .atomicWrite)
-        } catch let error {
-            DDLogError("AnnotationPreviewController: can't store preview - \(error)")
+        autoreleasepool {
+            guard let data = image.pngData() else {
+                DDLogError("AnnotationPreviewController: can't create data from image")
+                return
+            }
+            
+            do {
+                try fileStorage.write(data, to: Files.annotationPreview(annotationKey: key, pdfKey: pdfKey, libraryId: libraryId, isDark: isDark), options: .atomicWrite)
+            } catch let error {
+                DDLogError("AnnotationPreviewController: can't store preview - \(error)")
+            }
         }
     }
 }

--- a/Zotero/Controllers/PDFThumbnailController.swift
+++ b/Zotero/Controllers/PDFThumbnailController.swift
@@ -149,14 +149,16 @@ extension PDFThumbnailController {
         }
 
         func cache(image: UIImage, page: UInt, key: String, libraryId: LibraryIdentifier, isDark: Bool) {
-            guard let data = image.pngData() else {
-                DDLogError("PdfThumbnailController: can't create data from image")
-                return
-            }
-            do {
-                try fileStorage.write(data, to: Files.pageThumbnail(pageIndex: page, key: key, libraryId: libraryId, isDark: isDark), options: .atomicWrite)
-            } catch let error {
-                DDLogError("PdfThumbnailController: can't store preview - \(error)")
+            autoreleasepool {
+                guard let data = image.pngData() else {
+                    DDLogError("PdfThumbnailController: can't create data from image")
+                    return
+                }
+                do {
+                    try fileStorage.write(data, to: Files.pageThumbnail(pageIndex: page, key: key, libraryId: libraryId, isDark: isDark), options: .atomicWrite)
+                } catch let error {
+                    DDLogError("PdfThumbnailController: can't store preview - \(error)")
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #1023 

This could be due to a large number of annotation previews. `pngData` may be called with a larger frequency than this  of memory release, resulting in this type of crash, regardless that a background queue is used. If so, an auto release pool may be enough to force memory purging.