### PR TITLE
Fix item default attachment

### DIFF
--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsActionHandler.swift
@@ -302,7 +302,7 @@ final class ItemsActionHandler: BaseItemsActionHandler, ViewModelActionHandler {
 
     private func process(downloadUpdate: AttachmentDownloader.Update, batchData: ItemsState.DownloadBatchData?, in viewModel: ViewModel<ItemsActionHandler>) {
         let updateKey = downloadUpdate.parentKey ?? downloadUpdate.key
-        guard let accessory = viewModel.state.itemAccessories[updateKey], let attachment = accessory.attachment else {
+        guard let accessory = viewModel.state.itemAccessories[updateKey], let attachment = accessory.attachment, attachment.key == downloadUpdate.key else {
             updateViewModel()
             return
         }

--- a/Zotero/Scenes/Detail/Trash/ViewModels/TrashActionHandler.swift
+++ b/Zotero/Scenes/Detail/Trash/ViewModels/TrashActionHandler.swift
@@ -495,7 +495,7 @@ final class TrashActionHandler: BaseItemsActionHandler, ViewModelActionHandler {
 
     private func process(downloadUpdate: AttachmentDownloader.Update, batchData: ItemsState.DownloadBatchData?, in viewModel: ViewModel<TrashActionHandler>) {
         let updateKey = TrashKey(type: .item, key: downloadUpdate.parentKey ?? downloadUpdate.key)
-        guard let itemData = viewModel.state.itemDataCache[updateKey], let attachment = itemData.accessory?.attachment else {
+        guard let itemData = viewModel.state.itemDataCache[updateKey], let attachment = itemData.accessory?.attachment, attachment.key == downloadUpdate.key else {
             updateViewModel()
             return
         }


### PR DESCRIPTION
Fixes an issue where downloading not the default attachment in item details, and then going back, would show the in the items screen the default attachment as downloaded, which would result in an error when attempting to open. Issue didn't appear if the specific collections items reloaded, e.g. by changing collections, only when going directly from item details to its collection items screen.