### PR TITLE
Improve PDF reader items observer

### DIFF
--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
@@ -1833,7 +1833,7 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
         }
 
         func observe(items: Results<RItem>, viewModel: ViewModel<PDFReaderActionHandler>, handler: PDFReaderActionHandler) -> NotificationToken {
-            return items.observe { [weak handler, weak viewModel] change in
+            return items.observe(keyPaths: [\RItem.changeType]) { [weak handler, weak viewModel] change in
                 guard let handler, let viewModel else { return }
                 switch change {
                 case .update(let objects, let deletions, let insertions, let modifications):


### PR DESCRIPTION
Improves lag reported in [forum post](https://forums.zotero.org/discussion/comment/479466)

For the items observer in PDF reader, filters with `keyPath` for `changeType` property, to only observe modifications of those annotations with a modified change type. Otherwise, every annotation insertion would also trigger after sync an observed update of all annotations modified. 
Since the observer runs on the main thread there is a noticeable lag with a large number of annotations (I tested with over 1000).  There is room for future improvements regarding this edge case.

