### PR TITLE
Improve attachment move to/from parent actions

### DIFF
--- a/Zotero/Controllers/Database/Requests/CancelParentCreationDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/CancelParentCreationDbRequest.swift
@@ -18,9 +18,19 @@ struct CancelParentCreationDbRequest: DbRequest {
 
     func process(in database: Realm) throws {
         guard let item = database.objects(RItem.self).uniqueObject(key: key, libraryId: libraryId), item.parent != nil else { return }
+        let parentCollections = item.parent?.collections
         item.parent = nil
         let parentChange = item.changes.filter { change in
             return change.rawChanges == RItemChanges.parent.rawValue
+        }
+        // Move item back to removed parent's collections.
+        if let parentCollections, !parentCollections.isEmpty {
+            for collection in parentCollections {
+                if collection.items.filter(.key(key)).first == nil {
+                    collection.items.append(item)
+                    item.changes.append(RObjectChange.create(changes: RItemChanges.collections))
+                }
+            }
         }
         item.changesSyncPaused = false
         database.delete(parentChange)

--- a/Zotero/Controllers/Database/Requests/MoveItemsToParentDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/MoveItemsToParentDbRequest.swift
@@ -30,8 +30,15 @@ struct MoveItemsToParentDbRequest: DbRequest {
 
             if !item.collections.isEmpty {
                 for collection in item.collections {
-                    guard let index = collection.items.index(of: item) else { continue }
-                    collection.items.remove(at: index)
+                    // Remove item from this collection, if needed.
+                    if let index = collection.items.index(of: item) {
+                        collection.items.remove(at: index)
+                    }
+                    // Append parent to this collection, if needed.
+                    if collection.items.filter(.key(parent.key)).first == nil {
+                        collection.items.append(parent)
+                        parent.changes.append(RObjectChange.create(changes: RItemChanges.collections))
+                    }
                 }
                 changes.insert(.collections)
             }

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -414,16 +414,16 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
 
         controller.addAction(UIAlertAction(title: L10n.Items.new, style: .default, handler: { [weak self, weak viewModel] _ in
             guard let self, let viewModel else { return }
-            let collectionKey: String?
+            let collectionsSource: ItemDetailState.DetailType.CollectionsSource?
             switch viewModel.state.collection.identifier {
             case .collection(let key):
-                collectionKey = key
+                collectionsSource = .collectionKeys([key])
 
             case .search, .custom:
-                collectionKey = nil
+                collectionsSource = nil
             }
             showTypePicker(selected: "") { [weak self] type in
-                self?.showItemDetail(for: .creation(type: type, child: nil, collectionKey: collectionKey), libraryId: viewModel.state.library.identifier, scrolledToKey: nil, animated: true)
+                self?.showItemDetail(for: .creation(type: type, child: nil, collectionsSource: collectionsSource), libraryId: viewModel.state.library.identifier, scrolledToKey: nil, animated: true)
             }
         }))
 

--- a/Zotero/Scenes/Detail/ItemDetail/Models/ItemDetailState.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/Models/ItemDetailState.swift
@@ -25,7 +25,12 @@ struct ItemDetailState: ViewModelState {
     }
 
     enum DetailType {
-        case creation(type: String, child: Attachment?, collectionKey: String?)
+        enum CollectionsSource {
+            case collectionKeys([String])
+            case fromChildren
+        }
+
+        case creation(type: String, child: Attachment?, collectionsSource: CollectionsSource?)
         case duplication(itemKey: String, collectionKey: String?)
         case preview(key: String)
 

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -156,9 +156,8 @@ final class ItemsViewController: BaseItemsViewController {
 
         case .createParent:
             guard let key = selectedKeys.first, case .attachment(let attachment, _) = viewModel.state.itemAccessories[key] else { return }
-            let collectionKey = collection.identifier.key
             coordinatorDelegate?.showItemDetail(
-                for: .creation(type: ItemTypes.document, child: attachment, collectionKey: collectionKey),
+                for: .creation(type: ItemTypes.document, child: attachment, collectionsSource: .fromChildren),
                 libraryId: library.identifier,
                 scrolledToKey: nil,
                 animated: true


### PR DESCRIPTION
Modifies these item actions to be in sync with the desktop implementations:
* Move item to an existing parent, by drag and drop.
* Move item to manually created parent. This action can be canceled. 
* Remove item atttachment from its parent, back to a standalone item.