### PR TITLE
Adjust free text annotation size on editing end

### DIFF
--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -452,7 +452,7 @@
 		B324278225C841A600567504 /* WsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B324278125C841A600567504 /* WsResponse.swift */; };
 		B3242CCD246ABBAF00D8748F /* AnnotationsConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3242CCC246ABBAF00D8748F /* AnnotationsConfig.swift */; };
 		B3243BC82A5EB2740033A7D6 /* HtmlAttributedStringConverterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3243BC72A5EB2740033A7D6 /* HtmlAttributedStringConverterSpec.swift */; };
-		B325C40A2A7A8DE0008A2F11 /* CustomFreeTextAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B325C4092A7A8DE0008A2F11 /* CustomFreeTextAnnotationView.swift */; };
+		B325C40A2A7A8DE0008A2F11 /* FreeTextAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B325C4092A7A8DE0008A2F11 /* FreeTextAnnotationView.swift */; };
 		B325DBAC24374F4600EFF0F5 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B325DBAB24374F4600EFF0F5 /* AppCoordinator.swift */; };
 		B325DBAD24375C7B00EFF0F5 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B305650E23FC051E003304F2 /* UIViewController+Extensions.swift */; };
 		B325DBAF24375D8D00EFF0F5 /* Conflict.swift in Sources */ = {isa = PBXBuildFile; fileRef = B325DBAE24375D8D00EFF0F5 /* Conflict.swift */; };
@@ -1570,7 +1570,7 @@
 		B324278125C841A600567504 /* WsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WsResponse.swift; sourceTree = "<group>"; };
 		B3242CCC246ABBAF00D8748F /* AnnotationsConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsConfig.swift; sourceTree = "<group>"; };
 		B3243BC72A5EB2740033A7D6 /* HtmlAttributedStringConverterSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HtmlAttributedStringConverterSpec.swift; sourceTree = "<group>"; };
-		B325C4092A7A8DE0008A2F11 /* CustomFreeTextAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFreeTextAnnotationView.swift; sourceTree = "<group>"; };
+		B325C4092A7A8DE0008A2F11 /* FreeTextAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTextAnnotationView.swift; sourceTree = "<group>"; };
 		B325DBAB24374F4600EFF0F5 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		B325DBAE24375D8D00EFF0F5 /* Conflict.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Conflict.swift; sourceTree = "<group>"; };
 		B325DBB124375DAC00EFF0F5 /* ConflictResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictResolution.swift; sourceTree = "<group>"; };
@@ -2976,7 +2976,7 @@
 				B340ECA5290FDC9F00EE920D /* AnnotationToolbarViewController.swift */,
 				B38B24B826E7664400BDD1BB /* AnnotationToolOptionsViewController.swift */,
 				B33AB487246D315F00490DDE /* CheckboxButton.swift */,
-				B325C4092A7A8DE0008A2F11 /* CustomFreeTextAnnotationView.swift */,
+				B325C4092A7A8DE0008A2F11 /* FreeTextAnnotationView.swift */,
 				B3A95DA929194BDE00BCCF11 /* DashedView.swift */,
 				B3756E8E2B835BDC0001CD0A /* IntraDocumentNavigationButtonsHandler.swift */,
 				B31941DB24531F6600BF6296 /* PDFAnnotationsViewController.swift */,
@@ -4982,7 +4982,7 @@
 				B3A47C3629015FCE00E7D90D /* TableOfContentsActionHandler.swift in Sources */,
 				B30565BE23FC051E003304F2 /* CreateItemFromDetailDbRequest.swift in Sources */,
 				B3593F77241A76E600760E20 /* CollectionEditActionHandler.swift in Sources */,
-				B325C40A2A7A8DE0008A2F11 /* CustomFreeTextAnnotationView.swift in Sources */,
+				B325C40A2A7A8DE0008A2F11 /* FreeTextAnnotationView.swift in Sources */,
 				B3BF7EE728A51BDC00A5A659 /* DeleteTagFromItemDbRequest.swift in Sources */,
 				B305661E23FC051E003304F2 /* DeleteGroupSyncAction.swift in Sources */,
 				B373877328FEA0C7004E5031 /* PDFSidebarViewController.swift in Sources */,

