### PR TITLE
Refactor citation controller

### DIFF
--- a/ZShare/Controllers/TranslationWebViewHandler.swift
+++ b/ZShare/Controllers/TranslationWebViewHandler.swift
@@ -50,22 +50,21 @@ final class TranslationWebViewHandler {
     }
 
     private let webViewHandler: WebViewHandler
-    let translatorsController: TranslatorsAndStylesController
+    private let translatorsController: TranslatorsAndStylesController
     private let disposeBag: DisposeBag
     let observable: PublishSubject<Action>
 
-    private var webDidLoad: ((SingleEvent<()>) -> Void)?
     private var itemSelectionMessageId: Int?
 
     // MARK: - Lifecycle
 
     init(webView: WKWebView, translatorsController: TranslatorsAndStylesController) {
-        self.webViewHandler = WebViewHandler(webView: webView, javascriptHandlers: JSHandlers.allCases.map({ $0.rawValue }))
-        self.disposeBag = DisposeBag()
+        webViewHandler = WebViewHandler(webView: webView, javascriptHandlers: JSHandlers.allCases.map({ $0.rawValue }))
+        disposeBag = DisposeBag()
         self.translatorsController = translatorsController
-        self.observable = PublishSubject()
+        observable = PublishSubject()
 
-        self.webViewHandler.receivedMessageHandler = { [weak self] name, body in
+        webViewHandler.receivedMessageHandler = { [weak self] name, body in
             self?.receiveMessage(name: name, body: body)
         }
     }
@@ -73,43 +72,39 @@ final class TranslationWebViewHandler {
     // MARK: - Actions
 
     func loadWebData(from url: URL) -> Single<ExtensionViewModel.State.RawAttachment> {
-        DDLogInfo("WebViewHandler: load web data")
+        DDLogInfo("TranslationWebViewHandler: load web data")
+        return webViewHandler.load(webUrl: url)
+            .flatMap { _ -> Single<Any> in
+                guard let url = Bundle.main.url(forResource: "webview_extraction", withExtension: "js"), let script = try? String(contentsOf: url) else {
+                    DDLogError("TranslationWebViewHandler: can't load extraction javascript")
+                    return .error(Error.webExtractionMissingJs)
+                }
+                DDLogInfo("TranslationWebViewHandler: call data extraction js")
+                return self.webViewHandler.call(javascript: script)
+            }
+            .flatMap { data -> Single<ExtensionViewModel.State.RawAttachment> in
+                guard let payload = data as? [String: Any],
+                      let isFile = payload["isFile"] as? Bool,
+                      let cookies = payload["cookies"] as? String,
+                      let userAgent = payload["userAgent"] as? String,
+                      let referrer = payload["referrer"] as? String else {
+                    DDLogError("TranslationWebViewHandler: extracted data missing response")
+                    DDLogError("\(String(describing: data as? [String: Any]))")
+                    return .error(Error.webExtractionMissingData)
+                }
 
-        return self.webViewHandler.load(webUrl: url)
-                   .flatMap({ _ -> Single<Any> in
-                       guard let url = Bundle.main.url(forResource: "webview_extraction", withExtension: "js"),
-                             let script = try? String(contentsOf: url) else {
-                           DDLogError("WebViewHandler: can't load extraction javascript")
-                           return Single.error(Error.webExtractionMissingJs)
-                       }
-                       DDLogInfo("WebViewHandler: call data extraction js")
-                       return self.webViewHandler.call(javascript: script)
-                   })
-                   .flatMap({ data -> Single<ExtensionViewModel.State.RawAttachment> in
-                       guard let payload = data as? [String: Any],
-                             let isFile = payload["isFile"] as? Bool,
-                             let cookies = payload["cookies"] as? String,
-                             let userAgent = payload["userAgent"] as? String,
-                             let referrer = payload["referrer"] as? String else {
-                           DDLogError("WebViewHandler: extracted data missing response")
-                           DDLogError("\(String(describing: data as? [String: Any]))")
-                           return Single.error(Error.webExtractionMissingData)
-                       }
-
-                       if isFile, let contentType = payload["contentType"] as? String {
-                           DDLogInfo("WebViewHandler: extracted file")
-                           return Single.just(.remoteFileUrl(url: url, contentType: contentType, cookies: cookies, userAgent: userAgent, referrer: referrer))
-                       } else if let title = payload["title"] as? String,
-                                 let html = payload["html"] as? String,
-                                 let frames = payload["frames"] as? [String] {
-                           DDLogInfo("WebViewHandler: extracted html")
-                           return Single.just(.web(title: title, url: url, html: html, cookies: cookies, frames: frames, userAgent: userAgent, referrer: referrer))
-                       } else {
-                           DDLogError("WebViewHandler: extracted data incompatible")
-                           DDLogError("\(payload)")
-                           return Single.error(Error.webExtractionMissingData)
-                       }
-                   })
+                if isFile, let contentType = payload["contentType"] as? String {
+                    DDLogInfo("TranslationWebViewHandler: extracted file")
+                    return .just(.remoteFileUrl(url: url, contentType: contentType, cookies: cookies, userAgent: userAgent, referrer: referrer))
+                } else if let title = payload["title"] as? String, let html = payload["html"] as? String, let frames = payload["frames"] as? [String] {
+                    DDLogInfo("TranslationWebViewHandler: extracted html")
+                    return .just(.web(title: title, url: url, html: html, cookies: cookies, frames: frames, userAgent: userAgent, referrer: referrer))
+                } else {
+                    DDLogError("TranslationWebViewHandler: extracted data incompatible")
+                    DDLogError("\(payload)")
+                    return .error(Error.webExtractionMissingData)
+                }
+            }
     }
 
     /// Runs translation server against html content with cookies. Results are then provided through observable publisher.
@@ -119,81 +114,79 @@ final class TranslationWebViewHandler {
     /// - parameter cookies: Cookies string from shared website. Equals to javacsript "document.cookie".
     /// - parameter frames: HTML content of frames contained in initial HTML document.
     func translate(url: URL, title: String, html: String, cookies: String, frames: [String], userAgent: String, referrer: String) {
-        DDLogInfo("WebViewHandler: translate")
+        DDLogInfo("TranslationWebViewHandler: translate")
+        webViewHandler.set(cookies: cookies, userAgent: userAgent, referrer: referrer)
+        return loadIndex()
+            .flatMap { _ -> Single<(String, String)> in
+                return loadBundledFiles()
+            }
+            .flatMap { encodedSchema, encodedDateFormats -> Single<Any> in
+                return self.webViewHandler.call(javascript: "initSchemaAndDateFormats(\(encodedSchema), \(encodedDateFormats));")
+            }
+            .flatMap { _ -> Single<[RawTranslator]> in
+                DDLogInfo("TranslationWebViewHandler: load translators")
+                return self.translatorsController.translators(matching: url.absoluteString)
+            }
+            .flatMap { translators -> Single<Any> in
+                DDLogInfo("TranslationWebViewHandler: encode translators")
+                let encodedTranslators = WebViewEncoder.encodeAsJSONForJavascript(translators)
+                return self.webViewHandler.call(javascript: "initTranslators(\(encodedTranslators));")
+            }
+            .flatMap({ _ -> Single<Any> in
+                DDLogInfo("TranslationWebViewHandler: call translate js")
+                let encodedHtml = WebViewEncoder.encodeForJavascript(html.data(using: .utf8))
+                let jsonFramesData = try? JSONSerialization.data(withJSONObject: frames, options: .fragmentsAllowed)
+                let encodedFrames = jsonFramesData.flatMap({ WebViewEncoder.encodeForJavascript($0) }) ?? "''"
+                return self.webViewHandler.call(javascript: "translate('\(url.absoluteString)', \(encodedHtml), \(encodedFrames));")
+            })
+            .subscribe(onFailure: { [weak self] error in
+                DDLogError("TranslationWebViewHandler: translation failed - \(error)")
+                self?.observable.on(.error(error))
+            })
+            .disposed(by: disposeBag)
 
-        self.webViewHandler.set(cookies: cookies, userAgent: userAgent, referrer: referrer)
+        func loadIndex() -> Single<()> {
+            guard let indexUrl = Bundle.main.url(forResource: "index", withExtension: "html", subdirectory: "translation") else {
+                return .error(Error.cantFindFile)
+            }
+            return webViewHandler.load(fileUrl: indexUrl)
+        }
 
-        return self.loadIndex()
-                   .flatMap { _ -> Single<(String, String)> in
-                       return self.loadBundledFiles()
-                   }
-                   .flatMap { encodedSchema, encodedDateFormats -> Single<Any> in
-                       return self.webViewHandler.call(javascript: "initSchemaAndDateFormats(\(encodedSchema), \(encodedDateFormats));")
-                   }
-                   .flatMap { _ -> Single<[RawTranslator]> in
-                       DDLogInfo("WebViewHandler: load translators")
-                       return self.translatorsController.translators(matching: url.absoluteString)
-                   }
-                   .flatMap { translators -> Single<Any> in
-                       DDLogInfo("WebViewHandler: encode translators")
-                       let encodedTranslators = WebViewEncoder.encodeAsJSONForJavascript(translators)
-                       return self.webViewHandler.call(javascript: "initTranslators(\(encodedTranslators));")
-                   }
-                   .flatMap({ _ -> Single<Any> in
-                       DDLogInfo("WebViewHandler: call translate js")
-                       let encodedHtml = WebViewEncoder.encodeForJavascript(html.data(using: .utf8))
-                       let jsonFramesData = try? JSONSerialization.data(withJSONObject: frames, options: .fragmentsAllowed)
-                       let encodedFrames = jsonFramesData.flatMap({ WebViewEncoder.encodeForJavascript($0) }) ?? "''"
-                       return self.webViewHandler.call(javascript: "translate('\(url.absoluteString)', \(encodedHtml), \(encodedFrames));")
-                   })
-                   .subscribe(onFailure: { [weak self] error in
-                       DDLogError("WebViewHandler: translation failed - \(error)")
-                       self?.observable.on(.error(error))
-                   })
-                   .disposed(by: self.disposeBag)
-    }
+        func loadBundledFiles() -> Single<(String, String)> {
+            return .create { subscriber in
+                guard let schemaUrl = Bundle.main.url(forResource: "schema", withExtension: "json", subdirectory: "Bundled"), let schemaData = try? Data(contentsOf: schemaUrl) else {
+                    DDLogError("TranslationWebViewHandler: can't load schema json")
+                    subscriber(.failure(Error.cantFindFile))
+                    return Disposables.create()
+                }
 
-    private func loadBundledFiles() -> Single<(String, String)> {
-        return Single.create { subscriber in
-            guard let schemaUrl = Bundle.main.url(forResource: "schema", withExtension: "json", subdirectory: "Bundled"),
-                  let schemaData = try? Data(contentsOf: schemaUrl) else {
-                DDLogError("WebViewHandler: can't load schema json")
-                subscriber(.failure(Error.cantFindFile))
+                guard let dateFormatsUrl = Bundle.main.url(forResource: "dateFormats", withExtension: "json", subdirectory: "translation/translate/modules/utilities/resource"),
+                      let dateFormatData = try? Data(contentsOf: dateFormatsUrl)
+                else {
+                    DDLogError("TranslationWebViewHandler: can't load dateFormats json")
+                    subscriber(.failure(Error.cantFindFile))
+                    return Disposables.create()
+                }
+
+                let encodedSchema = WebViewEncoder.encodeForJavascript(schemaData)
+                let encodedFormats = WebViewEncoder.encodeForJavascript(dateFormatData)
+
+                DDLogInfo("TranslationWebViewHandler: loaded bundled files")
+
+                subscriber(.success((encodedSchema, encodedFormats)))
+
                 return Disposables.create()
             }
-
-            guard let dateFormatsUrl = Bundle.main.url(forResource: "dateFormats", withExtension: "json", subdirectory: "translation/translate/modules/utilities/resource"),
-                  let dateFormatData = try? Data(contentsOf: dateFormatsUrl) else {
-                DDLogError("WebViewHandler: can't load dateFormats json")
-                subscriber(.failure(Error.cantFindFile))
-                return Disposables.create()
-            }
-
-            let encodedSchema = WebViewEncoder.encodeForJavascript(schemaData)
-            let encodedFormats = WebViewEncoder.encodeForJavascript(dateFormatData)
-
-            DDLogInfo("WebViewHandler: loaded bundled files")
-
-            subscriber(.success((encodedSchema, encodedFormats)))
-
-            return Disposables.create()
         }
     }
 
     /// Sends selected item back to `webView`.
     /// - parameter item: Selected item by the user.
     func selectItem(_ item: (String, String)) {
-        guard let messageId = self.itemSelectionMessageId else { return }
+        guard let messageId = itemSelectionMessageId else { return }
         let (key, value) = item
-        self.webViewHandler.sendMessaging(response: [key: value], for: messageId)
-        self.itemSelectionMessageId = nil
-    }
-
-    private func loadIndex() -> Single<()> {
-        guard let indexUrl = Bundle.main.url(forResource: "index", withExtension: "html", subdirectory: "translation") else {
-            return Single.error(Error.cantFindFile)
-        }
-        return self.webViewHandler.load(fileUrl: indexUrl)
+        webViewHandler.sendMessaging(response: [key: value], for: messageId)
+        itemSelectionMessageId = nil
     }
 
     // MARK: - Messaging
@@ -205,33 +198,31 @@ final class TranslationWebViewHandler {
 
         switch handler {
         case .request:
-            guard let body = body as? [String: Any],
-                  let messageId = body["messageId"] as? Int else {
+            guard let body = body as? [String: Any], let messageId = body["messageId"] as? Int else {
                 DDLogError("TranslationWebViewHandler: request missing body - \(body)")
                 return
             }
 
             if let options = body["payload"] as? [String: Any] {
                 do {
-                    try self.webViewHandler.sendRequest(with: options, for: messageId)
+                    try webViewHandler.sendRequest(with: options, for: messageId)
                 } catch let error {
                     DDLogError("TranslationWebViewHandler: send request error \(error)")
-                    self.observable.on(.error(Error.noSuccessfulTranslators))
+                    observable.on(.error(Error.noSuccessfulTranslators))
                 }
             } else {
                 DDLogError("TranslationWebViewHandler: request missing payload - \(body)")
-                self.webViewHandler.sendMessaging(error: "HTTP request missing payload", for: messageId)
+                webViewHandler.sendMessaging(error: "HTTP request missing payload", for: messageId)
             }
 
         case .itemSelection:
-            guard let body = body as? [String: Any],
-                  let messageId = body["messageId"] as? Int else {
+            guard let body = body as? [String: Any], let messageId = body["messageId"] as? Int else {
                 DDLogError("TranslationWebViewHandler: item selection missing body - \(body)")
                 return
             }
 
             if let payload = body["payload"] as? [[String]] {
-                self.itemSelectionMessageId = messageId
+                itemSelectionMessageId = messageId
 
                 var sortedDictionary: [(String, String)] = []
                 for data in payload {
@@ -239,37 +230,37 @@ final class TranslationWebViewHandler {
                     sortedDictionary.append((data[0], data[1]))
                 }
 
-                self.observable.on(.next(.selectItem(sortedDictionary)))
+                observable.on(.next(.selectItem(sortedDictionary)))
             } else {
                 DDLogError("TranslationWebViewHandler: item selection missing payload - \(body)")
-                self.webViewHandler.sendMessaging(error: "Item selection missing payload", for: messageId)
+                webViewHandler.sendMessaging(error: "Item selection missing payload", for: messageId)
             }
 
         case .item:
             if let info = body as? [[String: Any]] {
-                self.observable.on(.next(.loadedItems(data: info, cookies: self.webViewHandler.cookies, userAgent: self.webViewHandler.userAgent, referrer: self.webViewHandler.referer)))
+                observable.on(.next(.loadedItems(data: info, cookies: webViewHandler.cookies, userAgent: webViewHandler.userAgent, referrer: webViewHandler.referer)))
             } else {
                 DDLogError("TranslationWebViewHandler: got incompatible body - \(body)")
-                self.observable.on(.error(Error.incompatibleItem))
+                observable.on(.error(Error.incompatibleItem))
             }
 
         case .progress:
             if let progress = body as? String {
                 if progress == "item_selection" {
-                    self.observable.on(.next(.reportProgress(L10n.Shareext.Translation.itemSelection)))
+                    observable.on(.next(.reportProgress(L10n.Shareext.Translation.itemSelection)))
                 } else if progress.starts(with: "translating_with_") {
                     let name = progress[progress.index(progress.startIndex, offsetBy: 17)..<progress.endIndex]
-                    self.observable.on(.next(.reportProgress(L10n.Shareext.Translation.translatingWith(name))))
+                    observable.on(.next(.reportProgress(L10n.Shareext.Translation.translatingWith(name))))
                 } else {
-                    self.observable.on(.next(.reportProgress(progress)))
+                    observable.on(.next(.reportProgress(progress)))
                 }
             }
 
         case .saveAsWeb:
-            self.observable.on(.error(Error.noSuccessfulTranslators))
+            observable.on(.error(Error.noSuccessfulTranslators))
 
         case .log:
-            DDLogInfo("JSLOG: \(body)")
+            DDLogInfo("TranslationWebViewHandler: JSLOG - \(body)")
         }
     }
 }

--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		61C817F22A49B5D30085B1E6 /* CollectionResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1EDEE250242E700D8BC1E /* CollectionResponseSpec.swift */; };
 		61DE64D52C5BD0250096776C /* FormattedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DE64D42C5BD0250096776C /* FormattedTextView.swift */; };
 		61E24DCC2ABB385E00D75F50 /* OpenItemsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E24DCB2ABB385E00D75F50 /* OpenItemsController.swift */; };
+		61E3CD502D9545DF00ACA004 /* CitationWebViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E3CD4F2D9545DF00ACA004 /* CitationWebViewHandler.swift */; };
 		61FA14CE2B05081D00E7D423 /* TextConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FA14CD2B05081D00E7D423 /* TextConverter.swift */; };
 		61FA14D02B08E24A00E7D423 /* ColorPickerStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FA14CF2B08E24A00E7D423 /* ColorPickerStackView.swift */; };
 		B300B33324291C8D00C1FE1E /* RTranslatorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = B300B33224291C8D00C1FE1E /* RTranslatorMetadata.swift */; };
