### PR TITLE
Fix collections action handler crash

### DIFF
--- a/Zotero/Scenes/Master/Collections/ViewModels/CollectionsActionHandler.swift
+++ b/Zotero/Scenes/Master/Collections/ViewModels/CollectionsActionHandler.swift
@@ -80,8 +80,9 @@ final class CollectionsActionHandler: ViewModelActionHandler, BackgroundDbProces
             guard let self, let viewModel else { return }
             do {
                 let items = try dbStorage.perform(request: ReadAllAttachmentsFromCollectionDbRequest(collectionId: collectionId, libraryId: viewModel.state.library.identifier), on: backgroundQueue)
-                let attachments = items.compactMap({ [weak self] item -> (Attachment, String?)? in
-                    guard let self, let attachment = AttachmentCreator.attachment(for: item, fileStorage: fileStorage, urlDetector: nil) else { return nil }
+                let fileStorage = self.fileStorage
+                let attachments = items.compactMap({ item -> (Attachment, String?)? in
+                    guard let attachment = AttachmentCreator.attachment(for: item, fileStorage: fileStorage, urlDetector: nil) else { return nil }
 
                     switch attachment.type {
                     case .file(_, _, _, let linkType, _):


### PR DESCRIPTION
Potential fix for issue reported in this forum [post](https://forums.zotero.org/discussion/125361/ios-crash-report-666393121/).

The crash with the error `swift_unknownObjectUnownedLoadStrong` when accessing`dbStorage` in the nested fuction `updateTrashCount`. Both calls of this are in `Results<RItem>` observation blocks. Converting the struct to class allows to also weakly capture `self` and also pass explicitely to nested functions after guarding that it is valid.

If we still get similar crashes though, perhaps due to internal iOS changes that cause these edge cases, we should consider refactoring `BackgroundDbProcessingActionHandler` `dbStorage` to `DbStorage?` so that it can be `weak` when implementing the protocol.