### PR TITLE
Move fonts directory to bundled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,4 @@ bundled/translators
 bundled/styles
 bundled/locales
 bundled/note_editor
-fonts
+bundled/fonts

--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		618404262A4456A9005AAF22 /* IdentifierLookupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618404252A4456A9005AAF22 /* IdentifierLookupController.swift */; };
 		618D83E72BAAC88C00E7966B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 618D83E62BAAC88C00E7966B /* PrivacyInfo.xcprivacy */; };
 		618D83E82BAAC88C00E7966B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 618D83E62BAAC88C00E7966B /* PrivacyInfo.xcprivacy */; };
-		61975C422D38E6E8005BB41A /* fonts in Resources */ = {isa = PBXBuildFile; fileRef = 61975C412D38E6E8005BB41A /* fonts */; };
 		61A0C8472B8F669C0048FF92 /* PSPDFKitUI+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A0C8462B8F669B0048FF92 /* PSPDFKitUI+Extensions.swift */; };
 		61ABA7512A6137D1002A4219 /* ShareableImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61ABA7502A6137D1002A4219 /* ShareableImage.swift */; };
 		61BD13952A5831EF008A0704 /* TextKit1TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BD13942A5831EF008A0704 /* TextKit1TextView.swift */; };
@@ -4514,7 +4513,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				61975C422D38E6E8005BB41A /* fonts in Resources */,
 				B3593F33241A61C700760E20 /* ItemDetailNoteContentView.xib in Resources */,
 				618D83E72BAAC88C00E7966B /* PrivacyInfo.xcprivacy in Resources */,
 				B32A273D254841B80081E061 /* CreatorEditViewController.xib in Resources */,

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 # Download missing fonts (remove if fixed in PSPDFKit)
 font_url="https://raw.githubusercontent.com/notofonts/noto-cjk/refs/heads/main/google-fonts/NotoSansSC%5Bwght%5D.ttf"
-output_directory="../fonts"
+output_directory="../bundled/fonts"
 mkdir -p $output_directory
 output_filename="NotoSansSC[wght].ttf"
 output_path="$output_directory/$output_filename"


### PR DESCRIPTION
Moves `fonts` directory to `bundled`, as it streamlines more the project structure and fixes a github action issue.