### PR TITLE
Fix PDF reader find selection ignoring first search

### DIFF
--- a/Zotero/Scenes/Detail/PDF/Views/PDFSearchViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFSearchViewController.swift
@@ -62,6 +62,10 @@ final class PDFSearchViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupViews()
+        if let text {
+            searchBar.text = text
+            search(for: text)
+        }
 
         func setupViews() {
             let tableView = UITableView()


### PR DESCRIPTION
Text provided during initialization of `PDFSearchViewController` is not actually searched for. Since the view controller is reused, this would affect only an initial search using the `Find Selection` action of selected text.