--- a/Zotero/Scenes/Detail/PDF/Views/FreeTextAnnotationView.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/FreeTextAnnotationView.swift
@@ -1,5 +1,5 @@
 //
-//  CustomFreeTextAnnotationView.swift
+//  FreeTextAnnotationView.swift
 //  Zotero
 //
 //  Created by Michal Rentka on 02.08.2023.
@@ -23,7 +23,7 @@ protocol FreeTextInputDelegate: AnyObject {
     func getTags(for key: PDFReaderState.AnnotationKey) -> [Tag]?
 }
 
-final class CustomFreeTextAnnotationView: FreeTextAnnotationView {
+final class FreeTextAnnotationView: PSPDFKitUI.FreeTextAnnotationView {
     var annotationKey: PDFReaderState.AnnotationKey?
     weak var delegate: FreeTextInputDelegate?
 

--- a/Zotero/Scenes/Detail/PDF/Views/FreeTextAnnotationView.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/FreeTextAnnotationView.swift
@@ -37,6 +37,22 @@ final class FreeTextAnnotationView: PSPDFKitUI.FreeTextAnnotationView {
     }
 }
 
+extension FreeTextAnnotationView {
+    override func textViewDidEndEditing(_ textView: UITextView) {
+        guard let annotation = annotation as? FreeTextAnnotation else { return }
+        let previousTextBoundingBox = annotation.textBoundingBox
+        super.textViewDidEndEditing(textView)
+        annotation.sizeToFit()
+        var newTextBoundingBox = annotation.textBoundingBox
+        let minX = min(previousTextBoundingBox.minX, newTextBoundingBox.minX)
+        let maxX = max(previousTextBoundingBox.maxX, newTextBoundingBox.maxX)
+        let minY = min(previousTextBoundingBox.minY, newTextBoundingBox.minY)
+        let maxY = max(previousTextBoundingBox.maxY, newTextBoundingBox.maxY)
+        annotation.textBoundingBox = CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+        NotificationCenter.default.post(name: .PSPDFAnnotationChanged, object: annotation, userInfo: [PSPDFAnnotationChangedNotificationKeyPathKey: ["boundingBox", "fontSize"]])
+    }
+}
+
 final class FreeTextInputAccessory: UIView {
     private weak var delegate: FreeTextInputDelegate?
     private weak var sizePicker: FontSizeView?

--- a/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
@@ -629,8 +629,9 @@ final class PDFDocumentViewController: UIViewController {
             builder.overrideClass(PSPDFKit.NoteAnnotation.self, with: NoteAnnotation.self)
             builder.overrideClass(PSPDFKit.SquareAnnotation.self, with: SquareAnnotation.self)
             builder.overrideClass(PSPDFKit.UnderlineAnnotation.self, with: UnderlineAnnotation.self)
-            builder.overrideClass(FreeTextAnnotationView.self, with: CustomFreeTextAnnotationView.self)
             builder.overrideClass(PSPDFKit.AnnotationManager.self, with: AnnotationManager.self)
+            builder.overrideClass(PSPDFKitUI.FreeTextAnnotationView.self, with: FreeTextAnnotationView.self)
+            builder.propertiesForAnnotations = [.freeText: []]
         }
 
         let controller = PDFViewController(document: document, configuration: pdfConfiguration)
@@ -736,7 +737,7 @@ extension PDFDocumentViewController: PDFViewControllerDelegate {
     ) -> UIMenu {
         guard let annotation = annotations.first,
               annotation.type == .freeText,
-              let annotationView = pageView.visibleAnnotationViews.first(where: { $0.annotation == annotation }) as? CustomFreeTextAnnotationView
+              let annotationView = pageView.visibleAnnotationViews.first(where: { $0.annotation == annotation }) as? FreeTextAnnotationView
         else { return UIMenu(children: []) }
 
         annotationView.delegate = self
@@ -744,7 +745,7 @@ extension PDFDocumentViewController: PDFViewControllerDelegate {
 
         if annotation.key != nil && self.selectedAnnotationWasSelectedBefore {
             // Focus only if Zotero annotation is selected, if annotation popup is dismissed and this annotation has been already selected
-            annotationView.beginEditing()
+            _ = annotationView.beginEditing()
         }
 
         self.selectedAnnotationWasSelectedBefore = false


### PR DESCRIPTION
Should improve sync between different clients, for those text annotations that are created in iOS.