### PR TITLE
Fix SplitControllerDelegate for iOS 26

### DIFF
--- a/Zotero/Scenes/Main/Views/MainViewController.swift
+++ b/Zotero/Scenes/Main/Views/MainViewController.swift
@@ -57,6 +57,7 @@ final class MainViewController: UISplitViewController {
             let masterCoordinator = MasterCoordinator(navigationController: masterController, mainCoordinatorDelegate: self, controllers: controllers)
             masterController.coordinatorDelegate = masterCoordinator
             masterCoordinator.start(animated: false)
+            // In iOS 26 setting the viewControllers here (or in viewDidLoad for that matter), doesn't set the view controller's children initially.
             viewControllers = [masterController]
             self.masterCoordinator = masterCoordinator
         }

--- a/Zotero/Scenes/Master/Collections/Views/CollectionsViewController.swift
+++ b/Zotero/Scenes/Master/Collections/Views/CollectionsViewController.swift
@@ -242,6 +242,10 @@ extension CollectionsViewController: BottomSheetObserver { }
 
 extension CollectionsViewController: SplitControllerDelegate {
     var isSplit: Bool {
-        splitViewController?.isCollapsed == false
+        // In iOS 26 split view controller is nil when this view loads for the first time.
+        // We assume in that case that the view is split, as we want in any case for the collection items view controller to load.
+        // In actual split view it shown as the detail, while in collapsed view it is pushed in the stack as the initially presented view controller.
+        guard let splitViewController else { return true }
+        return splitViewController.isCollapsed == false
     }
 }


### PR DESCRIPTION
In iOS 26 setting the `MainViewController`'s `viewControllers` directly doesn't update its 'children` at once (possibly an iOS 26 bug), resulting in faulty logic in `CollectionsViewController` `viewDidLoad`, that shows detail view controller blank. This is fixed by assuming that lack of a `splitViewController reference` means a split state.