### PR TITLE
Fix transformed annotation user

### DIFF
--- a/Zotero/Scenes/Detail/PDF/Models/PDFDatabaseAnnotation.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/PDFDatabaseAnnotation.swift
@@ -66,7 +66,6 @@ struct PDFDatabaseAnnotation {
             DDLogWarn("PDFDatabaseAnnotation: isAuthor for currentUserId: \(currentUserId) encountered nil user")
             return false
         }
-        DDLogInfo("PDFDatabaseAnnotation: isAuthor for currentUserId: \(currentUserId) compared to \(user.identifier)")
         return user.identifier == currentUserId
     }
 

--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
@@ -1370,7 +1370,7 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
         for annotation in finalAnnotations {
             if annotation.key == nil {
                 // We use the displayName, but if this is empty we use the username, which is what would be presented anyway.
-                // Since a username cannot be empty, we guarranty an non-empty annotation.user field.
+                // Since a username cannot be empty, we guarantee an non-empty annotation.user field.
                 annotation.user = viewModel.state.displayName.isEmpty ? viewModel.state.username : viewModel.state.displayName
                 annotation.customData = [AnnotationsConfig.keyKey: KeyGenerator.newKey]
             }

--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
@@ -1369,7 +1369,9 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
         let finalAnnotations = keptAsIs + toAdd
         for annotation in finalAnnotations {
             if annotation.key == nil {
-                annotation.user = viewModel.state.displayName
+                // We use the displayName, but if this is empty we use the username, which is what would be presented anyway.
+                // Since a username cannot be empty, we guarranty an non-empty annotation.user field.
+                annotation.user = viewModel.state.displayName.isEmpty ? viewModel.state.username : viewModel.state.displayName
                 annotation.customData = [AnnotationsConfig.keyKey: KeyGenerator.newKey]
             }
         }
@@ -1393,6 +1395,7 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
                     document.remove(annotations: needRemove, options: [.suppressNotifications: true])
                 }
                 // Transformed annotations need to be added, before they are converted, otherwise their document property is nil.
+                // Caution, if an annotation is added this way, with any empty string user, its user field will be converted to nil!
                 document.add(annotations: finalAnnotations, options: [.suppressNotifications: true])
             }
         }


### PR DESCRIPTION
Fixes issue reported in forum [post](https://forums.zotero.org/discussion/118984/autolocking-annotations-on-ipad)

When an annotation is transformed, e.g. due to overlapping rects or rects that need to be split, the new annotations are added using `document.add`. If these annotations have an empty string for the `user` field, the field is converted to `nil`. This will cause the PSPDFKIT annotation to be added in the database with `createdBy = nil`, until the next sync happens, that will assign the proper user.

Guarantying a non-empty `user` field, alleviates the issue. Alternatively, we can consider adding the `username` or event better the `userId`, in the annotation `customData`, and not rely at all to `user`.