### PR TITLE
Fix items search bar placement iOS 18 bug

### DIFF
--- a/Zotero/Scenes/Detail/Items/Views/BaseItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/BaseItemsViewController.swift
@@ -77,6 +77,15 @@ class BaseItemsViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        if #available(iOS 18, *) {
+            // In some cases in iOS 18, where the horizontal size class changes, e.g. when switching to a scene with a PDF reader and dismissing it,
+            // this error is logged multiple times, and leaves the search bar in stack placement, but overlapping the table view:
+            // "UINavigationBar has changed horizontal size class without updating search bar to new placement. Fixing, but delegate searchBarPlacement callbacks have been skipped."
+            // Setting "navigationItem.preferredSearchBarPlacement = .inline" explicitly, would even freeze the app and crash it.
+            // Instead, hiding and showing the navigation bar momentarily when the view will appear, fixes the issue.
+            navigationController?.setNavigationBarHidden(true, animated: false)
+            navigationController?.setNavigationBarHidden(false, animated: false)
+        }
         toolbarController?.willAppear()
     }
 


### PR DESCRIPTION
Fixes issue mention in this forum [post](https://forums.zotero.org/discussion/119807/ios-search-field-overlaps-with-item-list)