### PR TITLE
Show share extension tags picker only for translated items

### DIFF
--- a/ZShare/View Controllers/ShareViewController.swift
+++ b/ZShare/View Controllers/ShareViewController.swift
@@ -240,6 +240,13 @@ final class ShareViewController: UIViewController {
         self.update(attachmentState: state.attachmentState, itemState: state.itemPickerState, hasItem: hasItem, isSubmitting: state.isSubmitting)
         self.update(collectionPicker: state.collectionPickerState, recents: state.recents)
         self.update(itemPicker: state.itemPickerState, hasExpectedItem: (state.expectedItem != nil || state.expectedAttachment != nil))
+        switch state.processedAttachment {
+        case .none, .file:
+            tagPickerStackContainer.isHidden = true
+
+        case .item, .itemWithAttachment:
+            tagPickerStackContainer.isHidden = false
+        }
         self.updateTagPicker(with: state.tags)
 
         if self.viewIsVisible {


### PR DESCRIPTION
Since tags are ignored when creating the database item for a shared file without a parent, the tags picker is shown only when needed, so that there are no false user expections.