@@ -1321,6 +1322,7 @@
 		61C122E92D91BBC9004AC0C7 /* BackForwardActionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackForwardActionList.swift; sourceTree = "<group>"; };
 		61DE64D42C5BD0250096776C /* FormattedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattedTextView.swift; sourceTree = "<group>"; };
 		61E24DCB2ABB385E00D75F50 /* OpenItemsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenItemsController.swift; sourceTree = "<group>"; };
+		61E3CD4F2D9545DF00ACA004 /* CitationWebViewHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CitationWebViewHandler.swift; sourceTree = "<group>"; };
 		61FA14CD2B05081D00E7D423 /* TextConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextConverter.swift; sourceTree = "<group>"; };
 		61FA14CF2B08E24A00E7D423 /* ColorPickerStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerStackView.swift; sourceTree = "<group>"; };
 		B300B33224291C8D00C1FE1E /* RTranslatorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTranslatorMetadata.swift; sourceTree = "<group>"; };
@@ -3608,6 +3610,7 @@
 		B39E0130283276470091CE4A /* Web View Handling */ = {
 			isa = PBXGroup;
 			children = (
+				61E3CD4F2D9545DF00ACA004 /* CitationWebViewHandler.swift */,
 				B323703F2C0DC65600170779 /* LookupWebViewHandler.swift */,
 				B39E0131283276830091CE4A /* WebViewHandler.swift */,
 			);
@@ -5039,6 +5042,7 @@
 				B36C508E2575221C00A370D3 /* AnnotationEditState.swift in Sources */,
 				B34DF1A825768AAC0019CCD1 /* AnnotationPageLabelActionHandler.swift in Sources */,
 				B30548F82B331B2500853966 /* DeleteDownloadDbRequest.swift in Sources */,
+				61E3CD502D9545DF00ACA004 /* CitationWebViewHandler.swift in Sources */,
 				B30565D523FC051E003304F2 /* MarkCollectionAndItemsAsDeletedDbRequest.swift in Sources */,
 				B3235C9224ADE11E0034113B /* StringAttributes.swift in Sources */,
 				B3D58D6B25EE437700D8FA31 /* CircularProgressView.swift in Sources */,

--- a/Zotero/Controllers/Citation/CitationController.swift
+++ b/Zotero/Controllers/Citation/CitationController.swift
@@ -25,6 +25,18 @@ private struct StyleData {
 }
 
 class CitationController: NSObject {
+    struct Session: Hashable {
+        let id = UUID()
+        let itemIds: Set<String>
+        let libraryId: LibraryIdentifier
+
+        let styleXML: String
+        let styleLocaleId: String
+        let localeXML: String
+        let supportsBibliography: Bool
+        var itemsCSL: String
+    }
+
     enum Format: String {
         case html
         case text
@@ -32,8 +44,9 @@ class CitationController: NSObject {
     }
 
     enum Error: Swift.Error {
+        case webViewNotProvided
         case styleOrLocaleMissing
-        case prepareNotCalled
+        case invalidSession
         case cantFindFile
         case invalidItemTypes
     }
@@ -45,14 +58,8 @@ class CitationController: NSObject {
     private unowned let bundledDataStorage: DbStorage
     private let backgroundQueue: DispatchQueue
     private let backgroundScheduler: SerialDispatchQueueScheduler
-    private var citationWebViewHandler: CitationWebViewHandler?
-
-    // Store temporary data for citation preview so that they don't need to be reloaded for each preview generation.
-    private var styleXml: String?
-    private var localeId: String?
-    private var localeXml: String?
-    private var itemsCsl: String?
-    private var supportsBibliography: Bool?
+    weak var webViewProvider: WebViewProvider?
+    private var citationWebViewHandlerBySession: [Session: CitationWebViewHandler] = [:]
 
     init(stylesController: TranslatorsAndStylesController, fileStorage: FileStorage, dbStorage: DbStorage, bundledDataStorage: DbStorage) {
         let queue = DispatchQueue(label: "org.zotero.CitationController.queue", qos: .userInitiated)
@@ -67,54 +74,200 @@ class CitationController: NSObject {
 
     // MARK: - Actions
 
-    /// Pre-loads given webView in a CitationWebViewHandler, so that it's ready immediately for citation/bibliography generation.
+    /// Starts citation session by creating a CitationWebViewHandler, that it's ready immediately for citation/bibliography generation.
     /// - parameter itemIds: Ids of items for which CSL will be generated.
     /// - parameter libraryId: Library identifier of given items.
     /// - parameter styleId: Id of style to use for citation/bibliography generation.
     /// - parameter localeId: Id of locale to use for citation/bibliography generation.
-    /// - returns: Single which is called when webView is fully loaded.
-    func prepare(webView: WKWebView, for itemIds: Set<String>, libraryId: LibraryIdentifier, styleId: String, localeId: String) -> Single<()> {
+    /// - parameter webView: Optional web view for theCitationWebViewHandler. If nil one from the web view provider is requested.
+    /// - returns: Single with the session that is called when webView is fully loaded.
+    func startSession(for itemIds: Set<String>, libraryId: LibraryIdentifier, styleId: String, localeId: String, webView: WKWebView? = nil) -> Single<Session> {
+        guard let webView = webView ?? webViewProvider?.addWebView(configuration: nil) else {
+            return .error(Error.webViewNotProvided)
+        }
         let citationWebViewHandler = CitationWebViewHandler(webView: webView)
-        self.citationWebViewHandler = citationWebViewHandler
-
         return loadStyleData(for: styleId)
             .subscribe(on: backgroundScheduler)
             .observe(on: backgroundScheduler)
-            .flatMap({ styleData -> Single<(String, String, String, Bool)> in
+            .flatMap { styleData -> Single<(String, String, String, Bool)> in
                 let styleLocaleId = styleData.defaultLocaleId ?? localeId
-                return self.loadEncodedXmls(styleFilename: styleData.filename, localeId: styleLocaleId).flatMap({ .just(($0.0, $0.1, styleLocaleId, styleData.supportsBibliography)) })
-            })
-            .do(onSuccess: { styleXml, localeXml, localeId, supportsBibliography in
-                self.styleXml = styleXml
-                self.localeId = localeId
-                self.localeXml = localeXml
-                self.supportsBibliography = supportsBibliography
-            })
-            .flatMap({ _ -> Single<(String, String)> in
-                return self.loadBundledFiles()
-            })
-            .flatMap({ schema, dateFormats -> Single<(String, String, String)> in
-                return self.loadItemJsons(for: itemIds, libraryId: libraryId).flatMap({ .just((schema, dateFormats, $0)) })
-            })
-            .flatMap({ schema, dateFormats, itemJsons -> Single<String> in
-                return citationWebViewHandler.getItemsCsl(from: itemJsons, schema: schema, dateFormats: dateFormats)
-            })
-            .do(onSuccess: { itemsCsl in
-                self.itemsCsl = itemsCsl
-            })
-            .flatMap({ _ in return .just(()) })
+                return loadEncodedXmls(styleFilename: styleData.filename, localeId: styleLocaleId).flatMap { .just(($0.0, styleLocaleId, $0.1, styleData.supportsBibliography)) }
+            }
+            .flatMap { styleXML, styleLocaleId, localeXML, supportsBibliography -> Single<(String, String, String, Bool, String, String)> in
+                return loadBundledFiles().flatMap { .just((styleXML, styleLocaleId, localeXML, supportsBibliography, $0, $1)) }
+            }
+            .flatMap { styleXML, styleLocaleId, localeXML, supportsBibliography, schema, dateFormats -> Single<(String, String, String, Bool, String, String, String)> in
+                return loadItemJsons(for: itemIds, libraryId: libraryId)
+                    .flatMap { .just((styleXML, styleLocaleId, localeXML, supportsBibliography, schema, dateFormats, $0)) }
+            }
+            .flatMap { styleXML, styleLocaleId, localeXML, supportsBibliography, schema, dateFormats, itemJsons -> Single<(String, String, String, Bool, String)> in
+                return citationWebViewHandler.getItemsCSL(from: itemJsons, schema: schema, dateFormats: dateFormats)
+                    .flatMap { .just((styleXML, styleLocaleId, localeXML, supportsBibliography, $0)) }
+            }
+            .flatMap { styleXML, styleLocaleId, localeXML, supportsBibliography, itemCSL -> Single<Session> in
+                let session = Session(
+                    itemIds: itemIds,
+                    libraryId: libraryId,
+                    styleXML: styleXML,
+                    styleLocaleId: styleLocaleId,
+                    localeXML: localeXML,
+                    supportsBibliography: supportsBibliography,
+                    itemsCSL: itemCSL
+                )
+                self.citationWebViewHandlerBySession[session] = citationWebViewHandler
+                return .just(session)
+            }
+
+        /// Loads style data.
+        /// - parameter styleId: Identifier of style
+        /// - returns: Style data.
+        func loadStyleData(for styleId: String) -> Single<StyleData> {
+            return .create { subscriber in
+                do {
+                    let style = try self.bundledDataStorage.perform(request: ReadStyleDbRequest(identifier: styleId), on: self.backgroundQueue)
+                    let data = StyleData(style: style)
+                    style.realm?.invalidate()
+                    subscriber(.success(data))
+                } catch let error {
+                    DDLogError("CitationController: can't load style - \(error)")
+                    subscriber(.failure(Error.styleOrLocaleMissing))
+                }
+                return Disposables.create()
+            }
+        }
+
+        func loadEncodedXmls(styleFilename: String, localeId: String) -> Single<(String, String)> {
+            return .create { subscriber in
+                guard let localeUrl = Bundle.main.url(forResource: "locales-\(localeId)", withExtension: "xml", subdirectory: "Bundled/locales") else {
+                    DDLogError("CitationController: can't load locale xml")
+                    subscriber(.failure(Error.styleOrLocaleMissing))
+                    return Disposables.create()
+                }
+
+                do {
+                    let localeData = try Data(contentsOf: localeUrl)
+                    let styleData = try self.fileStorage.read(Files.style(filename: styleFilename))
+
+                    subscriber(.success((WebViewEncoder.encodeForJavascript(styleData), WebViewEncoder.encodeForJavascript(localeData))))
+                } catch let error {
+                    DDLogError("CitationController: can't read locale or style - \(error)")
+                    subscriber(.failure(Error.styleOrLocaleMissing))
+                }
+
+                return Disposables.create()
+            }
+        }
+
+        func loadBundledFiles() -> Single<(String, String)> {
+            return .create { subscriber in
+                guard let schemaPath = Bundle.main.path(forResource: "citation/utilities/resource/schema/global/schema", ofType: "json"),
+                      let schemaData = try? Data(contentsOf: URL(fileURLWithPath: schemaPath))
+                else {
+                    subscriber(.failure(Error.cantFindFile))
+                    return Disposables.create()
+                }
+                guard let dateFormatsPath = Bundle.main.path(forResource: "citation/utilities/resource/dateFormats", ofType: "json"),
+                      let dateFormatsData = try? Data(contentsOf: URL(fileURLWithPath: dateFormatsPath))
+                else {
+                    subscriber(.failure(Error.cantFindFile))
+                    return Disposables.create()
+                }
+
+                let encodedSchema = WebViewEncoder.encodeForJavascript(schemaData)
+                let encodedFormats = WebViewEncoder.encodeForJavascript(dateFormatsData)
+                subscriber(.success((encodedSchema, encodedFormats)))
+                return Disposables.create()
+            }
+        }
+
+        func loadItemJsons(for keys: Set<String>, libraryId: LibraryIdentifier) -> Single<String> {
+            return .create { subscriber in
+                do {
+                    let items = try self.dbStorage.perform(request: ReadItemsWithKeysDbRequest(keys: keys, libraryId: libraryId), on: self.backgroundQueue)
+                        .filter(.item(notTypeIn: CitationController.invalidItemTypes))
+
+                    if items.isEmpty {
+                        subscriber(.failure(Error.invalidItemTypes))
+                        return Disposables.create()
+                    }
+
+                    let data = Array(items.map({ data(for: $0) }))
+
+                    items.first?.realm?.invalidate()
+
+                    subscriber(.success(WebViewEncoder.encodeAsJSONForJavascript(data)))
+                } catch let error {
+                    DDLogError("CitationController: can't read items - \(error)")
+                    subscriber(.failure(error))
+                }
+
+                return Disposables.create()
+            }
+
+            func data(for item: RItem) -> [String: Any] {
+                var data: [String: Any] = [:]
+
+                // Add all fields
+                for field in item.fields {
+                    data[field.key] = field.value
+                }
+
+                // Add creators
+                var creators: [[String: Any]] = []
+                for rCreator in item.creators.sorted(byKeyPath: "orderId") {
+                    var creator: [String: Any] = ["creatorType": rCreator.rawType]
+                    if !rCreator.name.isEmpty {
+                        creator["name"] = rCreator.name
+                    } else {
+                        creator["firstName"] = rCreator.firstName
+                        creator["lastName"] = rCreator.lastName
+                    }
+                    creators.append(creator)
+                }
+                data["creators"] = creators
+
+                // Add relations
+                var relations: [[String: Any]] = []
+                for rRelation in item.relations {
+                    guard !rRelation.urlString.isEmpty else { continue }
+
+                    let urls = rRelation.urlString.components(separatedBy: ";").filter({ !$0.isEmpty })
+                    var relation: [String: Any] = [:]
+
+                    if urls.count == 1, let url = urls.first {
+                        relation[rRelation.type] = url
+                    } else {
+                        relation[rRelation.type] = urls
+                    }
+                    relations.append(relation)
+                }
+                data["relations"] = relations
+
+                // Add remaining data
+                data["key"] = item.key
+                data["itemType"] = item.rawType
+                data["version"] = item.version
+                if let key = item.parent?.key {
+                    data["parentItem"] = key
+                }
+                data["dateAdded"] = Formatter.iso8601.string(from: item.dateAdded)
+                data["dateModified"] = Formatter.iso8601.string(from: item.dateModified)
+                data["uri"] = "https://www.zotero.org/\(item.key)"
+                data["inPublications"] = item.inPublications
+                data["collections"] = [] as [Any]
+                data["tags"] = [] as [Any]
+
+                return data
+            }
+        }
     }
 
     /// Cleans up after citeproc-js is finished. Should be called when all requests are called.
-    func finishCitation() {
-        self.localeXml = nil
-        self.localeId = nil
-        self.styleXml = nil
-        self.itemsCsl = nil
-        self.supportsBibliography = nil
+    func endSession(_ session: Session) {
+        citationWebViewHandlerBySession.removeValue(forKey: session)?.webViewHandler.removeFromSuperviewAsynchronously()
     }
 
-    /// Generates citation preview for given item in given format. Has to be called after `prepareForCitation(styleId:localeId:in:)` finishes!
+    /// Generates citation preview for given citation session, in given format. Has to be called after session has started.
     /// - parameter itemIds: Ids of items of which citation is created.
     /// - parameter libraryId: Id of library for given items.
     /// - parameter label: Label for locator which should be used.
@@ -123,11 +276,20 @@ class CitationController: NSObject {
     /// - parameter format: Format in which citation is generated.
     /// - parameter showInWebView: If true, shows generated result in webView body. If false, just returns generated result through handlers.
     /// - returns: Single with generated citation.
-    func citation(for itemIds: Set<String>, label: String?, locator: String?, omitAuthor: Bool, format: Format, showInWebView: Bool) -> Single<String> {
-        guard let styleXml, let localeId, let localeXml, let itemsCsl, let citationWebViewHandler else { return .error(Error.prepareNotCalled) }
+    func citation(for session: Session, itemIds: Set<String>? = nil, label: String?, locator: String?, omitAuthor: Bool, format: Format, showInWebView: Bool) -> Single<String> {
+        guard let citationWebViewHandler = citationWebViewHandlerBySession[session] else { return .error(Error.invalidSession) }
+        let itemIds = itemIds ?? session.itemIds
         let itemsData = itemsData(for: itemIds, label: label, locator: locator, omitAuthor: omitAuthor)
         return citationWebViewHandler
-            .getCitation(itemsCsl: itemsCsl, itemsData: itemsData, styleXml: styleXml, localeId: localeId, localeXml: localeXml, format: format.rawValue, showInWebView: showInWebView)
+            .getCitation(
+                itemsCSL: session.itemsCSL,
+                itemsData: itemsData,
+                styleXML: session.styleXML,
+                localeId: session.styleLocaleId,
+                localeXML: session.localeXML,
+                format: format.rawValue,
+                showInWebView: showInWebView
+            )
             .flatMap({ .just(self.format(result: $0, format: format)) })
 
         func itemsData(for itemIds: Set<String>, label: String?, locator: String?, omitAuthor: Bool) -> String {
@@ -146,23 +308,30 @@ class CitationController: NSObject {
         }
     }
 
-    /// Bibliography happens once for selected item(s). Appropriate style and locale xmls are loaded, webView is initialized and loaded with index.html. When everything is loaded,
+    /// Bibliography happens once for session item(s). Seession starts, and when everything is loaded,
     /// appropriate js function is called and result is returned. When everything is finished, webView is removed from controller.
     /// - parameter itemIds: Ids of items of which bibliography is created.
     /// - parameter libraryId: Id of library for given items.
     /// - parameter format: Bibliography format to use for generation.
     /// - returns: Single which returns bibliography.
-    func bibliography(for itemIds: Set<String>, format: Format) -> Single<String> {
-        guard let styleXml, let localeId, let localeXml, let itemsCsl, let supportsBibliography, let citationWebViewHandler else { return .error(Error.prepareNotCalled) }
-        if supportsBibliography {
-            return citationWebViewHandler.getBibliography(itemsCsl: itemsCsl, styleXml: styleXml, localeId: localeId, localeXml: localeXml, format: format.rawValue)
+    func bibliography(for session: Session, format: Format) -> Single<String> {
+        guard let citationWebViewHandler = citationWebViewHandlerBySession[session] else { return .error(Error.invalidSession) }
+        if session.supportsBibliography {
+            return citationWebViewHandler
+                .getBibliography(
+                    itemsCSL: session.itemsCSL,
+                    styleXML: session.styleXML,
+                    localeId: session.styleLocaleId,
+                    localeXML: session.localeXML,
+                    format: format.rawValue
+                )
                 .flatMap({ .just(self.format(result: $0, format: format)) })
         }
-        return numberedBibliography(for: itemIds, format: format)
+        return numberedBibliography(for: session.itemIds, format: format)
             .flatMap({ .just(self.format(result: $0, format: format)) })
 
         func numberedBibliography(for itemIds: Set<String>, format: Format) -> Single<String> {
-            let actions = itemIds.map({ citation(for: [$0], label: nil, locator: nil, omitAuthor: false, format: format, showInWebView: false).asObservable() })
+            let actions = itemIds.map({ citation(for: session, itemIds: [$0], label: nil, locator: nil, omitAuthor: false, format: format, showInWebView: false).asObservable() })
 
             return Observable.concat(actions)
                 .reduce([]) { array, citation -> [String] in
@@ -218,148 +387,5 @@ class CitationController: NSObject {
         case .text:
             return result
         }
-    }
-
-    private func loadEncodedXmls(styleFilename: String, localeId: String) -> Single<(String, String)> {
-        return .create { subscriber in
-            guard let localeUrl = Bundle.main.url(forResource: "locales-\(localeId)", withExtension: "xml", subdirectory: "Bundled/locales") else {
-                DDLogError("CitationController: can't load locale xml")
-                subscriber(.failure(Error.styleOrLocaleMissing))
-                return Disposables.create()
-            }
-
-            do {
-                let localeData = try Data(contentsOf: localeUrl)
-                let styleData = try self.fileStorage.read(Files.style(filename: styleFilename))
-
-                subscriber(.success((WebViewEncoder.encodeForJavascript(styleData), WebViewEncoder.encodeForJavascript(localeData))))
-            } catch let error {
-                DDLogError("CitationController: can't read locale or style - \(error)")
-                subscriber(.failure(Error.styleOrLocaleMissing))
-            }
-
-            return Disposables.create()
-        }
-    }
-
-    /// Loads style data.
-    /// - parameter styleId: Identifier of style
-    /// - returns: Style data.
-    private func loadStyleData(for styleId: String) -> Single<StyleData> {
-        return .create { subscriber in
-            do {
-                let style = try self.bundledDataStorage.perform(request: ReadStyleDbRequest(identifier: styleId), on: self.backgroundQueue)
-                let data = StyleData(style: style)
-                style.realm?.invalidate()
-                subscriber(.success(data))
-            } catch let error {
-                DDLogError("CitationController: can't load style - \(error)")
-                subscriber(.failure(Error.styleOrLocaleMissing))
-            }
-            return Disposables.create()
-        }
-    }
-
-    private func loadBundledFiles() -> Single<(String, String)> {
-        return .create { subscriber in
-            guard let schemaPath = Bundle.main.path(forResource: "citation/utilities/resource/schema/global/schema", ofType: "json"),
-                    let schemaData = try? Data(contentsOf: URL(fileURLWithPath: schemaPath))
-            else {
-                subscriber(.failure(Error.cantFindFile))
-                return Disposables.create()
-            }
-            guard let dateFormatsPath = Bundle.main.path(forResource: "citation/utilities/resource/dateFormats", ofType: "json"),
-                  let dateFormatsData = try? Data(contentsOf: URL(fileURLWithPath: dateFormatsPath))
-            else {
-                subscriber(.failure(Error.cantFindFile))
-                return Disposables.create()
-            }
-
-            let encodedSchema = WebViewEncoder.encodeForJavascript(schemaData)
-            let encodedFormats = WebViewEncoder.encodeForJavascript(dateFormatsData)
-            subscriber(.success((encodedSchema, encodedFormats)))
-            return Disposables.create()
-        }
-    }
-
-    private func loadItemJsons(for keys: Set<String>, libraryId: LibraryIdentifier) -> Single<String> {
-        return .create { subscriber in
-            do {
-                let items = try self.dbStorage.perform(request: ReadItemsWithKeysDbRequest(keys: keys, libraryId: libraryId), on: self.backgroundQueue)
-                    .filter(.item(notTypeIn: CitationController.invalidItemTypes))
-
-                if items.isEmpty {
-                    subscriber(.failure(Error.invalidItemTypes))
-                    return Disposables.create()
-                }
-
-                let data = Array(items.map({ self.data(for: $0) }))
-
-                items.first?.realm?.invalidate()
-
-                subscriber(.success(WebViewEncoder.encodeAsJSONForJavascript(data)))
-            } catch let error {
-                DDLogError("CitationController: can't read items - \(error)")
-                subscriber(.failure(error))
-            }
-
-            return Disposables.create()
-        }
-    }
-
-    private func data(for item: RItem) -> [String: Any] {
-        var data: [String: Any] = [:]
-
-        // Add all fields
-        for field in item.fields {
-            data[field.key] = field.value
-        }
-
-        // Add creators
-        var creators: [[String: Any]] = []
-        for rCreator in item.creators.sorted(byKeyPath: "orderId") {
-            var creator: [String: Any] = ["creatorType": rCreator.rawType]
-            if !rCreator.name.isEmpty {
-                creator["name"] = rCreator.name
-            } else {
-                creator["firstName"] = rCreator.firstName
-                creator["lastName"] = rCreator.lastName
-            }
-            creators.append(creator)
-        }
-        data["creators"] = creators
-
-        // Add relations
-        var relations: [[String: Any]] = []
-        for rRelation in item.relations {
-            guard !rRelation.urlString.isEmpty else { continue }
-
-            let urls = rRelation.urlString.components(separatedBy: ";").filter({ !$0.isEmpty })
-            var relation: [String: Any] = [:]
-
-            if urls.count == 1, let url = urls.first {
-                relation[rRelation.type] = url
-            } else {
-                relation[rRelation.type] = urls
-            }
-            relations.append(relation)
-        }
-        data["relations"] = relations
-
-        // Add remaining data
-        data["key"] = item.key
-        data["itemType"] = item.rawType
-        data["version"] = item.version
-        if let key = item.parent?.key {
-            data["parentItem"] = key
-        }
-        data["dateAdded"] = Formatter.iso8601.string(from: item.dateAdded)
-        data["dateModified"] = Formatter.iso8601.string(from: item.dateModified)
-        data["uri"] = "https://www.zotero.org/\(item.key)"
-        data["inPublications"] = item.inPublications
-        data["collections"] = [] as [Any]
-        data["tags"] = [] as [Any]
-
-        return data
     }
 }

--- a/Zotero/Controllers/Citation/CitationController.swift
+++ b/Zotero/Controllers/Citation/CitationController.swift
@@ -18,35 +18,20 @@ private struct StyleData {
     let supportsBibliography: Bool
 
     init(style: RStyle) {
-        self.filename = style.dependency?.filename ?? style.filename
-        self.defaultLocaleId = style.defaultLocale.isEmpty ? nil : style.defaultLocale
-        self.supportsBibliography = style.supportsBibliography
+        filename = style.dependency?.filename ?? style.filename
+        defaultLocaleId = style.defaultLocale.isEmpty ? nil : style.defaultLocale
+        supportsBibliography = style.supportsBibliography
     }
 }
 
 class CitationController: NSObject {
-    fileprivate typealias WebViewResponseHandler = (SingleEvent<String>) -> Void
-
     enum Format: String {
         case html
         case text
         case rtf
     }
 
-    /// Handlers for communication with JS in `webView`
-    enum JSHandlers: String, CaseIterable {
-        /// Handler used for HTTP requests. Expects response (HTTP response).
-        case citation = "citationHandler"
-        case log = "logHandler"
-        case bibliography = "bibliographyHandler"
-        case csl = "cslHandler"
-    }
-
     enum Error: Swift.Error {
-        case deinitialized
-        case alreadyRunning
-        case cantFindBaseFile
-        case missingResponse
         case styleOrLocaleMissing
         case prepareNotCalled
         case cantFindFile
@@ -60,6 +45,7 @@ class CitationController: NSObject {
     private unowned let bundledDataStorage: DbStorage
     private let backgroundQueue: DispatchQueue
     private let backgroundScheduler: SerialDispatchQueueScheduler
+    private var citationWebViewHandler: CitationWebViewHandler?
 
     // Store temporary data for citation preview so that they don't need to be reloaded for each preview generation.
     private var styleXml: String?
@@ -68,71 +54,55 @@ class CitationController: NSObject {
     private var itemsCsl: String?
     private var supportsBibliography: Bool?
 
-    private var webDidLoad: ((SingleEvent<()>) -> Void)?
-    private var responseHandlers: [String: WebViewResponseHandler]
-
     init(stylesController: TranslatorsAndStylesController, fileStorage: FileStorage, dbStorage: DbStorage, bundledDataStorage: DbStorage) {
         let queue = DispatchQueue(label: "org.zotero.CitationController.queue", qos: .userInitiated)
         self.stylesController = stylesController
         self.fileStorage = fileStorage
         self.dbStorage = dbStorage
         self.bundledDataStorage = bundledDataStorage
-        self.backgroundQueue = queue
-        self.backgroundScheduler = SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: "org.zotero.CitationController.scheduler")
-        self.responseHandlers = [:]
+        backgroundQueue = queue
+        backgroundScheduler = SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: "org.zotero.CitationController.scheduler")
         super.init()
     }
 
     // MARK: - Actions
 
-    /// Pre-loads given webView with appropriate index.html so that it's ready immediately for citation/bibliography generation.
+    /// Pre-loads given webView in a CitationWebViewHandler, so that it's ready immediately for citation/bibliography generation.
     /// - parameter itemIds: Ids of items for which CSL will be generated.
     /// - parameter libraryId: Library identifier of given items.
     /// - parameter styleId: Id of style to use for citation/bibliography generation.
     /// - parameter localeId: Id of locale to use for citation/bibliography generation.
     /// - returns: Single which is called when webView is fully loaded.
     func prepare(webView: WKWebView, for itemIds: Set<String>, libraryId: LibraryIdentifier, styleId: String, localeId: String) -> Single<()> {
-        webView.navigationDelegate = self
-        JSHandlers.allCases.forEach { handler in
-            webView.configuration.userContentController.removeScriptMessageHandler(forName: handler.rawValue)
-            webView.configuration.userContentController.add(self, name: handler.rawValue)
-        }
+        let citationWebViewHandler = CitationWebViewHandler(webView: webView)
+        self.citationWebViewHandler = citationWebViewHandler
 
-        return self.loadStyleData(for: styleId)
-                   .subscribe(on: self.backgroundScheduler)
-                   .observe(on: self.backgroundScheduler)
-                   .flatMap({ styleData -> Single<(String, String, String, Bool)> in
-                       let styleLocaleId = styleData.defaultLocaleId ?? localeId
-                       return self.loadEncodedXmls(styleFilename: styleData.filename, localeId: styleLocaleId).flatMap({ Single.just(($0.0, $0.1, styleLocaleId, styleData.supportsBibliography)) })
-                   })
-                   .do(onSuccess: { styleXml, localeXml, localeId, supportsBibliography in
-                       self.styleXml = styleXml
-                       self.localeId = localeId
-                       self.localeXml = localeXml
-                       self.supportsBibliography = supportsBibliography
-                   })
-                   .flatMap({ _ -> Single<(String, String)> in
-                       return self.loadBundledFiles()
-                   })
-                   .flatMap({ schema, dateFormats -> Single<(String, String, String)> in
-                       return self.loadItemJsons(for: itemIds, libraryId: libraryId).flatMap({ Single.just((schema, dateFormats, $0)) })
-                   })
-                   .flatMap({ schema, dateFormats, itemJsons -> Single<(String, URL, String, String, String)> in
-                       return self.loadIndexHtml().flatMap({ Single.just(($0, $1, schema, dateFormats, itemJsons)) })
-                   })
-                   .observe(on: MainScheduler.instance)
-                   .flatMap({ [weak webView] html, url, schema, dateFormats, itemJsons -> Single<(String, String, String)> in
-                        guard let webView = webView else { return Single.error(Error.deinitialized) }
-                        return self.load(html: html, baseUrl: url, in: webView).flatMap({ _ in Single.just((schema, dateFormats, itemJsons)) })
-                   })
-                   .flatMap({ [weak webView] schema, dateFormats, itemJsons -> Single<String> in
-                       guard let webView = webView else { return Single.error(Error.deinitialized) }
-                       return self.getItemsCsl(from: itemJsons, schema: schema, dateFormats: dateFormats, webView: webView)
-                   })
-                   .do(onSuccess: { itemsCsl in
-                       self.itemsCsl = itemsCsl
-                   })
-                   .flatMap({ _ in return Single.just(()) })
+        return loadStyleData(for: styleId)
+            .subscribe(on: backgroundScheduler)
+            .observe(on: backgroundScheduler)
+            .flatMap({ styleData -> Single<(String, String, String, Bool)> in
+                let styleLocaleId = styleData.defaultLocaleId ?? localeId
+                return self.loadEncodedXmls(styleFilename: styleData.filename, localeId: styleLocaleId).flatMap({ .just(($0.0, $0.1, styleLocaleId, styleData.supportsBibliography)) })
+            })
+            .do(onSuccess: { styleXml, localeXml, localeId, supportsBibliography in
+                self.styleXml = styleXml
+                self.localeId = localeId
+                self.localeXml = localeXml
+                self.supportsBibliography = supportsBibliography
+            })
+            .flatMap({ _ -> Single<(String, String)> in
+                return self.loadBundledFiles()
+            })
+            .flatMap({ schema, dateFormats -> Single<(String, String, String)> in
+                return self.loadItemJsons(for: itemIds, libraryId: libraryId).flatMap({ .just((schema, dateFormats, $0)) })
+            })
+            .flatMap({ schema, dateFormats, itemJsons -> Single<String> in
+                return citationWebViewHandler.getItemsCsl(from: itemJsons, schema: schema, dateFormats: dateFormats)
+            })
+            .do(onSuccess: { itemsCsl in
+                self.itemsCsl = itemsCsl
+            })
+            .flatMap({ _ in return .just(()) })
     }
 
     /// Cleans up after citeproc-js is finished. Should be called when all requests are called.
@@ -152,29 +122,28 @@ class CitationController: NSObject {
     /// - parameter omitAuthor: True if author should be suppressed, false otherwise.
     /// - parameter format: Format in which citation is generated.
     /// - parameter showInWebView: If true, shows generated result in webView body. If false, just returns generated result through handlers.
-    /// - parameter webView: Web view which is fully loaded (`prepareForCitation(styleId:localeId:in:)` finished).
     /// - returns: Single with generated citation.
-    func citation(for itemIds: Set<String>, label: String?, locator: String?, omitAuthor: Bool, format: Format, showInWebView: Bool, in webView: WKWebView) -> Single<String> {
-        guard let style = self.styleXml, let localeId = self.localeId, let locale = self.localeXml, let itemsCsl = self.itemsCsl else { return Single.error(Error.prepareNotCalled) }
-        let itemsData = self.itemsData(for: itemIds, label: label, locator: locator, omitAuthor: omitAuthor)
-        return self.getCitation(itemsCsl: itemsCsl, itemsData: itemsData, styleXml: style, localeId: localeId, localeXml: locale,
-                                format: format.rawValue, showInWebView: showInWebView, webView: webView)
-                   .flatMap({ Single.just(self.format(result: $0, format: format)) })
-    }
+    func citation(for itemIds: Set<String>, label: String?, locator: String?, omitAuthor: Bool, format: Format, showInWebView: Bool) -> Single<String> {
+        guard let styleXml, let localeId, let localeXml, let itemsCsl, let citationWebViewHandler else { return .error(Error.prepareNotCalled) }
+        let itemsData = itemsData(for: itemIds, label: label, locator: locator, omitAuthor: omitAuthor)
+        return citationWebViewHandler
+            .getCitation(itemsCsl: itemsCsl, itemsData: itemsData, styleXml: styleXml, localeId: localeId, localeXml: localeXml, format: format.rawValue, showInWebView: showInWebView)
+            .flatMap({ .just(self.format(result: $0, format: format)) })
 
-    private func itemsData(for itemIds: Set<String>, label: String?, locator: String?, omitAuthor: Bool) -> String {
-        var itemsData: [[String: Any]] = []
-        for key in itemIds {
-            var data: [String: Any] = ["id": "https://www.zotero.org/\(key)", "suppress-author": omitAuthor]
-            if let value = label {
-                data["label"] = value
+        func itemsData(for itemIds: Set<String>, label: String?, locator: String?, omitAuthor: Bool) -> String {
+            var itemsData: [[String: Any]] = []
+            for key in itemIds {
+                var data: [String: Any] = ["id": "https://www.zotero.org/\(key)", "suppress-author": omitAuthor]
+                if let value = label {
+                    data["label"] = value
+                }
+                if let value = locator {
+                    data["locator"] = value
+                }
+                itemsData.append(data)
             }
-            if let value = locator {
-                data["locator"] = value
-            }
-            itemsData.append(data)
+            return WebViewEncoder.encodeAsJSONForJavascript(itemsData)
         }
-        return WebViewEncoder.encodeAsJSONForJavascript(itemsData)
     }
 
     /// Bibliography happens once for selected item(s). Appropriate style and locale xmls are loaded, webView is initialized and loaded with index.html. When everything is loaded,
@@ -182,19 +151,46 @@ class CitationController: NSObject {
     /// - parameter itemIds: Ids of items of which bibliography is created.
     /// - parameter libraryId: Id of library for given items.
     /// - parameter format: Bibliography format to use for generation.
-    /// - parameter webView: WebView which will run the javascript.
     /// - returns: Single which returns bibliography.
-    func bibliography(for itemIds: Set<String>, format: Format, in webView: WKWebView) -> Single<String> {
-        guard let style = self.styleXml, let localeId = self.localeId, let locale = self.localeXml, let itemsCsl = self.itemsCsl, let supportsBibliography = self.supportsBibliography else {
-            return Single.error(Error.prepareNotCalled)
-        }
-
+    func bibliography(for itemIds: Set<String>, format: Format) -> Single<String> {
+        guard let styleXml, let localeId, let localeXml, let itemsCsl, let supportsBibliography, let citationWebViewHandler else { return .error(Error.prepareNotCalled) }
         if supportsBibliography {
-            return self.getBibliography(itemsCsl: itemsCsl, styleXml: style, localeId: localeId, localeXml: locale, format: format.rawValue, webView: webView)
-                       .flatMap({ Single.just(self.format(result: $0, format: format)) })
+            return citationWebViewHandler.getBibliography(itemsCsl: itemsCsl, styleXml: styleXml, localeId: localeId, localeXml: localeXml, format: format.rawValue)
+                .flatMap({ .just(self.format(result: $0, format: format)) })
         }
-        return self.numberedBibliography(for: itemIds, format: format, in: webView)
-                   .flatMap({ Single.just(self.format(result: $0, format: format)) })
+        return numberedBibliography(for: itemIds, format: format)
+            .flatMap({ .just(self.format(result: $0, format: format)) })
+
+        func numberedBibliography(for itemIds: Set<String>, format: Format) -> Single<String> {
+            let actions = itemIds.map({ citation(for: [$0], label: nil, locator: nil, omitAuthor: false, format: format, showInWebView: false).asObservable() })
+
+            return Observable.concat(actions)
+                .reduce([]) { array, citation -> [String] in
+                    var new = array
+                    new.append(citation)
+                    return new
+                }
+                .asSingle()
+                .flatMap({ citations -> Single<String> in
+                    return .just(formatBibliography(from: citations, to: format))
+                })
+
+            func formatBibliography(from citations: [String], to format: Format) -> String {
+                switch format {
+                case .html:
+                    return "<ol>\n\t<li>" + citations.joined(separator: "</li>\n\t<li>") + "</li>\n</ol>"
+
+                case .rtf:
+                    let prefix = "{\\*\\listtable{\\list\\listtemplateid1\\listhybrid{\\listlevel\\levelnfc0\\levelnfcn0\\leveljc0\\leveljcn0\\levelfollow0\\levelstartat1" +
+                                "\\levelspace360\\levelindent0{\\*\\levelmarker \\{decimal\\}.}{\\leveltext\\leveltemplateid1\\'02\\'00.;}{\\levelnumbers\\'01;}\\fi-360\\li720\\lin720 }" +
+                                "{\\listname ;}\\listid1}}\n{\\*\\listoverridetable{\\listoverride\\listid1\\listoverridecount0\\ls1}}\n\\tx720\\li720\\fi-480\\ls1\\ilvl0\n"
+                    return prefix + citations.enumerated().map({ "{\\listtext \($0.offset + 1).    }\($0.element)\\\n" }).joined()
+
+                case .text:
+                    return citations.enumerated().map({ "\($0.offset + 1). \($0.element)" }).joined(separator: "\r\n")
+                }
+            }
+        }
     }
 
     private func format(result: String, format: Format) -> String {
@@ -219,43 +215,13 @@ class CitationController: NSObject {
             }
             return newResult
 
-        case .text: return result
-        }
-    }
-
-    private func numberedBibliography(for itemIds: Set<String>, format: Format, in webView: WKWebView) -> Single<String> {
-        let actions = itemIds.map({ self.citation(for: [$0], label: nil, locator: nil, omitAuthor: false, format: format, showInWebView: false, in: webView).asObservable() })
-
-        return Observable.concat(actions)
-                         .reduce([]) { array, citation -> [String] in
-                             var new = array
-                             new.append(citation)
-                             return new
-                         }
-                         .asSingle()
-                         .flatMap({ citations -> Single<String> in
-                             return Single.just(self.formatBibliography(from: citations, to: format))
-                         })
-    }
-
-    private func formatBibliography(from citations: [String], to format: Format) -> String {
-        switch format {
-        case .html:
-            return "<ol>\n\t<li>" + citations.joined(separator: "</li>\n\t<li>") + "</li>\n</ol>"
-
-        case .rtf:
-            let prefix = "{\\*\\listtable{\\list\\listtemplateid1\\listhybrid{\\listlevel\\levelnfc0\\levelnfcn0\\leveljc0\\leveljcn0\\levelfollow0\\levelstartat1" +
-                        "\\levelspace360\\levelindent0{\\*\\levelmarker \\{decimal\\}.}{\\leveltext\\leveltemplateid1\\'02\\'00.;}{\\levelnumbers\\'01;}\\fi-360\\li720\\lin720 }" +
-                        "{\\listname ;}\\listid1}}\n{\\*\\listoverridetable{\\listoverride\\listid1\\listoverridecount0\\ls1}}\n\\tx720\\li720\\fi-480\\ls1\\ilvl0\n"
-            return prefix + citations.enumerated().map({ "{\\listtext \($0.offset + 1).    }\($0.element)\\\n" }).joined()
-
         case .text:
-            return citations.enumerated().map({ "\($0.offset + 1). \($0.element)" }).joined(separator: "\r\n")
+            return result
         }
     }
 
     private func loadEncodedXmls(styleFilename: String, localeId: String) -> Single<(String, String)> {
-        return Single.create { subscriber in
+        return .create { subscriber in
             guard let localeUrl = Bundle.main.url(forResource: "locales-\(localeId)", withExtension: "xml", subdirectory: "Bundled/locales") else {
                 DDLogError("CitationController: can't load locale xml")
                 subscriber(.failure(Error.styleOrLocaleMissing))
@@ -280,7 +246,7 @@ class CitationController: NSObject {
     /// - parameter styleId: Identifier of style
     /// - returns: Style data.
     private func loadStyleData(for styleId: String) -> Single<StyleData> {
-        return Single.create { subscriber in
+        return .create { subscriber in
             do {
                 let style = try self.bundledDataStorage.perform(request: ReadStyleDbRequest(identifier: styleId), on: self.backgroundQueue)
                 let data = StyleData(style: style)
@@ -317,10 +283,10 @@ class CitationController: NSObject {
     }
 
     private func loadItemJsons(for keys: Set<String>, libraryId: LibraryIdentifier) -> Single<String> {
-        return Single.create { subscriber in
+        return .create { subscriber in
             do {
                 let items = try self.dbStorage.perform(request: ReadItemsWithKeysDbRequest(keys: keys, libraryId: libraryId), on: self.backgroundQueue)
-                                              .filter(.item(notTypeIn: CitationController.invalidItemTypes))
+                    .filter(.item(notTypeIn: CitationController.invalidItemTypes))
 
                 if items.isEmpty {
                     subscriber(.failure(Error.invalidItemTypes))
@@ -395,130 +361,5 @@ class CitationController: NSObject {
         data["tags"] = [] as [Any]
 
         return data
-    }
-
-    // MARK: - Web View
-
-    /// Calls javascript in webView and waits for response.
-    /// - returns: Single with citation response or error.
-    private func getCitation(itemsCsl: String, itemsData: String, styleXml: String, localeId: String, localeXml: String, format: String, showInWebView: Bool, webView: WKWebView) -> Single<String> {
-        return self.perform(javascript: "getCit(\(itemsCsl), \(itemsData), \(styleXml), '\(localeId)', \(localeXml), '\(format)', \(showInWebView), 'msgid');", in: webView)
-    }
-
-    /// Calls javascript in webView and waits for response.
-    /// - returns: Single with bibliography response or error.
-    private func getBibliography(itemsCsl: String, styleXml: String, localeId: String, localeXml: String, format: String, webView: WKWebView) -> Single<String> {
-        return self.perform(javascript: "getBib(\(itemsCsl), \(styleXml), '\(localeId)', \(localeXml), '\(format)', 'msgid');", in: webView)
-    }
-
-    private func getItemsCsl(from jsons: String, schema: String, dateFormats: String, webView: WKWebView) -> Single<String> {
-        return self.perform(javascript: "convertItemsToCSL(\(jsons), \(schema), \(dateFormats), 'msgid');", in: webView)
-    }
-
-    /// Performs javascript script in web view, returns `Single` with registered response handler.
-    private func perform(javascript: String, in webView: WKWebView) -> Single<String> {
-        return Single.create { [weak self, weak webView] subscriber -> Disposable in
-            guard let self = self, let webView = webView else {
-                subscriber(.failure(Error.deinitialized))
-                return Disposables.create()
-            }
-
-            let id = UUID().uuidString
-            let javascriptWithId = javascript.replacingOccurrences(of: "msgid", with: id)
-
-            self.responseHandlers[id] = subscriber
-            webView.evaluateJavaScript(javascriptWithId, completionHandler: nil)
-
-            return Disposables.create { [weak self] in
-                self?.responseHandlers[id] = nil
-            }
-        }
-    }
-
-    /// Loads html in given web view.
-    /// - returns: Single called after index is loaded.
-    private func load(html: String, baseUrl: URL, in webView: WKWebView) -> Single<()> {
-        return Single.create { [weak self, weak webView] subscriber -> Disposable in
-            self?.webDidLoad = subscriber
-            webView?.loadHTMLString(html, baseURL: baseUrl)
-
-            return Disposables.create {
-                self?.webDidLoad = nil
-            }
-        }
-    }
-
-    private func loadIndexHtml() -> Single<(String, URL)> {
-        return Single.create { subscriber in
-            guard let containerUrl = Bundle.main.url(forResource: "index", withExtension: "html", subdirectory: "citation"),
-                  let containerHtml = try? String(contentsOf: containerUrl, encoding: .utf8) else {
-                DDLogError("CitationController: can't load citation html")
-                subscriber(.failure(Error.cantFindBaseFile))
-                return Disposables.create()
-            }
-            subscriber(.success((containerHtml, containerUrl)))
-            return Disposables.create()
-        }
-    }
-}
-
-extension CitationController: WKNavigationDelegate {
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        // Wait for javascript to load
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
-            self.webDidLoad?(.success(()))
-        }
-    }
-
-    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Swift.Error) {
-        DDLogError("CitationController: failed to load webview - \(error)")
-        self.webDidLoad?(.failure(error))
-    }
-}
-
-/// Communication with JS in `webView`. The `webView` sends a message through one of the registered `JSHandlers`, which is received here.
-extension CitationController: WKScriptMessageHandler {
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        guard let handler = JSHandlers(rawValue: message.name) else { return }
-
-        if handler == .log {
-            DDLogInfo("CitationController: \((message.body as? String) ?? "-")")
-            return
-        }
-
-        guard let messageBody = message.body as? [String: Any],
-              let messageId = messageBody["id"] as? String,
-              let jsResult = messageBody["result"] else {
-            DDLogError("CitationController: unknown message body - \(message.body)")
-            return
-        }
-
-        let result: SingleEvent<String>
-
-        switch handler {
-        case .citation, .bibliography:
-            if let _result = jsResult as? String {
-                result = .success(_result)
-            } else {
-                DDLogError("CitationController: Citation/bibliography got unknown response - \(jsResult)")
-                result = .failure(Error.missingResponse)
-            }
-
-        case .csl:
-            if let csl = jsResult as? [[String: Any]] {
-                result = .success(WebViewEncoder.encodeAsJSONForJavascript(csl))
-            } else {
-                DDLogError("CitationController: CSL got unknown response - \(jsResult)")
-                result = .failure(Error.missingResponse)
-            }
-
-        case .log: return
-        }
-
-        if let handler = self.responseHandlers[messageId] {
-            handler(result)
-        } else {
-            DDLogError("CitationController: handler for \(message.name) doesn't exist anymore")
-        }
     }
 }

--- a/Zotero/Controllers/Citation/CitationController.swift
+++ b/Zotero/Controllers/Citation/CitationController.swift
@@ -272,7 +272,7 @@ class CitationController: NSObject {
 
     /// Cleans up after citeproc-js is finished. Should be called when all requests are called.
     func endSession(_ session: Session) {
-        citationWebViewHandlerBySession.removeValue(forKey: session)?.webViewHandler.removeFromSuperviewAsynchronously()
+        citationWebViewHandlerBySession.removeValue(forKey: session)?.removeFromSuperviewAsynchronously()
     }
 
     /// Generates citation preview for given citation session, in given format. Has to be called after session has started.

--- a/Zotero/Controllers/Citation/CitationController.swift
+++ b/Zotero/Controllers/Citation/CitationController.swift
@@ -114,9 +114,11 @@ class CitationController: NSObject {
                     supportsBibliography: supportsBibliography,
                     itemsCSL: itemCSL
                 )
-                self.citationWebViewHandlerBySession[session] = citationWebViewHandler
                 return .just(session)
             }
+            .do(onSuccess: { [weak self] session in
+                self?.citationWebViewHandlerBySession[session] = citationWebViewHandler
+            })
 
         /// Loads style data.
         /// - parameter styleId: Identifier of style

--- a/Zotero/Controllers/IdentifierLookupController.swift
+++ b/Zotero/Controllers/IdentifierLookupController.swift
@@ -223,7 +223,7 @@ final class IdentifierLookupController {
             DDLogInfo("IdentifierLookupController: cancel all lookups")
             let keys = lookupWebViewHandlersByLookupSettings.keys
             for key in keys {
-                lookupWebViewHandlersByLookupSettings.removeValue(forKey: key)?.webViewHandler.removeFromSuperviewAsynchronously()
+                lookupWebViewHandlersByLookupSettings.removeValue(forKey: key)?.removeFromSuperviewAsynchronously()
             }
             remoteFileDownloader.stop()
             let lookupData = self.lookupData
@@ -528,7 +528,7 @@ final class IdentifierLookupController {
                 DDLogInfo("IdentifierLookupController: cleaned up lookup data")
                 let keys = lookupWebViewHandlersByLookupSettings.keys
                 for key in keys {
-                    lookupWebViewHandlersByLookupSettings.removeValue(forKey: key)?.webViewHandler.removeFromSuperviewAsynchronously()
+                    lookupWebViewHandlersByLookupSettings.removeValue(forKey: key)?.removeFromSuperviewAsynchronously()
                 }
                 completion(true)
             }

--- a/Zotero/Controllers/IdentifierLookupController.swift
+++ b/Zotero/Controllers/IdentifierLookupController.swift
@@ -13,10 +13,6 @@ import OrderedCollections
 import CocoaLumberjackSwift
 import RxSwift
 
-protocol IdentifierLookupWebViewProvider: AnyObject {
-    func addWebView() -> WKWebView
-}
-
 protocol IdentifierLookupPresenter: AnyObject {
     func isPresenting() -> Bool
 }
@@ -143,7 +139,7 @@ final class IdentifierLookupController {
         return (savedCount, failedCount, totalCount)
     }
 
-    internal weak var webViewProvider: IdentifierLookupWebViewProvider?
+    internal weak var webViewProvider: WebViewProvider?
     internal weak var presenter: IdentifierLookupPresenter? {
         didSet {
             guard presenter == nil, oldValue != nil else { return }
@@ -198,7 +194,7 @@ final class IdentifierLookupController {
             }
             var lookupWebViewHandler: LookupWebViewHandler?
             inMainThread(sync: true) {
-                if let webView = self.webViewProvider?.addWebView() {
+                if let webView = self.webViewProvider?.addWebView(configuration: nil) {
                     lookupWebViewHandler = LookupWebViewHandler(webView: webView, translatorsController: self.translatorsController)
                 }
             }
@@ -227,10 +223,7 @@ final class IdentifierLookupController {
             DDLogInfo("IdentifierLookupController: cancel all lookups")
             let keys = lookupWebViewHandlersByLookupSettings.keys
             for key in keys {
-                guard let webView = lookupWebViewHandlersByLookupSettings.removeValue(forKey: key)?.webViewHandler.webView else { continue }
-                inMainThread {
-                    webView.removeFromSuperview()
-                }
+                lookupWebViewHandlersByLookupSettings.removeValue(forKey: key)?.webViewHandler.removeFromSuperviewAsynchronously()
             }
             remoteFileDownloader.stop()
             let lookupData = self.lookupData
@@ -463,7 +456,7 @@ final class IdentifierLookupController {
                     
                     func storeDataAndDownloadAttachmentIfNecessary(identifier: String, response: ItemResponse, attachments: [(Attachment, URL)]) throws {
                         let request = CreateTranslatedItemsDbRequest(responses: [response], schemaController: schemaController, dateParser: dateParser)
-                        try dbStorage.perform(request: request, on: backgroundQueue)
+                        _ = try dbStorage.perform(request: request, on: backgroundQueue)
                         changeLookup(
                             for: identifier,
                             to: .translated(.init(response: response, attachments: attachments, libraryId: libraryId, collectionKeys: collectionKeys))
@@ -535,10 +528,7 @@ final class IdentifierLookupController {
                 DDLogInfo("IdentifierLookupController: cleaned up lookup data")
                 let keys = lookupWebViewHandlersByLookupSettings.keys
                 for key in keys {
-                    guard let webView = lookupWebViewHandlersByLookupSettings.removeValue(forKey: key)?.webViewHandler.webView else { continue }
-                    DispatchQueue.main.async {
-                        webView.removeFromSuperview()
-                    }
+                    lookupWebViewHandlersByLookupSettings.removeValue(forKey: key)?.webViewHandler.removeFromSuperviewAsynchronously()
                 }
                 completion(true)
             }

--- a/Zotero/Controllers/Web View Handling/CitationWebViewHandler.swift
+++ b/Zotero/Controllers/Web View Handling/CitationWebViewHandler.swift
@@ -157,10 +157,7 @@ final class CitationWebViewHandler {
             return
         }
 
-        guard let body = body as? [String: Any],
-              let id = body["id"] as? String,
-              let jsResult = body["result"]
-        else {
+        guard let body = body as? [String: Any], let id = body["id"] as? String, let jsResult = body["result"] else {
             DDLogError("CitationWebViewHandler: unknown message body - \(body)")
             return
         }

--- a/Zotero/Controllers/Web View Handling/CitationWebViewHandler.swift
+++ b/Zotero/Controllers/Web View Handling/CitationWebViewHandler.swift
@@ -1,0 +1,197 @@
+//
+//  CitationWebViewHandler.swift
+//  Zotero
+//
+//  Created by Miltiadis Vasilakis on 15/3/25.
+//  Copyright © 2025 Corporation for Digital Scholarship. All rights reserved.
+//
+
+import Foundation
+import WebKit
+
+import CocoaLumberjackSwift
+import RxCocoa
+import RxSwift
+
+final class CitationWebViewHandler {
+    /// Handlers for communication with JS in `webView`
+    enum JSHandlers: String, CaseIterable {
+        case citation = "citationHandler"
+        case bibliography = "bibliographyHandler"
+        case csl = "cslHandler"
+        /// Handler used to log JS debug info.
+        case log = "logHandler"
+    }
+
+    enum Error: Swift.Error {
+        case deinitialized
+        case cantFindFile
+        case missingResponse
+    }
+
+    private enum InitializationState {
+        case initialized
+        case inProgress
+        case failed(Swift.Error)
+    }
+
+    let webViewHandler: WebViewHandler
+    private let disposeBag: DisposeBag
+
+    private var initializationState: BehaviorRelay<InitializationState>
+
+    init(webView: WKWebView) {
+        webViewHandler = WebViewHandler(webView: webView, javascriptHandlers: JSHandlers.allCases.map({ $0.rawValue }))
+        disposeBag = DisposeBag()
+        initializationState = BehaviorRelay(value: .inProgress)
+
+        webViewHandler.receivedMessageHandler = { [weak self] name, body in
+            self?.receiveMessage(name: name, body: body)
+        }
+
+        initialize()
+            .subscribe(on: MainScheduler.instance)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] _ in
+                DDLogInfo("CitationWebViewHandler: initialization succeeded")
+                self?.initializationState.accept(.initialized)
+            }, onFailure: { [weak self] error in
+                DDLogInfo("CitationWebViewHandler: initialization failed - \(error)")
+                self?.initializationState.accept(.failed(error))
+            })
+            .disposed(by: disposeBag)
+
+        func initialize() -> Single<()> {
+            DDLogInfo("CitationWebViewHandler: initialize web view")
+            return loadIndex()
+
+            func loadIndex() -> Single<()> {
+                guard let indexUrl = Bundle.main.url(forResource: "index", withExtension: "html", subdirectory: "citation") else {
+                    return .error(Error.cantFindFile)
+                }
+                return webViewHandler.load(fileUrl: indexUrl)
+            }
+        }
+    }
+
+    private var responseHandlers: [String: (SingleEvent<String>) -> Void] = [:]
+
+    private func performAfterInitialization() -> Single<()> {
+        return initializationState.filter { state in
+            switch state {
+            case .inProgress:
+                return false
+
+            case .initialized, .failed:
+                return true
+            }
+        }
+        .first()
+        .flatMap { state -> Single<()> in
+            switch state {
+            case .failed(let error):
+                return .error(error)
+
+            case .initialized:
+                return .just(())
+
+            case .inProgress, .none:
+                // Should never happen.
+                return .never()
+            }
+        }
+    }
+
+    /// Performs javascript script, returns `Single` with registered response handler.
+    private func perform(javascript: String) -> Single<String> {
+        performAfterInitialization().flatMap { _ in
+            return .create { [weak self] subscriber -> Disposable in
+                guard let self else {
+                    subscriber(.failure(Error.deinitialized))
+                    return Disposables.create()
+                }
+                let id = UUID().uuidString
+                let javascriptWithId = javascript.replacingOccurrences(of: "msgid", with: id)
+                responseHandlers[id] = subscriber
+                webViewHandler.call(javascript: javascriptWithId)
+                    .subscribe(on: MainScheduler.instance)
+                    .observe(on: MainScheduler.instance)
+                    .subscribe(onFailure: { [weak self] error in
+                        guard let self else { return }
+                        DDLogError("CitationWebViewHandler: javascript call failed - \(error)")
+                        responseHandlers[id]?(.failure(error))
+                    })
+                    .disposed(by: disposeBag)
+                
+                return Disposables.create { [weak self] in
+                    self?.responseHandlers[id] = nil
+                }
+            }
+        }
+    }
+
+    func getItemsCsl(from jsons: String, schema: String, dateFormats: String) -> Single<String> {
+        DDLogInfo("CitationWebViewHandler: call get items CSL js")
+        return perform(javascript: "convertItemsToCSL(\(jsons), \(schema), \(dateFormats), 'msgid');")
+    }
+
+    /// Calls javascript in webView and waits for response.
+    /// - returns: Single with citation response or error.
+    func getCitation(itemsCsl: String, itemsData: String, styleXml: String, localeId: String, localeXml: String, format: String, showInWebView: Bool) -> Single<String> {
+        return perform(javascript: "getCit(\(itemsCsl), \(itemsData), \(styleXml), '\(localeId)', \(localeXml), '\(format)', \(showInWebView), 'msgid');")
+    }
+
+    /// Calls javascript in webView and waits for response.
+    /// - returns: Single with bibliography response or error.
+    func getBibliography(itemsCsl: String, styleXml: String, localeId: String, localeXml: String, format: String) -> Single<String> {
+        return perform(javascript: "getBib(\(itemsCsl), \(styleXml), '\(localeId)', \(localeXml), '\(format)', 'msgid');")
+    }
+
+    /// Communication with JS in `webView`. The `webView` sends a message through one of the registered `JSHandlers`, which is received here.
+    /// Each message contains a `messageId` in the body, which is used to identify the message in case a response is expected.
+    private func receiveMessage(name: String, body: Any) {
+        guard let handler = JSHandlers(rawValue: name) else { return }
+
+        if handler == .log {
+            DDLogInfo("CitationWebViewHandler: JSLOG - \(body)")
+            return
+        }
+
+        guard let body = body as? [String: Any],
+              let id = body["id"] as? String,
+              let jsResult = body["result"]
+        else {
+            DDLogError("CitationWebViewHandler: unknown message body - \(body)")
+            return
+        }
+
+        let result: SingleEvent<String>
+
+        switch handler {
+        case .citation, .bibliography:
+            if let jsResult = jsResult as? String {
+                result = .success(jsResult)
+            } else {
+                DDLogError("CitationWebViewHandler: Citation/Bibliography got unknown response - \(jsResult)")
+                result = .failure(Error.missingResponse)
+            }
+
+        case .csl:
+            if let csl = jsResult as? [[String: Any]] {
+                result = .success(WebViewEncoder.encodeAsJSONForJavascript(csl))
+            } else {
+                DDLogError("CitationWebViewHandler: CSL got unknown response - \(jsResult)")
+                result = .failure(Error.missingResponse)
+            }
+
+        case .log:
+            return
+        }
+
+        if let responseHandler = responseHandlers[id] {
+            responseHandler(result)
+        } else {
+            DDLogError("CitationWebViewHandler: response handler for \(name) with id \(id) doesn't exist anymore")
+        }
+    }
+}

--- a/Zotero/Controllers/Web View Handling/CitationWebViewHandler.swift
+++ b/Zotero/Controllers/Web View Handling/CitationWebViewHandler.swift
@@ -130,21 +130,21 @@ final class CitationWebViewHandler {
         }
     }
 
-    func getItemsCsl(from jsons: String, schema: String, dateFormats: String) -> Single<String> {
+    func getItemsCSL(from jsons: String, schema: String, dateFormats: String) -> Single<String> {
         DDLogInfo("CitationWebViewHandler: call get items CSL js")
         return perform(javascript: "convertItemsToCSL(\(jsons), \(schema), \(dateFormats), 'msgid');")
     }
 
     /// Calls javascript in webView and waits for response.
     /// - returns: Single with citation response or error.
-    func getCitation(itemsCsl: String, itemsData: String, styleXml: String, localeId: String, localeXml: String, format: String, showInWebView: Bool) -> Single<String> {
-        return perform(javascript: "getCit(\(itemsCsl), \(itemsData), \(styleXml), '\(localeId)', \(localeXml), '\(format)', \(showInWebView), 'msgid');")
+    func getCitation(itemsCSL: String, itemsData: String, styleXML: String, localeId: String, localeXML: String, format: String, showInWebView: Bool) -> Single<String> {
+        return perform(javascript: "getCit(\(itemsCSL), \(itemsData), \(styleXML), '\(localeId)', \(localeXML), '\(format)', \(showInWebView), 'msgid');")
     }
 
     /// Calls javascript in webView and waits for response.
     /// - returns: Single with bibliography response or error.
-    func getBibliography(itemsCsl: String, styleXml: String, localeId: String, localeXml: String, format: String) -> Single<String> {
-        return perform(javascript: "getBib(\(itemsCsl), \(styleXml), '\(localeId)', \(localeXml), '\(format)', 'msgid');")
+    func getBibliography(itemsCSL: String, styleXML: String, localeId: String, localeXML: String, format: String) -> Single<String> {
+        return perform(javascript: "getBib(\(itemsCSL), \(styleXML), '\(localeId)', \(localeXML), '\(format)', 'msgid');")
     }
 
     /// Communication with JS in `webView`. The `webView` sends a message through one of the registered `JSHandlers`, which is received here.

--- a/Zotero/Controllers/Web View Handling/LookupWebViewHandler.swift
+++ b/Zotero/Controllers/Web View Handling/LookupWebViewHandler.swift
@@ -77,7 +77,7 @@ final class LookupWebViewHandler: WebViewHandler {
                 return self.call(javascript: "initTranslators(\(encodedTranslators));")
             }
             .flatMap { _ -> Single<()> in
-                    .just(())
+                return .just(())
             }
 
         func loadIndex() -> Single<()> {

--- a/Zotero/Controllers/Web View Handling/LookupWebViewHandler.swift
+++ b/Zotero/Controllers/Web View Handling/LookupWebViewHandler.swift
@@ -107,7 +107,7 @@ final class LookupWebViewHandler {
             func loadBundledFiles() -> Single<(String, String)> {
                 return .create { subscriber in
                     guard let schemaUrl = Bundle.main.url(forResource: "schema", withExtension: "json", subdirectory: "Bundled"), let schemaData = try? Data(contentsOf: schemaUrl) else {
-                        DDLogError("WebViewHandler: can't load schema json")
+                        DDLogError("LookupWebViewHandler: can't load schema json")
                         subscriber(.failure(Error.cantFindFile))
                         return Disposables.create()
                     }
@@ -115,7 +115,7 @@ final class LookupWebViewHandler {
                     guard let dateFormatsUrl = Bundle.main.url(forResource: "dateFormats", withExtension: "json", subdirectory: "translation/translate/modules/utilities/resource"),
                           let dateFormatData = try? Data(contentsOf: dateFormatsUrl)
                     else {
-                        DDLogError("WebViewHandler: can't load dateFormats json")
+                        DDLogError("LookupWebViewHandler: can't load dateFormats json")
                         subscriber(.failure(Error.cantFindFile))
                         return Disposables.create()
                     }
@@ -123,7 +123,7 @@ final class LookupWebViewHandler {
                     let encodedSchema = WebViewEncoder.encodeForJavascript(schemaData)
                     let encodedFormats = WebViewEncoder.encodeForJavascript(dateFormatData)
 
-                    DDLogInfo("WebViewHandler: loaded bundled files")
+                    DDLogInfo("LookupWebViewHandler: loaded bundled files")
 
                     subscriber(.success((encodedSchema, encodedFormats)))
 
@@ -204,8 +204,7 @@ final class LookupWebViewHandler {
             DDLogInfo("LookupWebViewHandler: JSLOG - \(body)")
 
         case .request:
-            guard let body = body as? [String: Any],
-                  let messageId = body["messageId"] as? Int else {
+            guard let body = body as? [String: Any], let messageId = body["messageId"] as? Int else {
                 DDLogError("LookupWebViewHandler: request missing body - \(body)")
                 return
             }

--- a/Zotero/Controllers/Web View Handling/LookupWebViewHandler.swift
+++ b/Zotero/Controllers/Web View Handling/LookupWebViewHandler.swift
@@ -13,7 +13,7 @@ import CocoaLumberjackSwift
 import RxCocoa
 import RxSwift
 
-final class LookupWebViewHandler {
+final class LookupWebViewHandler: WebViewHandler {
     /// Handlers for communication with JS in `webView`
     enum JSHandlers: String, CaseIterable {
         /// Handler used for reporting new items.
@@ -40,137 +40,96 @@ final class LookupWebViewHandler {
         case item([String: Any])
     }
 
-    private enum InitializationState {
-        case initialized
-        case inProgress
-        case failed(Swift.Error)
-    }
-
-    let webViewHandler: WebViewHandler
     private let translatorsController: TranslatorsAndStylesController
     private let disposeBag: DisposeBag
     let observable: PublishSubject<Result<LookupData, Swift.Error>>
 
-    private var initializationState: BehaviorRelay<InitializationState>
-
     init(webView: WKWebView, translatorsController: TranslatorsAndStylesController) {
         self.translatorsController = translatorsController
-        webViewHandler = WebViewHandler(webView: webView, javascriptHandlers: JSHandlers.allCases.map({ $0.rawValue }))
         observable = PublishSubject()
         disposeBag = DisposeBag()
-        initializationState = BehaviorRelay(value: .inProgress)
 
-        webViewHandler.receivedMessageHandler = { [weak self] name, body in
+        super.init(webView: webView, javascriptHandlers: JSHandlers.allCases.map({ $0.rawValue }))
+
+        receivedMessageHandler = { [weak self] name, body in
             self?.receiveMessage(name: name, body: body)
         }
+    }
 
-        initialize()
-            .subscribe(on: MainScheduler.instance)
-            .observe(on: MainScheduler.instance)
-            .subscribe(onSuccess: { [weak self] _ in
-                DDLogInfo("LookupWebViewHandler: initialization succeeded")
-                self?.initializationState.accept(.initialized)
-            }, onFailure: { [weak self] error in
-                DDLogInfo("LookupWebViewHandler: initialization failed - \(error)")
-                self?.initializationState.accept(.failed(error))
-            })
-            .disposed(by: disposeBag)
-
-        func initialize() -> Single<Any> {
-            DDLogInfo("LookupWebViewHandler: initialize web view")
-            return loadIndex()
-                .flatMap { _ -> Single<(String, String)> in
-                    DDLogInfo("LookupWebViewHandler: load bundled files")
-                    return loadBundledFiles()
-                }
-                .flatMap { encodedSchema, encodedDateFormats -> Single<Any> in
-                    DDLogInfo("LookupWebViewHandler: init schema and date formats")
-                    return self.webViewHandler.call(javascript: "initSchemaAndDateFormats(\(encodedSchema), \(encodedDateFormats));")
-                }
-                .flatMap { _ -> Single<[RawTranslator]> in
-                    DDLogInfo("LookupWebViewHandler: load translators")
-                    return translatorsController.translators()
-                }
-                .flatMap { translators -> Single<Any> in
-                    DDLogInfo("LookupWebViewHandler: encode translators")
-                    let encodedTranslators = WebViewEncoder.encodeAsJSONForJavascript(translators)
-                    return self.webViewHandler.call(javascript: "initTranslators(\(encodedTranslators));")
-                }
-
-            func loadIndex() -> Single<()> {
-                guard let indexUrl = Bundle.main.url(forResource: "lookup", withExtension: "html", subdirectory: "translation") else {
-                    return .error(Error.cantFindFile)
-                }
-                return webViewHandler.load(fileUrl: indexUrl)
+    override func initializeWebView() -> Single<()> {
+        DDLogInfo("LookupWebViewHandler: initialize web view")
+        return loadIndex()
+            .flatMap { _ -> Single<(String, String)> in
+                DDLogInfo("LookupWebViewHandler: load bundled files")
+                return loadBundledFiles()
+            }
+            .flatMap { encodedSchema, encodedDateFormats -> Single<Any> in
+                DDLogInfo("LookupWebViewHandler: init schema and date formats")
+                return self.call(javascript: "initSchemaAndDateFormats(\(encodedSchema), \(encodedDateFormats));")
+            }
+            .flatMap { _ -> Single<[RawTranslator]> in
+                DDLogInfo("LookupWebViewHandler: load translators")
+                return self.translatorsController.translators()
+            }
+            .flatMap { translators -> Single<Any> in
+                DDLogInfo("LookupWebViewHandler: encode translators")
+                let encodedTranslators = WebViewEncoder.encodeAsJSONForJavascript(translators)
+                return self.call(javascript: "initTranslators(\(encodedTranslators));")
+            }
+            .flatMap { _ -> Single<()> in
+                    .just(())
             }
 
-            func loadBundledFiles() -> Single<(String, String)> {
-                return .create { subscriber in
-                    guard let schemaUrl = Bundle.main.url(forResource: "schema", withExtension: "json", subdirectory: "Bundled"), let schemaData = try? Data(contentsOf: schemaUrl) else {
-                        DDLogError("LookupWebViewHandler: can't load schema json")
-                        subscriber(.failure(Error.cantFindFile))
-                        return Disposables.create()
-                    }
+        func loadIndex() -> Single<()> {
+            guard let indexUrl = Bundle.main.url(forResource: "lookup", withExtension: "html", subdirectory: "translation") else {
+                return .error(Error.cantFindFile)
+            }
+            return load(fileUrl: indexUrl)
+        }
 
-                    guard let dateFormatsUrl = Bundle.main.url(forResource: "dateFormats", withExtension: "json", subdirectory: "translation/translate/modules/utilities/resource"),
-                          let dateFormatData = try? Data(contentsOf: dateFormatsUrl)
-                    else {
-                        DDLogError("LookupWebViewHandler: can't load dateFormats json")
-                        subscriber(.failure(Error.cantFindFile))
-                        return Disposables.create()
-                    }
-
-                    let encodedSchema = WebViewEncoder.encodeForJavascript(schemaData)
-                    let encodedFormats = WebViewEncoder.encodeForJavascript(dateFormatData)
-
-                    DDLogInfo("LookupWebViewHandler: loaded bundled files")
-
-                    subscriber(.success((encodedSchema, encodedFormats)))
-
+        func loadBundledFiles() -> Single<(String, String)> {
+            return .create { subscriber in
+                guard let schemaUrl = Bundle.main.url(forResource: "schema", withExtension: "json", subdirectory: "Bundled"), let schemaData = try? Data(contentsOf: schemaUrl) else {
+                    DDLogError("LookupWebViewHandler: can't load schema json")
+                    subscriber(.failure(Error.cantFindFile))
                     return Disposables.create()
                 }
+
+                guard let dateFormatsUrl = Bundle.main.url(forResource: "dateFormats", withExtension: "json", subdirectory: "translation/translate/modules/utilities/resource"),
+                      let dateFormatData = try? Data(contentsOf: dateFormatsUrl)
+                else {
+                    DDLogError("LookupWebViewHandler: can't load dateFormats json")
+                    subscriber(.failure(Error.cantFindFile))
+                    return Disposables.create()
+                }
+
+                let encodedSchema = WebViewEncoder.encodeForJavascript(schemaData)
+                let encodedFormats = WebViewEncoder.encodeForJavascript(dateFormatData)
+
+                DDLogInfo("LookupWebViewHandler: loaded bundled files")
+
+                subscriber(.success((encodedSchema, encodedFormats)))
+
+                return Disposables.create()
             }
         }
     }
 
     func lookUp(identifier: String) {
-        initializationState.filter { result in
-            switch result {
-            case .inProgress:
-                return false
-
-            case .initialized, .failed:
-                return true
+        performAfterInitialization()
+            .flatMap { [weak self] _ -> Single<Any> in
+                guard let self else { return .never() }
+                DDLogInfo("LookupWebViewHandler: call translate js")
+                let encodedIdentifiers = WebViewEncoder.encodeForJavascript(identifier.data(using: .utf8))
+                return call(javascript: "lookup(\(encodedIdentifiers));")
             }
-        }
-        .first()
-        .subscribe(onSuccess: { [weak self] result in
-            guard let self, let result else { return }
-            switch result {
-            case .failed(let error):
-                observable.on(.next(.failure(error)))
-
-            case .initialized:
-                performLookUp(for: identifier)
-
-            case .inProgress:
-                break
-            }
-        })
-        .disposed(by: disposeBag)
-
-        func performLookUp(for identifier: String) {
-            DDLogInfo("LookupWebViewHandler: call translate js")
-            let encodedIdentifiers = WebViewEncoder.encodeForJavascript(identifier.data(using: .utf8))
-            return webViewHandler.call(javascript: "lookup(\(encodedIdentifiers));")
-                .subscribe(on: MainScheduler.instance)
-                .observe(on: MainScheduler.instance)
-                .subscribe(onFailure: { [weak self] error in
-                    DDLogError("LookupWebViewHandler: translation failed - \(error)")
-                    self?.observable.on(.next(.failure(error)))
-                })
-                .disposed(by: disposeBag)
-        }
+            .subscribe(on: MainScheduler.instance)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onFailure: { [weak self] error in
+                DDLogError("LookupWebViewHandler: translation failed - \(error)")
+                self?.observable.on(.next(.failure(error)))
+            })
+            .disposed(by: disposeBag)
     }
 
     /// Communication with JS in `webView`. The `webView` sends a message through one of the registered `JSHandlers`, which is received here.
@@ -211,14 +170,14 @@ final class LookupWebViewHandler {
 
             if let options = body["payload"] as? [String: Any] {
                 do {
-                    try webViewHandler.sendRequest(with: options, for: messageId)
+                    try sendRequest(with: options, for: messageId)
                 } catch let error {
                     DDLogError("LookupWebViewHandler: send request error \(error)")
-                    webViewHandler.sendMessaging(error: "Could not create request", for: messageId)
+                    sendMessaging(error: "Could not create request", for: messageId)
                 }
             } else {
                 DDLogError("LookupWebViewHandler: request missing payload - \(body)")
-                webViewHandler.sendMessaging(error: "HTTP request missing payload", for: messageId)
+                sendMessaging(error: "HTTP request missing payload", for: messageId)
             }
         }
     }

--- a/Zotero/Controllers/Web View Handling/WebViewHandler.swift
+++ b/Zotero/Controllers/Web View Handling/WebViewHandler.swift
@@ -17,7 +17,7 @@ protocol WebViewProvider: AnyObject {
     func addWebView(configuration: WKWebViewConfiguration?) -> WKWebView
 }
 
-open class WebViewHandler: NSObject {
+class WebViewHandler: NSObject {
     enum Error: Swift.Error {
         case webViewMissing
         case urlMissingTranslators

--- a/Zotero/Controllers/Web View Handling/WebViewHandler.swift
+++ b/Zotero/Controllers/Web View Handling/WebViewHandler.swift
@@ -10,16 +10,23 @@ import Foundation
 import WebKit
 
 import CocoaLumberjackSwift
+import RxCocoa
 import RxSwift
 
 protocol WebViewProvider: AnyObject {
     func addWebView(configuration: WKWebViewConfiguration?) -> WKWebView
 }
 
-final class WebViewHandler: NSObject {
+open class WebViewHandler: NSObject {
     enum Error: Swift.Error {
         case webViewMissing
         case urlMissingTranslators
+    }
+
+    private enum InitializationState {
+        case initialized
+        case inProgress
+        case failed(Swift.Error)
     }
 
     private let session: URLSession
@@ -31,6 +38,8 @@ final class WebViewHandler: NSObject {
     private(set) var cookies: String?
     private(set) var userAgent: String?
     private(set) var referer: String?
+    private var initializationState: BehaviorRelay<InitializationState>
+    private let disposeBag: DisposeBag
 
     // MARK: - Lifecycle
 
@@ -45,6 +54,8 @@ final class WebViewHandler: NSObject {
 
         session = URLSession(configuration: configuration)
         self.webView = webView
+        initializationState = BehaviorRelay(value: .inProgress)
+        disposeBag = DisposeBag()
 
         super.init()
 
@@ -60,9 +71,51 @@ final class WebViewHandler: NSObject {
 #if DEBUG
         webView.isInspectable = true
 #endif
+        initializeWebView()
+            .subscribe(on: MainScheduler.instance)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] _ in
+                DDLogInfo("WebViewHandler: initialization succeeded")
+                self?.initializationState.accept(.initialized)
+            }, onFailure: { [weak self] error in
+                DDLogInfo("WebViewHandler: initialization failed - \(error)")
+                self?.initializationState.accept(.failed(error))
+            })
+            .disposed(by: disposeBag)
     }
 
     // MARK: - Actions
+
+    /// Method to be overriden by subclasses. Default implementation just assumes web view is already initialized.
+    func initializeWebView() -> Single<()> {
+        return .just(())
+    }
+
+    func performAfterInitialization() -> Single<()> {
+        return initializationState.filter { state in
+            switch state {
+            case .inProgress:
+                return false
+
+            case .initialized, .failed:
+                return true
+            }
+        }
+        .first()
+        .flatMap { state -> Single<()> in
+            switch state {
+            case .failed(let error):
+                return .error(error)
+
+            case .initialized:
+                return .just(())
+
+            case .inProgress, .none:
+                // Should never happen.
+                return .never()
+            }
+        }
+    }
 
     func set(cookies: String?, userAgent: String?, referrer: String?) {
         self.cookies = cookies
@@ -202,14 +255,14 @@ final class WebViewHandler: NSObject {
 }
 
 extension WebViewHandler: WKNavigationDelegate {
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         // Wait for javascript to load
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
             self.webDidLoad?(.success(()))
         }
     }
 
-    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Swift.Error) {
+    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Swift.Error) {
         DDLogError("WebViewHandler: did fail - \(error)")
         webDidLoad?(.failure(error))
     }
@@ -218,7 +271,7 @@ extension WebViewHandler: WKNavigationDelegate {
 /// Communication with JS in `webView`. The `webView` sends a message through one of the registered `JSHandlers`, which is received here.
 /// Each message contains a `messageId` in the body, which is used to identify the message in case a response is expected.
 extension WebViewHandler: WKScriptMessageHandler {
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         inMainThread {
             self.receivedMessageHandler?(message.name, message.body)
         }

--- a/Zotero/Scenes/Detail/CitationBibliographyExport/CitationBibliographyExportCoordinator.swift
+++ b/Zotero/Scenes/Detail/CitationBibliographyExport/CitationBibliographyExportCoordinator.swift
@@ -67,7 +67,7 @@ final class CitationBibliographyExportCoordinator: NSObject, Coordinator {
 
         let state = CitationBibliographyExportState(itemIds: self.itemIds, libraryId: self.libraryId, selectedStyle: style, selectedLocaleId: localeId, languagePickerEnabled: languageEnabled,
                                                     selectedMode: Defaults.shared.exportOutputMode, selectedMethod: Defaults.shared.exportOutputMethod)
-        var handler = CitationBibliographyExportActionHandler(citationController: citationController, fileStorage: self.controllers.fileStorage, webView: webView)
+        var handler = CitationBibliographyExportActionHandler(citationController: citationController, fileStorage: self.controllers.fileStorage)
         handler.coordinatorDelegate = self
         let viewModel = ViewModel(initialState: state, handler: handler)
 

--- a/Zotero/Scenes/Detail/CitationBibliographyExport/Models/CitationBibliographyExportState.swift
+++ b/Zotero/Scenes/Detail/CitationBibliographyExport/Models/CitationBibliographyExportState.swift
@@ -51,6 +51,7 @@ struct CitationBibliographyExportState: ViewModelState {
     var outputFile: File?
 
     // Cite
+    var citationSession: CitationController.Session?
     var localeId: String
     var localeName: String
     var languagePickerEnabled: Bool

--- a/Zotero/Scenes/Detail/CitationBibliographyExport/ViewModels/CitationBibliographyExportActionHandler.swift
+++ b/Zotero/Scenes/Detail/CitationBibliographyExport/ViewModels/CitationBibliographyExportActionHandler.swift
@@ -19,41 +19,39 @@ struct CitationBibliographyExportActionHandler: ViewModelActionHandler {
 
     private unowned let citationController: CitationController
     private unowned let fileStorage: FileStorage
-    private unowned let webView: WKWebView
     private let queue: DispatchQueue
     private let disposeBag: DisposeBag
 
     weak var coordinatorDelegate: CitationBibliographyExportCoordinatorDelegate?
 
-    init(citationController: CitationController, fileStorage: FileStorage, webView: WKWebView) {
+    init(citationController: CitationController, fileStorage: FileStorage) {
         self.citationController = citationController
         self.fileStorage = fileStorage
-        self.webView = webView
-        self.queue = DispatchQueue(label: "org.zotero.CitationBibliographyExportActionHandler", qos: .userInteractive)
-        self.disposeBag = DisposeBag()
+        queue = DispatchQueue(label: "org.zotero.CitationBibliographyExportActionHandler", qos: .userInteractive)
+        disposeBag = DisposeBag()
     }
 
     func process(action: CitationBibliographyExportAction, in viewModel: ViewModel<CitationBibliographyExportActionHandler>) {
         switch action {
         case .setMethod(let method):
-            self.update(viewModel: viewModel) { state in
+            update(viewModel: viewModel) { state in
                 state.method = method
                 Defaults.shared.exportOutputMethod = method
             }
 
         case .setMode(let mode):
-            self.update(viewModel: viewModel) { state in
+            update(viewModel: viewModel) { state in
                 state.mode = mode
                 Defaults.shared.exportOutputMode = mode
             }
 
         case .setType(let type):
-            self.update(viewModel: viewModel) { state in
+            update(viewModel: viewModel) { state in
                 state.type = type
             }
 
         case .setStyle(let style):
-            self.update(viewModel: viewModel) { state in
+            update(viewModel: viewModel) { state in
                 state.style = style
                 Defaults.shared.exportStyleId = style.identifier
 
@@ -69,87 +67,103 @@ struct CitationBibliographyExportActionHandler: ViewModelActionHandler {
             }
 
         case .setLocale(let id, let name):
-            self.update(viewModel: viewModel) { state in
+            update(viewModel: viewModel) { state in
                 state.localeId = id
                 state.localeName = name
                 Defaults.shared.exportLocaleId = id
             }
 
         case .process:
-            self.process(in: viewModel)
+            process(in: viewModel)
         }
     }
 
     private func process(in viewModel: ViewModel<CitationBibliographyExportActionHandler>) {
-        self.update(viewModel: viewModel) { state in
+        update(viewModel: viewModel) { state in
             state.isLoading = true
         }
 
         switch viewModel.state.method {
         case .copy:
-            self.loadForCopy(in: viewModel)
+            loadForCopy(in: viewModel)
                 .subscribe(with: viewModel, onSuccess: { viewModel, data in
-                    self.copy(html: data.0, plaintext: data.1, in: viewModel)
-                    self.citationController.finishCitation()
+                    copy(html: data.0, plaintext: data.1, in: viewModel)
                 }, onFailure: { viewModel, error in
                     DDLogError("CitationBibliographyExportActionHandler: can't create citation of bibliography - \(error)")
-                    self.handle(error: error, in: viewModel)
-                    self.citationController.finishCitation()
+                    handle(error: error, in: viewModel)
+                }, onDisposed: { viewModel in
+                    endCitationSession(in: viewModel)
                 })
-                .disposed(by: self.disposeBag)
+                .disposed(by: disposeBag)
 
         case .html:
-            self.loadForHtml(in: viewModel)
+            loadForHtml(in: viewModel)
                 .subscribe(with: viewModel, onSuccess: { viewModel, html in
-                    self.save(html: html, in: viewModel)
-                    self.citationController.finishCitation()
+                    save(html: html, in: viewModel)
                 }, onFailure: { viewModel, error in
                     DDLogError("CitationBibliographyExportActionHandler: can't create citation of bibliography - \(error)")
-                    self.handle(error: error, in: viewModel)
-                    self.citationController.finishCitation()
+                    handle(error: error, in: viewModel)
+                }, onDisposed: { viewModel in
+                    endCitationSession(in: viewModel)
                 })
-                .disposed(by: self.disposeBag)
+                .disposed(by: disposeBag)
+        }
+
+        func endCitationSession(in viewModel: ViewModel<CitationBibliographyExportActionHandler>) {
+            guard let session = viewModel.state.citationSession else { return }
+            citationController.endSession(session)
+            update(viewModel: viewModel) { state in
+                state.citationSession = nil
+            }
         }
     }
 
+    private func loadSession(in viewModel: ViewModel<CitationBibliographyExportActionHandler>) -> Single<CitationController.Session> {
+        let state = viewModel.state
+        if let session = state.citationSession {
+            return .just(session)
+        }
+        return citationController.startSession(for: state.itemIds, libraryId: state.libraryId, styleId: state.style.identifier, localeId: state.localeId)
+            .flatMap { session -> Single<CitationController.Session> in
+                update(viewModel: viewModel) { state in
+                    state.citationSession = session
+                }
+                return .just(session)
+            }
+    }
+
     private func loadForCopy(in viewModel: ViewModel<CitationBibliographyExportActionHandler>) -> Single<(String, String)> {
-        let itemIds = viewModel.state.itemIds
+        return loadSession(in: viewModel).flatMap { session in
+            return loadForHtml(in: viewModel)
+                .flatMap { html in
+                    switch viewModel.state.mode {
+                    case .citation:
+                        return citationController.citation(for: session, label: nil, locator: nil, omitAuthor: false, format: .text, showInWebView: false)
+                            .flatMap({ return .just((html, $0)) })
 
-        switch viewModel.state.mode {
-        case .citation:
-            return self.loadForHtml(in: viewModel)
-                       .flatMap { html -> Single<(String, String)> in
-                           return self.citationController.citation(for: itemIds, label: nil, locator: nil, omitAuthor: false, format: .text, showInWebView: false)
-                                                         .flatMap({ return Single.just((html, $0)) })
-                       }
-
-        case .bibliography:
-            return self.loadForHtml(in: viewModel)
-                       .flatMap { html -> Single<(String, String)> in
-                        return self.citationController.bibliography(for: itemIds, format: .text).flatMap({ return Single.just((html, $0)) })
-                       }
+                    case .bibliography:
+                        return citationController.bibliography(for: session, format: .html)
+                            .flatMap({ return .just((html, $0)) })
+                    }
+                }
         }
     }
 
     private func loadForHtml(in viewModel: ViewModel<CitationBibliographyExportActionHandler>) -> Single<String> {
-        let itemIds = viewModel.state.itemIds
-        let libraryId = viewModel.state.libraryId
+        return loadSession(in: viewModel).flatMap { session in
+            switch viewModel.state.mode {
+            case .citation:
+                return citationController.citation(for: session, label: nil, locator: nil, omitAuthor: false, format: .html, showInWebView: false)
 
-        let prepare: Single<()> = self.citationController.prepare(webView: self.webView, for: itemIds, libraryId: libraryId,
-                                                                  styleId: viewModel.state.style.identifier, localeId: viewModel.state.localeId)
-
-        switch viewModel.state.mode {
-        case .citation:
-            return prepare.flatMap { self.citationController.citation(for: itemIds, label: nil, locator: nil, omitAuthor: false, format: .html, showInWebView: false) }
-
-        case .bibliography:
-            return prepare.flatMap { self.citationController.bibliography(for: itemIds, format: .html) }
+            case .bibliography:
+                return citationController.bibliography(for: session, format: .html)
+            }
         }
     }
 
     private func copy(html: String, plaintext: String, in viewModel: ViewModel<CitationBibliographyExportActionHandler>) {
         UIPasteboard.general.copy(html: html, plaintext: plaintext)
-        self.update(viewModel: viewModel) { state in
+        update(viewModel: viewModel) { state in
             state.isLoading = false
             state.changes = .finished
         }
@@ -158,7 +172,7 @@ struct CitationBibliographyExportActionHandler: ViewModelActionHandler {
     private func save(html: String, in viewModel: ViewModel<CitationBibliographyExportActionHandler>) {
         let finish: (Result<File, Error>) -> Void = { result in
             DispatchQueue.main.async {
-                self.update(viewModel: viewModel) { state in
+                update(viewModel: viewModel) { state in
                     switch result {
                     case .success(let file):
                         state.outputFile = file
@@ -173,7 +187,7 @@ struct CitationBibliographyExportActionHandler: ViewModelActionHandler {
             }
         }
 
-        self.queue.async {
+        queue.async {
             guard let data = html.data(using: .utf8) else {
                 finish(.failure(CitationBibliographyExportState.Error.cantCreateData))
                 return
@@ -183,7 +197,7 @@ struct CitationBibliographyExportActionHandler: ViewModelActionHandler {
             let file = Files.file(from: url)
 
             do {
-                try self.fileStorage.write(data, to: file, options: [])
+                try fileStorage.write(data, to: file, options: [])
                 finish(.success(file))
             } catch let error {
                 finish(.failure(error))
@@ -192,11 +206,11 @@ struct CitationBibliographyExportActionHandler: ViewModelActionHandler {
     }
 
     private func handle(error: Error, in viewModel: ViewModel<CitationBibliographyExportActionHandler>) {
-        self.update(viewModel: viewModel) { state in
+        update(viewModel: viewModel) { state in
             state.isLoading = false
 
             if let error = error as? CitationController.Error, error == .styleOrLocaleMissing {
-                self.coordinatorDelegate?.showStylePicker(picked: { style in
+                coordinatorDelegate?.showStylePicker(picked: { style in
                     viewModel.process(action: .setStyle(style))
                 })
             } else {

--- a/Zotero/Scenes/Detail/CitationBibliographyExport/ViewModels/CitationBibliographyExportActionHandler.swift
+++ b/Zotero/Scenes/Detail/CitationBibliographyExport/ViewModels/CitationBibliographyExportActionHandler.swift
@@ -119,14 +119,14 @@ struct CitationBibliographyExportActionHandler: ViewModelActionHandler {
         case .citation:
             return self.loadForHtml(in: viewModel)
                        .flatMap { html -> Single<(String, String)> in
-                           return self.citationController.citation(for: itemIds, label: nil, locator: nil, omitAuthor: false, format: .text, showInWebView: false, in: self.webView)
+                           return self.citationController.citation(for: itemIds, label: nil, locator: nil, omitAuthor: false, format: .text, showInWebView: false)
                                                          .flatMap({ return Single.just((html, $0)) })
                        }
 
         case .bibliography:
             return self.loadForHtml(in: viewModel)
                        .flatMap { html -> Single<(String, String)> in
-                        return self.citationController.bibliography(for: itemIds, format: .text, in: self.webView).flatMap({ return Single.just((html, $0)) })
+                        return self.citationController.bibliography(for: itemIds, format: .text).flatMap({ return Single.just((html, $0)) })
                        }
         }
     }
@@ -140,10 +140,10 @@ struct CitationBibliographyExportActionHandler: ViewModelActionHandler {
 
         switch viewModel.state.mode {
         case .citation:
-            return prepare.flatMap { self.citationController.citation(for: itemIds, label: nil, locator: nil, omitAuthor: false, format: .html, showInWebView: false, in: self.webView) }
+            return prepare.flatMap { self.citationController.citation(for: itemIds, label: nil, locator: nil, omitAuthor: false, format: .html, showInWebView: false) }
 
         case .bibliography:
-            return prepare.flatMap { self.citationController.bibliography(for: itemIds, format: .html, in: self.webView) }
+            return prepare.flatMap { self.citationController.bibliography(for: itemIds, format: .html) }
         }
     }
 

--- a/Zotero/Scenes/Detail/CitationBibliographyExport/ViewModels/CitationBibliographyExportActionHandler.swift
+++ b/Zotero/Scenes/Detail/CitationBibliographyExport/ViewModels/CitationBibliographyExportActionHandler.swift
@@ -130,7 +130,8 @@ struct CitationBibliographyExportActionHandler: ViewModelActionHandler {
             return .just(session)
         }
         return citationController.startSession(for: state.itemIds, libraryId: state.libraryId, styleId: state.style.identifier, localeId: state.localeId)
-            .do(onSuccess: { session in
+            .do(onSuccess: { [weak viewModel] session in
+                guard let viewModel else { return }
                 update(viewModel: viewModel) { state in
                     state.citationSession = session
                 }

--- a/Zotero/Scenes/Detail/CitationBibliographyExport/Views/CitationBibliographyExportView.swift
+++ b/Zotero/Scenes/Detail/CitationBibliographyExport/Views/CitationBibliographyExportView.swift
@@ -247,7 +247,7 @@ struct CitationBibliographyExportView_Previews: PreviewProvider {
                           isNoteStyle: false, defaultLocale: nil)
         let state = CitationBibliographyExportState(itemIds: [], libraryId: .custom(.myLibrary), selectedStyle: style, selectedLocaleId: "en_US", languagePickerEnabled: true,
                                                     selectedMode: .bibliography, selectedMethod: .copy)
-        let handler = CitationBibliographyExportActionHandler(citationController: controllers.userControllers!.citationController, fileStorage: controllers.fileStorage, webView: WKWebView())
+        let handler = CitationBibliographyExportActionHandler(citationController: controllers.userControllers!.citationController, fileStorage: controllers.fileStorage)
         let viewModel = ViewModel(initialState: state, handler: handler)
         return CitationBibliographyExportView().environmentObject(viewModel)
     }

--- a/Zotero/Scenes/Detail/CopyBibliography/Models/CopyBibliographyAction.swift
+++ b/Zotero/Scenes/Detail/CopyBibliography/Models/CopyBibliographyAction.swift
@@ -10,6 +10,6 @@ import UIKit
 import WebKit
 
 enum CopyBibliographyAction {
-    case preload(WKWebView)
+    case preload
     case cleanup
 }

--- a/Zotero/Scenes/Detail/CopyBibliography/Models/CopyBibliographyState.swift
+++ b/Zotero/Scenes/Detail/CopyBibliography/Models/CopyBibliographyState.swift
@@ -15,6 +15,7 @@ struct CopyBibliographyState: ViewModelState {
     let localeId: String
     let exportAsHtml: Bool
 
+    var citationSession: CitationController.Session?
     var processingBibliography = false
     var error: Error?
 

--- a/Zotero/Scenes/Detail/CopyBibliography/ViewModels/CopyBibliographyActionHandler.swift
+++ b/Zotero/Scenes/Detail/CopyBibliography/ViewModels/CopyBibliographyActionHandler.swift
@@ -43,10 +43,12 @@ struct CopyBibliographyActionHandler: ViewModelActionHandler {
 
             let state = viewModel.state
             citationController.startSession(for: state.itemIds, libraryId: state.libraryId, styleId: state.styleId, localeId: state.localeId)
-                .flatMap { session -> Single<(CitationController.Session, String)> in
+                .do(onSuccess: { session in
                     update(viewModel: viewModel) { state in
                         state.citationSession = session
                     }
+                })
+                .flatMap { session -> Single<(CitationController.Session, String)> in
                     return citationController.bibliography(for: session, format: .html).flatMap({ .just((session, $0)) })
                 }
                 .flatMap { session, html -> Single<(String, String?)> in

--- a/Zotero/Scenes/Detail/CopyBibliography/ViewModels/CopyBibliographyActionHandler.swift
+++ b/Zotero/Scenes/Detail/CopyBibliography/ViewModels/CopyBibliographyActionHandler.swift
@@ -43,14 +43,12 @@ struct CopyBibliographyActionHandler: ViewModelActionHandler {
             let localeId = viewModel.state.localeId
             let exportAsHtml = viewModel.state.exportAsHtml
             citationController.prepare(webView: webView, for: itemIds, libraryId: libraryId, styleId: styleId, localeId: localeId)
-                .flatMap { [weak webView] _ -> Single<String> in
-                    guard let webView else { return Single.error(CitationController.Error.prepareNotCalled) }
-                    return citationController.bibliography(for: itemIds, format: .html, in: webView)
+                .flatMap { _ -> Single<String> in
+                    return citationController.bibliography(for: itemIds, format: .html)
                 }
-                .flatMap { [weak webView] html -> Single<(String, String?)> in
+                .flatMap { html -> Single<(String, String?)> in
                     if exportAsHtml { return Single.just((html, nil)) }
-                    guard let webView else { return Single.error(CitationController.Error.prepareNotCalled) }
-                    return citationController.bibliography(for: itemIds, format: .text, in: webView).flatMap({ Single.just((html, $0)) })
+                    return citationController.bibliography(for: itemIds, format: .text).flatMap({ Single.just((html, $0)) })
                 }
                 .subscribe(with: viewModel, onSuccess: { viewModel, data in
                     if let plaintext = data.1 {

--- a/Zotero/Scenes/Detail/CopyBibliography/ViewModels/CopyBibliographyActionHandler.swift
+++ b/Zotero/Scenes/Detail/CopyBibliography/ViewModels/CopyBibliographyActionHandler.swift
@@ -43,7 +43,8 @@ struct CopyBibliographyActionHandler: ViewModelActionHandler {
 
             let state = viewModel.state
             citationController.startSession(for: state.itemIds, libraryId: state.libraryId, styleId: state.styleId, localeId: state.localeId)
-                .do(onSuccess: { session in
+                .do(onSuccess: { [weak viewModel] session in
+                    guard let viewModel else { return }
                     update(viewModel: viewModel) { state in
                         state.citationSession = session
                     }

--- a/Zotero/Scenes/Detail/CopyBibliography/Views/CopyBibliographyViewController.swift
+++ b/Zotero/Scenes/Detail/CopyBibliography/Views/CopyBibliographyViewController.swift
@@ -24,7 +24,6 @@ class CopyBibliographyViewController: UIViewController {
     private weak var overlayActivityIndicator: UIActivityIndicatorView!
     private weak var overlayErrorIcon: UIImageView!
     private weak var overlayText: UILabel!
-    private weak var webView: WKWebView!
 
     private let viewModel: ViewModel<CopyBibliographyActionHandler>
     private let disposeBag = DisposeBag()
@@ -53,7 +52,7 @@ class CopyBibliographyViewController: UIViewController {
         view.alpha = 0
         setupView()
         setupObserving()
-        viewModel.process(action: .preload(webView))
+        viewModel.process(action: .preload)
 
         func setupView() {
             let overlayBody = UIView()
@@ -91,11 +90,6 @@ class CopyBibliographyViewController: UIViewController {
             overlayText.setContentCompressionResistancePriority(.required, for: .vertical)
             self.overlayText = overlayText
             stackView.addArrangedSubview(overlayText)
-
-            let webView = WKWebView()
-            webView.isHidden = true
-            view.insertSubview(webView, at: 0)
-            self.webView = webView
 
             NSLayoutConstraint.activate([
                 overlayBody.centerXAnchor.constraint(equalTo: view.centerXAnchor),

--- a/Zotero/Scenes/Detail/CopyBibliography/Views/CopyBibliographyViewController.swift
+++ b/Zotero/Scenes/Detail/CopyBibliography/Views/CopyBibliographyViewController.swift
@@ -84,7 +84,7 @@ class CopyBibliographyViewController: UIViewController {
             stackView.addArrangedSubview(overlayErrorIcon)
 
             let overlayText = UILabel()
-            overlayText.text = "Generating Bibliography"
+            overlayText.text = L10n.Items.generatingBib
             overlayText.textColor = .white
             overlayText.font = .preferredFont(forTextStyle: .body)
             overlayText.setContentCompressionResistancePriority(.required, for: .horizontal)

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -189,7 +189,6 @@ final class DetailCoordinator: Coordinator {
                 schemaController: controllers.schemaController,
                 urlDetector: controllers.urlDetector,
                 fileDownloader: userControllers.fileDownloader,
-                citationController: userControllers.citationController,
                 fileCleanupController: userControllers.fileCleanupController,
                 syncScheduler: userControllers.syncScheduler,
                 htmlAttributedStringConverter: controllers.htmlAttributedStringConverter

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
@@ -22,7 +22,6 @@ final class ItemsActionHandler: BaseItemsActionHandler, ViewModelActionHandler {
     private unowned let schemaController: SchemaController
     private unowned let urlDetector: UrlDetector
     private unowned let fileDownloader: AttachmentDownloader
-    private unowned let citationController: CitationController
     private unowned let fileCleanupController: AttachmentFileCleanupController
     private unowned let syncScheduler: SynchronizationScheduler
     private unowned let htmlAttributedStringConverter: HtmlAttributedStringConverter
@@ -34,7 +33,6 @@ final class ItemsActionHandler: BaseItemsActionHandler, ViewModelActionHandler {
         schemaController: SchemaController,
         urlDetector: UrlDetector,
         fileDownloader: AttachmentDownloader,
-        citationController: CitationController,
         fileCleanupController: AttachmentFileCleanupController,
         syncScheduler: SynchronizationScheduler,
         htmlAttributedStringConverter: HtmlAttributedStringConverter
@@ -43,7 +41,6 @@ final class ItemsActionHandler: BaseItemsActionHandler, ViewModelActionHandler {
         self.schemaController = schemaController
         self.urlDetector = urlDetector
         self.fileDownloader = fileDownloader
-        self.citationController = citationController
         self.fileCleanupController = fileCleanupController
         self.syncScheduler = syncScheduler
         self.htmlAttributedStringConverter = htmlAttributedStringConverter

--- a/Zotero/Scenes/Detail/SingleCitation/Models/SingleCitationAction.swift
+++ b/Zotero/Scenes/Detail/SingleCitation/Models/SingleCitationAction.swift
@@ -11,10 +11,10 @@ import WebKit
 
 enum SingleCitationAction {
     case preload(webView: WKWebView)
-    case setLocator(locator: String, webView: WKWebView)
-    case setLocatorValue(value: String, webView: WKWebView)
-    case setOmitAuthor(omitAuthor: Bool, webView: WKWebView)
+    case setLocator(locator: String)
+    case setLocatorValue(value: String)
+    case setOmitAuthor(omitAuthor: Bool)
     case setPreviewHeight(CGFloat)
     case cleanup
-    case copy(webView: WKWebView)
+    case copy
 }

--- a/Zotero/Scenes/Detail/SingleCitation/Models/SingleCitationState.swift
+++ b/Zotero/Scenes/Detail/SingleCitation/Models/SingleCitationState.swift
@@ -15,10 +15,11 @@ struct SingleCitationState: ViewModelState {
 
         let rawValue: UInt8
 
-        static let locator = Changes(rawValue: 1 << 0)
-        static let preview = Changes(rawValue: 1 << 1)
-        static let copied = Changes(rawValue: 1 << 2)
-        static let height = Changes(rawValue: 1 << 3)
+        static let webViewLoaded = Changes(rawValue: 1 << 0)
+        static let locator = Changes(rawValue: 1 << 1)
+        static let preview = Changes(rawValue: 1 << 2)
+        static let copied = Changes(rawValue: 1 << 3)
+        static let height = Changes(rawValue: 1 << 4)
     }
 
     enum Error: Swift.Error {
@@ -34,6 +35,7 @@ struct SingleCitationState: ViewModelState {
     let localeId: String
     let exportAsHtml: Bool
 
+    var citationSession: CitationController.Session?
     var loadingCopy: Bool
     var locator: String
     var locatorValue: String

--- a/Zotero/Scenes/Detail/SingleCitation/ViewModels/SingleCitationActionHandler.swift
+++ b/Zotero/Scenes/Detail/SingleCitation/ViewModels/SingleCitationActionHandler.swift
@@ -143,11 +143,13 @@ struct SingleCitationActionHandler: ViewModelActionHandler {
     private func preload(webView: WKWebView, in viewModel: ViewModel<SingleCitationActionHandler>) {
         let state = viewModel.state
         citationController.startSession(for: state.itemIds, libraryId: state.libraryId, styleId: state.styleId, localeId: state.localeId, webView: webView)
-            .flatMap { session -> Single<String> in
+            .do(onSuccess: { session in
                 update(viewModel: viewModel) { state in
                     state.citationSession = session
                     state.changes = .webViewLoaded
                 }
+            })
+            .flatMap { session -> Single<String> in
                 return citationController.citation(for: session, label: state.locator, locator: state.locatorValue, omitAuthor: state.omitAuthor, format: .html, showInWebView: true)
             }
             .subscribe(

--- a/Zotero/Scenes/Detail/SingleCitation/ViewModels/SingleCitationActionHandler.swift
+++ b/Zotero/Scenes/Detail/SingleCitation/ViewModels/SingleCitationActionHandler.swift
@@ -143,7 +143,8 @@ struct SingleCitationActionHandler: ViewModelActionHandler {
     private func preload(webView: WKWebView, in viewModel: ViewModel<SingleCitationActionHandler>) {
         let state = viewModel.state
         citationController.startSession(for: state.itemIds, libraryId: state.libraryId, styleId: state.styleId, localeId: state.localeId, webView: webView)
-            .do(onSuccess: { session in
+            .do(onSuccess: { [weak viewModel] session in
+                guard let viewModel else { return }
                 update(viewModel: viewModel) { state in
                     state.citationSession = session
                     state.changes = .webViewLoaded

--- a/Zotero/Scenes/Detail/SingleCitation/Views/SingleCitationViewController.swift
+++ b/Zotero/Scenes/Detail/SingleCitation/Views/SingleCitationViewController.swift
@@ -40,7 +40,7 @@ final class SingleCitationViewController: UIViewController {
                 value: data.1,
                 locatorChanged: { [weak self] newLocator in
                     guard let self else { return }
-                    viewModel.process(action: .setLocator(locator: newLocator, webView: previewWebView))
+                    viewModel.process(action: .setLocator(locator: newLocator))
                 }
             )
             if let valueObservable = cell.valueObservable {
@@ -48,7 +48,7 @@ final class SingleCitationViewController: UIViewController {
                     .debounce(.milliseconds(150), scheduler: MainScheduler.instance)
                     .subscribe(onNext: { [weak self] newValue in
                         guard let self else { return }
-                        viewModel.process(action: .setLocatorValue(value: newValue, webView: previewWebView))
+                        viewModel.process(action: .setLocatorValue(value: newValue))
                     })
                     .disposed(by: cell.disposeBag)
             }
@@ -58,7 +58,7 @@ final class SingleCitationViewController: UIViewController {
         return UICollectionView.CellRegistration<CitationAuthorCell, Bool> { [weak self] cell, _, omitAuthor in
             cell.contentConfiguration = CitationAuthorCell.ContentConfiguration(omitAuthor: omitAuthor, omitAuthorChanged: { [weak self] newOmitAuthor in
                 guard let self else { return }
-                viewModel.process(action: .setOmitAuthor(omitAuthor: newOmitAuthor, webView: previewWebView))
+                viewModel.process(action: .setOmitAuthor(omitAuthor: newOmitAuthor))
             })
         }
     }()
@@ -262,7 +262,7 @@ final class SingleCitationViewController: UIViewController {
             let copy = UIBarButtonItem(title: L10n.copy, style: .done, target: nil, action: nil)
             copy.rx.tap.subscribe(onNext: { [weak self] in
                 guard let self else { return }
-                viewModel.process(action: .copy(webView: previewWebView))
+                viewModel.process(action: .copy)
             })
             .disposed(by: disposeBag)
             navigationItem.rightBarButtonItem = copy

--- a/Zotero/Scenes/Detail/SingleCitation/Views/SingleCitationViewController.swift
+++ b/Zotero/Scenes/Detail/SingleCitation/Views/SingleCitationViewController.swift
@@ -211,18 +211,13 @@ final class SingleCitationViewController: UIViewController {
         }
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        previewWebView.configuration.userContentController.add(self, name: "heightHandler")
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        previewWebView.configuration.userContentController.removeAllScriptMessageHandlers()
-    }
-
     // MARK: - Actions
     private func update(state: SingleCitationState) {
+        if state.changes.contains(.webViewLoaded) {
+            previewWebView.configuration.userContentController.add(self, name: "heightHandler")
+            return
+        }
+
         setupRightButtonItem(isLoading: state.loadingCopy)
         navigationItem.rightBarButtonItem?.isEnabled = state.preview != nil
 

--- a/Zotero/Scenes/Master/Libraries/Views/LibrariesViewController.swift
+++ b/Zotero/Scenes/Master/Libraries/Views/LibrariesViewController.swift
@@ -232,9 +232,9 @@ extension LibrariesViewController: UITableViewDataSource, UITableViewDelegate {
 
 extension LibrariesViewController: BottomSheetObserver { }
 
-extension LibrariesViewController: IdentifierLookupWebViewProvider {
-    func addWebView() -> WKWebView {
-        let webView = WKWebView()
+extension LibrariesViewController: WebViewProvider {
+    func addWebView(configuration: WKWebViewConfiguration?) -> WKWebView {
+        let webView: WKWebView = configuration.flatMap({ WKWebView(frame: .zero, configuration: $0) }) ?? WKWebView()
         webView.isHidden = true
         view.insertSubview(webView, at: 0)
         return webView

--- a/Zotero/Scenes/Master/Libraries/Views/LibrariesViewController.swift
+++ b/Zotero/Scenes/Master/Libraries/Views/LibrariesViewController.swift
@@ -19,7 +19,6 @@ final class LibrariesViewController: UIViewController {
     private static let groupLibrariesSection = 1
     private let viewModel: ViewModel<LibrariesActionHandler>
     private unowned let syncScheduler: SynchronizationScheduler
-    private unowned let identifierLookupController: IdentifierLookupController
     private let disposeBag: DisposeBag
 
     private var refreshController: SyncRefreshController?
@@ -30,14 +29,11 @@ final class LibrariesViewController: UIViewController {
 
     // MARK: - Lifecycle
 
-    init(viewModel: ViewModel<LibrariesActionHandler>, syncScheduler: SynchronizationScheduler, identifierLookupController: IdentifierLookupController) {
+    init(viewModel: ViewModel<LibrariesActionHandler>, syncScheduler: SynchronizationScheduler) {
         self.viewModel = viewModel
         self.syncScheduler = syncScheduler
-        self.identifierLookupController = identifierLookupController
         self.disposeBag = DisposeBag()
         super.init(nibName: "LibrariesViewController", bundle: nil)
-        
-        identifierLookupController.webViewProvider = self
     }
 
     required init?(coder: NSCoder) {

--- a/Zotero/Scenes/Master/MasterCoordinator.swift
+++ b/Zotero/Scenes/Master/MasterCoordinator.swift
@@ -61,6 +61,7 @@ final class MasterCoordinator: NSObject, Coordinator {
             syncScheduler: userControllers.syncScheduler,
             identifierLookupController: userControllers.identifierLookupController
         )
+        userControllers.identifierLookupController.webViewProvider = librariesController
         let collectionsController = self.createCollectionsViewController(
             libraryId: self.visibleLibraryId,
             selectedCollectionId: Defaults.shared.selectedCollectionId,
@@ -72,9 +73,9 @@ final class MasterCoordinator: NSObject, Coordinator {
         self.navigationController?.setViewControllers([librariesController, collectionsController], animated: animated)
     }
 
-    private func createLibrariesViewController(dbStorage: DbStorage, syncScheduler: SynchronizationScheduler, identifierLookupController: IdentifierLookupController) -> UIViewController {
+    private func createLibrariesViewController(dbStorage: DbStorage, syncScheduler: SynchronizationScheduler, identifierLookupController: IdentifierLookupController) -> LibrariesViewController {
         let viewModel = ViewModel(initialState: LibrariesState(), handler: LibrariesActionHandler(dbStorage: dbStorage))
-        let controller = LibrariesViewController(viewModel: viewModel, syncScheduler: syncScheduler, identifierLookupController: identifierLookupController)
+        let controller = LibrariesViewController(viewModel: viewModel, syncScheduler: syncScheduler)
         controller.coordinatorDelegate = self
         return controller
     }

--- a/Zotero/Scenes/Master/MasterCoordinator.swift
+++ b/Zotero/Scenes/Master/MasterCoordinator.swift
@@ -62,6 +62,7 @@ final class MasterCoordinator: NSObject, Coordinator {
             identifierLookupController: userControllers.identifierLookupController
         )
         userControllers.identifierLookupController.webViewProvider = librariesController
+        userControllers.citationController.webViewProvider = librariesController
         let collectionsController = self.createCollectionsViewController(
             libraryId: self.visibleLibraryId,
             selectedCollectionId: Defaults.shared.selectedCollectionId,


### PR DESCRIPTION
Refactors citation controller to two a citation web view handler part and a citation controller part that allows multiple citation sessions, even without an explicitly provided web view, useful if preview is not desired. These changes will be used in drag-and-drop of items to generate a bibliography text representation rather than using the item key.