### PR TITLE
Allow Insecure HTTP for Reserved IP addresses (not covered by NSAllowsLocalNetworking)

### DIFF
--- a/Zotero/Info.plist
+++ b/Zotero/Info.plist
@@ -56,6 +56,11 @@
 				<key>NSIncludesSubdomains</key>
 				<true/>
 			</dict>
+			<key>100.64.0.0/10</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
 		</dict>
 	</dict>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
Allow Insecure HTTP for Reserved IP addresses (not covered by NSAllowsLocalNetworking)
When using private networking software, this option is required to allow intranet HTTP traffic.