### PR TITLE
Improve popover source item logic

### DIFF
--- a/Zotero/Controllers/Architecture/Coordinator.swift
+++ b/Zotero/Controllers/Architecture/Coordinator.swift
@@ -8,8 +8,8 @@
 
 import UIKit
 
-enum SourceView {
-    case view(UIView, CGRect = .null)
+private enum Source {
+    case view(UIView, CGRect)
     case item(UIPopoverPresentationControllerSourceItem)
 }
 
@@ -22,7 +22,15 @@ protocol Coordinator: AnyObject {
     func childDidFinish(_ child: Coordinator)
     func share(
         item: Any,
-        sourceView: SourceView,
+        sourceItem: UIPopoverPresentationControllerSourceItem,
+        presenter: UIViewController?,
+        userInterfaceStyle: UIUserInterfaceStyle?,
+        completionWithItemsHandler: UIActivityViewController.CompletionWithItemsHandler?
+    )
+    func share(
+        item: Any,
+        sourceView: UIView,
+        sourceRect: CGRect,
         presenter: UIViewController?,
         userInterfaceStyle: UIUserInterfaceStyle?,
         completionWithItemsHandler: UIActivityViewController.CompletionWithItemsHandler?
@@ -42,12 +50,12 @@ extension Coordinator {
         }
     }
 
-    func share(
+    private func share(
         item: Any,
-        sourceView: SourceView,
-        presenter: UIViewController? = nil,
-        userInterfaceStyle: UIUserInterfaceStyle? = nil,
-        completionWithItemsHandler: UIActivityViewController.CompletionWithItemsHandler? = nil
+        source: Source,
+        presenter: UIViewController?,
+        userInterfaceStyle: UIUserInterfaceStyle?,
+        completionWithItemsHandler: UIActivityViewController.CompletionWithItemsHandler?
     ) {
         let controller = UIActivityViewController(activityItems: [item], applicationActivities: nil)
         if let userInterfaceStyle {
@@ -56,7 +64,7 @@ extension Coordinator {
         controller.modalPresentationStyle = .pageSheet
         controller.completionWithItemsHandler = completionWithItemsHandler
 
-        switch sourceView {
+        switch source {
         case .item(let item):
             controller.popoverPresentationController?.sourceItem = item
 
@@ -66,5 +74,26 @@ extension Coordinator {
         }
 
         (presenter ?? navigationController)?.present(controller, animated: true, completion: nil)
+    }
+
+    func share(
+        item: Any,
+        sourceItem: UIPopoverPresentationControllerSourceItem,
+        presenter: UIViewController? = nil,
+        userInterfaceStyle: UIUserInterfaceStyle? = nil,
+        completionWithItemsHandler: UIActivityViewController.CompletionWithItemsHandler? = nil
+    ) {
+        share(item: item, source: .item(sourceItem), presenter: presenter, userInterfaceStyle: userInterfaceStyle, completionWithItemsHandler: completionWithItemsHandler)
+    }
+
+    func share(
+        item: Any,
+        sourceView: UIView,
+        sourceRect: CGRect,
+        presenter: UIViewController? = nil,
+        userInterfaceStyle: UIUserInterfaceStyle? = nil,
+        completionWithItemsHandler: UIActivityViewController.CompletionWithItemsHandler? = nil
+    ) {
+        share(item: item, source: .view(sourceView, sourceRect), presenter: presenter, userInterfaceStyle: userInterfaceStyle, completionWithItemsHandler: completionWithItemsHandler)
     }
 }

--- a/Zotero/Controllers/Architecture/Coordinator.swift
+++ b/Zotero/Controllers/Architecture/Coordinator.swift
@@ -9,8 +9,8 @@
 import UIKit
 
 enum SourceView {
-    case view(UIView, CGRect?)
-    case item(UIBarButtonItem)
+    case view(UIView, CGRect = .null)
+    case item(UIPopoverPresentationControllerSourceItem)
 }
 
 protocol Coordinator: AnyObject {
@@ -58,13 +58,11 @@ extension Coordinator {
 
         switch sourceView {
         case .item(let item):
-            controller.popoverPresentationController?.barButtonItem = item
+            controller.popoverPresentationController?.sourceItem = item
 
         case .view(let sourceView, let sourceRect):
             controller.popoverPresentationController?.sourceView = sourceView
-            if let rect = sourceRect {
-                controller.popoverPresentationController?.sourceRect = rect
-            }
+            controller.popoverPresentationController?.sourceRect = sourceRect
         }
 
         (presenter ?? navigationController)?.present(controller, animated: true, completion: nil)

--- a/Zotero/Scenes/Detail/CitationBibliographyExport/CitationBibliographyExportCoordinator.swift
+++ b/Zotero/Scenes/Detail/CitationBibliographyExport/CitationBibliographyExportCoordinator.swift
@@ -97,7 +97,7 @@ final class CitationBibliographyExportCoordinator: NSObject, Coordinator {
         guard let navigationController else { return }
         let controller = UIActivityViewController(activityItems: [file.createUrl()], applicationActivities: nil)
         controller.modalPresentationStyle = .pageSheet
-        controller.popoverPresentationController?.sourceView = navigationController.viewControllers.first?.view
+        controller.popoverPresentationController?.sourceItem = navigationController.viewControllers.first?.view
         controller.completionWithItemsHandler = { [weak self] _, finished, _, _ in
             if finished {
                 self?.cancel()

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -812,7 +812,7 @@ extension DetailCoordinator: DetailItemDetailCoordinatorDelegate {
     func showAttachmentPicker(save: @escaping ([URL]) -> Void) {
         guard let navigationController else { return }
         let controller = DocumentPickerViewController(forOpeningContentTypes: [.pdf, .png, .jpeg], asCopy: true)
-        controller.popoverPresentationController?.sourceView = navigationController.visibleViewController?.view
+        controller.popoverPresentationController?.sourceItem = navigationController.visibleViewController?.view
         controller.observable
                   .observe(on: MainScheduler.instance)
                   .subscribe(onNext: { urls in

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -439,7 +439,7 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
 
     func showAddActions(viewModel: ViewModel<ItemsActionHandler>, button: UIBarButtonItem) {
         let controller = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        controller.popoverPresentationController?.barButtonItem = button
+        controller.popoverPresentationController?.sourceItem = button
 
         if viewModel.state.library.metadataAndFilesEditable {
             controller.addAction(UIAlertAction(title: L10n.Items.lookup, style: .default, handler: { [weak self] _ in
@@ -488,8 +488,8 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
         DDLogInfo("DetailCoordinator: show item sort popup")
 
         let sortNavigationController = UINavigationController()
-        sortNavigationController.modalPresentationStyle = UIDevice.current.userInterfaceIdiom == .pad ? .popover : .formSheet
-        sortNavigationController.popoverPresentationController?.barButtonItem = button
+        sortNavigationController.modalPresentationStyle = .popover
+        sortNavigationController.popoverPresentationController?.sourceItem = button
         let view = ItemSortingView(
             sortType: sortType,
             changed: changed,
@@ -662,8 +662,8 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
         DDLogInfo("DetailCoordinator: show item filters")
 
         let navigationController = NavigationViewController()
-        navigationController.modalPresentationStyle = UIDevice.current.userInterfaceIdiom == .pad ? .popover : .formSheet
-        navigationController.popoverPresentationController?.barButtonItem = button
+        navigationController.modalPresentationStyle = .popover
+        navigationController.popoverPresentationController?.sourceItem = button
 
         let coordinator = ItemsFilterCoordinator(filters: filters, filtersDelegate: filtersDelegate, navigationController: navigationController, controllers: controllers)
         coordinator.parentCoordinator = self

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -208,10 +208,10 @@ final class DetailCoordinator: Coordinator {
             .compactMap({ ($0 as? DetailCoordinatorAttachmentProvider)?.attachment(for: key, parentKey: parentKey, libraryId: libraryId) })
             .first
         else { return }
-        self.show(attachment: attachment, parentKey: parentKey, libraryId: libraryId, sourceView: sourceView, sourceRect: sourceRect)
+        self.show(attachment: attachment, parentKey: parentKey, libraryId: libraryId, sourceView: sourceView, sourceRect: sourceRect ?? .null)
     }
 
-    private func show(attachment: Attachment, parentKey: String?, libraryId: LibraryIdentifier, sourceView: UIView, sourceRect: CGRect?) {
+    private func show(attachment: Attachment, parentKey: String?, libraryId: LibraryIdentifier, sourceView: UIView, sourceRect: CGRect) {
         switch attachment.type {
         case .url(let url):
             show(url: url)
@@ -219,7 +219,6 @@ final class DetailCoordinator: Coordinator {
         case .file(let filename, let contentType, _, _, _):
             let file = Files.attachmentFile(in: libraryId, key: attachment.key, filename: filename, contentType: contentType)
             let url = file.createUrl()
-            let rect = sourceRect ?? CGRect(x: (sourceView.frame.width / 3.0), y: (sourceView.frame.height * 2.0 / 3.0), width: (sourceView.frame.width / 3), height: (sourceView.frame.height / 3))
 
             switch contentType {
             case "application/pdf":
@@ -234,7 +233,7 @@ final class DetailCoordinator: Coordinator {
                     showWebView(for: url)
                 } else {
                     DDLogInfo("DetailCoordinator: share attachment \(attachment.key)")
-                    share(item: file.createUrl(), sourceView: .view(sourceView, rect))
+                    share(item: file.createUrl(), sourceView: .view(sourceView, sourceRect))
                 }
 
             case "text/plain":
@@ -244,7 +243,7 @@ final class DetailCoordinator: Coordinator {
                     show(text: text, title: filename)
                 } else {
                     DDLogInfo("DetailCoordinator: share plain text \(attachment.key)")
-                    share(item: url, sourceView: .view(sourceView, rect))
+                    share(item: url, sourceView: .view(sourceView, sourceRect))
                 }
 
             case _ where contentType.contains("image"):
@@ -254,7 +253,7 @@ final class DetailCoordinator: Coordinator {
                     show(image: image, title: filename)
                 } else {
                     DDLogInfo("DetailCoordinator: share image \(attachment.key)")
-                    share(item: url, sourceView: .view(sourceView, rect))
+                    share(item: url, sourceView: .view(sourceView, sourceRect))
                 }
 
             default:
@@ -263,7 +262,7 @@ final class DetailCoordinator: Coordinator {
                     showVideo(for: url)
                 } else {
                     DDLogInfo("DetailCoordinator: share attachment \(attachment.key)")
-                    share(item: file.createUrl(), sourceView: .view(sourceView, rect))
+                    share(item: file.createUrl(), sourceView: .view(sourceView, sourceRect))
                 }
             }
         }

--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -20,7 +20,7 @@ import RxSwift
 import SwiftyGif
 
 protocol DetailCoordinatorAttachmentProvider {
-    func attachment(for key: String, parentKey: String?, libraryId: LibraryIdentifier) -> (Attachment, UIView, CGRect?)?
+    func attachment(for key: String, parentKey: String?, libraryId: LibraryIdentifier) -> (Attachment, UIPopoverPresentationControllerSourceItem)?
 }
 
 protocol DetailMissingStyleErrorDelegate: AnyObject {
@@ -204,14 +204,14 @@ final class DetailCoordinator: Coordinator {
     }
 
     func showAttachment(key: String, parentKey: String?, libraryId: LibraryIdentifier) {
-        guard let (attachment, sourceView, sourceRect) = self.navigationController?.viewControllers.reversed()
+        guard let (attachment, sourceItem) = navigationController?.viewControllers.reversed()
             .compactMap({ ($0 as? DetailCoordinatorAttachmentProvider)?.attachment(for: key, parentKey: parentKey, libraryId: libraryId) })
             .first
         else { return }
-        self.show(attachment: attachment, parentKey: parentKey, libraryId: libraryId, sourceView: sourceView, sourceRect: sourceRect ?? .null)
+        show(attachment: attachment, parentKey: parentKey, libraryId: libraryId, sourceItem: sourceItem)
     }
 
-    private func show(attachment: Attachment, parentKey: String?, libraryId: LibraryIdentifier, sourceView: UIView, sourceRect: CGRect) {
+    private func show(attachment: Attachment, parentKey: String?, libraryId: LibraryIdentifier, sourceItem: UIPopoverPresentationControllerSourceItem) {
         switch attachment.type {
         case .url(let url):
             show(url: url)
@@ -233,7 +233,7 @@ final class DetailCoordinator: Coordinator {
                     showWebView(for: url)
                 } else {
                     DDLogInfo("DetailCoordinator: share attachment \(attachment.key)")
-                    share(item: file.createUrl(), sourceView: .view(sourceView, sourceRect))
+                    share(item: file.createUrl(), sourceItem: sourceItem)
                 }
 
             case "text/plain":
@@ -243,7 +243,7 @@ final class DetailCoordinator: Coordinator {
                     show(text: text, title: filename)
                 } else {
                     DDLogInfo("DetailCoordinator: share plain text \(attachment.key)")
-                    share(item: url, sourceView: .view(sourceView, sourceRect))
+                    share(item: url, sourceItem: sourceItem)
                 }
 
             case _ where contentType.contains("image"):
@@ -253,7 +253,7 @@ final class DetailCoordinator: Coordinator {
                     show(image: image, title: filename)
                 } else {
                     DDLogInfo("DetailCoordinator: share image \(attachment.key)")
-                    share(item: url, sourceView: .view(sourceView, sourceRect))
+                    share(item: url, sourceItem: sourceItem)
                 }
 
             default:
@@ -262,7 +262,7 @@ final class DetailCoordinator: Coordinator {
                     showVideo(for: url)
                 } else {
                     DDLogInfo("DetailCoordinator: share attachment \(attachment.key)")
-                    share(item: file.createUrl(), sourceView: .view(sourceView, sourceRect))
+                    share(item: file.createUrl(), sourceItem: sourceItem)
                 }
             }
         }

--- a/Zotero/Scenes/Detail/HTML:EPUB/Views/HtmlEpubReaderViewController.swift
+++ b/Zotero/Scenes/Detail/HTML:EPUB/Views/HtmlEpubReaderViewController.swift
@@ -515,7 +515,7 @@ extension HtmlEpubReaderViewController: AnnotationToolbarDelegate {
         viewModel.process(action: .toggleTool(tool))
     }
 
-    func showToolOptions(sender: SourceView) {
+    func showToolOptions(sourceItem: UIPopoverPresentationControllerSourceItem) {
         guard let tool = viewModel.state.activeTool else { return }
         let colorHex = viewModel.state.toolColors[tool]?.hexString
 
@@ -523,7 +523,7 @@ extension HtmlEpubReaderViewController: AnnotationToolbarDelegate {
             tool: tool,
             colorHex: colorHex,
             sizeValue: nil,
-            sender: sender,
+            sourceItem: sourceItem,
             userInterfaceStyle: viewModel.state.settings.appearance.userInterfaceStyle
         ) { [weak self] newColor, newSize in
             self?.viewModel.process(action: .setToolOptions(color: newColor, size: newSize.flatMap(CGFloat.init), tool: tool))

--- a/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailCollectionViewHandler.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailCollectionViewHandler.swift
@@ -445,8 +445,8 @@ final class ItemDetailCollectionViewHandler: NSObject {
 
     // MARK: - Actions
 
-    func sourceDataForCell(at indexPath: IndexPath) -> (UIView, CGRect?) {
-        return (collectionView, collectionView.cellForItem(at: indexPath)?.frame)
+    func sourceItemForCell(at indexPath: IndexPath) -> UIPopoverPresentationControllerSourceItem {
+        return collectionView.cellForItem(at: indexPath) ?? collectionView
     }
 
     /// Reloads the whole `collectionView`. Applies new snapshot based on `state` and reloads remaining items which were not changed between snapshots.

--- a/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailViewController.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailViewController.swift
@@ -437,16 +437,16 @@ extension ItemDetailViewController: ConflictViewControllerReceiver {
 }
 
 extension ItemDetailViewController: DetailCoordinatorAttachmentProvider {
-    func attachment(for key: String, parentKey: String?, libraryId: LibraryIdentifier) -> (Attachment, UIView, CGRect?)? {
+    func attachment(for key: String, parentKey: String?, libraryId: LibraryIdentifier) -> (Attachment, UIPopoverPresentationControllerSourceItem)? {
         guard let index = viewModel.state.attachments.firstIndex(where: { $0.key == key && $0.libraryId == libraryId }) else { return nil }
 
         let attachment = viewModel.state.attachments[index]
 
         guard let section = collectionViewHandler.attachmentSectionIndex else {
-            return (attachment, view, nil)
+            return (attachment, view)
         }
 
-        let (sourceView, sourceRect) = collectionViewHandler.sourceDataForCell(at: IndexPath(row: index, section: section))
-        return (attachment, sourceView, sourceRect)
+        let sourceItem = collectionViewHandler.sourceItemForCell(at: IndexPath(row: index, section: section))
+        return (attachment, sourceItem)
     }
 }

--- a/Zotero/Scenes/Detail/Items/Views/ItemsTableViewHandler.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsTableViewHandler.swift
@@ -143,9 +143,8 @@ final class ItemsTableViewHandler: NSObject {
         return UISwipeActionsConfiguration(actions: actions)
     }
 
-    func sourceDataForCell(for key: String) -> (UIView, CGRect?) {
-        let cell = self.tableView.visibleCells.first(where: { ($0 as? ItemCell)?.key == key })
-        return (self.tableView, cell?.frame)
+    func sourceItemForCell(for key: String) -> UIPopoverPresentationControllerSourceItem {
+        return tableView.visibleCells.first(where: { ($0 as? ItemCell)?.key == key }) ?? tableView
     }
 
     func reload(modifications: [IndexPath], insertions: [IndexPath], deletions: [IndexPath], updateSnapshot: () -> Void, completion: (() -> Void)? = nil) {

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -495,12 +495,9 @@ extension ItemsViewController: ItemsToolbarControllerDelegate {
 }
 
 extension ItemsViewController: DetailCoordinatorAttachmentProvider {
-    func attachment(for key: String, parentKey: String?, libraryId: LibraryIdentifier) -> (Attachment, UIView, CGRect?)? {
-        guard
-            let accessory = self.viewModel.state.itemAccessories[parentKey ?? key],
-            let attachment = accessory.attachment,
-            let (sourceView, sourceRect) = handler?.sourceDataForCell(for: (parentKey ?? key))
-        else { return nil }
-        return (attachment, sourceView, sourceRect)
+    func attachment(for key: String, parentKey: String?, libraryId: LibraryIdentifier) -> (Attachment, UIPopoverPresentationControllerSourceItem)? {
+        guard let accessory = viewModel.state.itemAccessories[parentKey ?? key], let attachment = accessory.attachment, let handler else { return nil }
+        let sourceItem = handler.sourceItemForCell(for: (parentKey ?? key))
+        return (attachment, sourceItem)
     }
 }

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -167,11 +167,11 @@ extension PDFCoordinator: PdfReaderCoordinatorDelegate {
     }
 
     func share(url: URL, barButton: UIBarButtonItem) {
-        self.share(item: url, sourceView: .item(barButton))
+        share(item: url, sourceItem: barButton)
     }
 
     func share(text: String, rect: CGRect, view: UIView, userInterfaceStyle: UIUserInterfaceStyle) {
-        self.share(item: text, sourceView: .view(view, rect), userInterfaceStyle: userInterfaceStyle)
+        share(item: text, sourceView: view, sourceRect: rect, userInterfaceStyle: userInterfaceStyle)
     }
 
     func lookup(text: String, rect: CGRect, view: UIView, userInterfaceStyle: UIUserInterfaceStyle) {
@@ -313,11 +313,7 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
                         DDLogInfo("PDFCoordinator: share pdf annotation image - activity type: \(String(describing: activityType)) completed: \(completed) error: \(String(describing: error))")
                     }
                     
-                    if let coordinator = self.childCoordinators.last, coordinator is AnnotationPopoverCoordinator {
-                        coordinator.share(item: shareableImage, sourceView: .item(sender), completionWithItemsHandler: completion)
-                    } else {
-                        (self as Coordinator).share(item: shareableImage, sourceView: .item(sender), completionWithItemsHandler: completion)
-                    }
+                    ((childCoordinators.last as? AnnotationPopoverCoordinator) ?? (self as? Coordinator))?.share(item: shareableImage, sourceItem: sender, completionWithItemsHandler: completion)
                 }
                 action.accessibilityLabel = L10n.Accessibility.Pdf.shareAnnotationImage + " " + title
                 action.isAccessibilityElement = true

--- a/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
+++ b/Zotero/Scenes/Detail/PDF/PDFCoordinator.swift
@@ -160,16 +160,9 @@ extension PDFCoordinator: PdfReaderCoordinatorDelegate {
         self.navigationController?.present(viewController, animated: true, completion: nil)
 
         func setupPresentation(for pdfSearchController: PDFSearchViewController, with sender: UIBarButtonItem) {
-            pdfSearchController.modalPresentationStyle = UIDevice.current.userInterfaceIdiom == .pad ? .popover : .formSheet
-            guard let popoverPresentationController = pdfSearchController.popoverPresentationController else { return }
-            if navigationController?.isNavigationBarHidden == false {
-                popoverPresentationController.sourceItem = sender
-                popoverPresentationController.sourceView = nil
-            } else {
-                popoverPresentationController.sourceItem = nil
-                popoverPresentationController.sourceView = navigationController?.view
-            }
-            popoverPresentationController.sourceRect = .zero
+            pdfSearchController.modalPresentationStyle = .popover
+            pdfSearchController.popoverPresentationController?.sourceItem = (navigationController?.isNavigationBarHidden == false) ? sender : navigationController?.view
+            pdfSearchController.popoverPresentationController?.sourceRect = .zero
         }
     }
 
@@ -226,7 +219,7 @@ extension PDFCoordinator: PdfReaderCoordinatorDelegate {
 
     func showDeleteAlertForAnnotation(sender: UIView, delete: @escaping () -> Void) {
         let controller = UIAlertController(title: nil, message: L10n.Pdf.deleteAnnotation, preferredStyle: .actionSheet)
-        controller.popoverPresentationController?.sourceView = sender
+        controller.popoverPresentationController?.sourceItem = sender
         controller.addAction(UIAlertAction(title: L10n.cancel, style: .cancel, handler: nil))
         controller.addAction(UIAlertAction(title: L10n.delete, style: .destructive, handler: { _ in
             delete()
@@ -257,7 +250,7 @@ extension PDFCoordinator: PdfReaderCoordinatorDelegate {
         switch UIDevice.current.userInterfaceIdiom {
         case .pad:
             controller.modalPresentationStyle = .popover
-            controller.popoverPresentationController?.sourceView = sender
+            controller.popoverPresentationController?.sourceItem = sender
             controller.preferredContentSize = CGSize(width: 200, height: 400)
             presentedController = controller
 
@@ -321,9 +314,9 @@ extension PDFCoordinator: PdfAnnotationsCoordinatorDelegate {
                     }
                     
                     if let coordinator = self.childCoordinators.last, coordinator is AnnotationPopoverCoordinator {
-                        coordinator.share(item: shareableImage, sourceView: .view(sender), completionWithItemsHandler: completion)
+                        coordinator.share(item: shareableImage, sourceView: .item(sender), completionWithItemsHandler: completion)
                     } else {
-                        (self as Coordinator).share(item: shareableImage, sourceView: .view(sender), completionWithItemsHandler: completion)
+                        (self as Coordinator).share(item: shareableImage, sourceView: .item(sender), completionWithItemsHandler: completion)
                     }
                 }
                 action.accessibilityLabel = L10n.Accessibility.Pdf.shareAnnotationImage + " " + title

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarViewController.swift
@@ -325,7 +325,7 @@ class AnnotationToolbarViewController: UIViewController {
                 picker.rx.controlEvent(.touchUpInside)
                     .subscribe(onNext: { [weak self] _ in
                         guard let self else { return }
-                        delegate?.showToolOptions(sender: .view(colorPickerButton, nil))
+                        delegate?.showToolOptions(sender: .view(colorPickerButton))
                     })
                     .disposed(by: disposeBag)
                 return picker

--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationToolbarViewController.swift
@@ -27,7 +27,7 @@ protocol AnnotationToolbarDelegate: AnyObject {
     var maxAvailableToolbarSize: CGFloat { get }
 
     func toggle(tool: AnnotationTool, options: AnnotationToolOptions)
-    func showToolOptions(sender: SourceView)
+    func showToolOptions(sourceItem: UIPopoverPresentationControllerSourceItem)
     func closeAnnotationToolbar()
     func performUndo()
     func performRedo()
@@ -325,7 +325,7 @@ class AnnotationToolbarViewController: UIViewController {
                 picker.rx.controlEvent(.touchUpInside)
                     .subscribe(onNext: { [weak self] _ in
                         guard let self else { return }
-                        delegate?.showToolOptions(sender: .view(colorPickerButton))
+                        delegate?.showToolOptions(sourceItem: colorPickerButton)
                     })
                     .disposed(by: disposeBag)
                 return picker

--- a/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
@@ -1057,7 +1057,7 @@ extension PDFDocumentViewController: FreeTextInputDelegate {
             tool: .freeText,
             colorHex: color,
             sizeValue: nil,
-            sender: .view(sender),
+            sourceItem: sender,
             userInterfaceStyle: self.overrideUserInterfaceStyle,
             valueChanged: { [weak viewModel] newColor, _ in
                 guard let newColor else { return }

--- a/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
@@ -1057,7 +1057,7 @@ extension PDFDocumentViewController: FreeTextInputDelegate {
             tool: .freeText,
             colorHex: color,
             sizeValue: nil,
-            sender: .view(sender, nil),
+            sender: .view(sender),
             userInterfaceStyle: self.overrideUserInterfaceStyle,
             valueChanged: { [weak viewModel] newColor, _ in
                 guard let newColor else { return }

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -542,7 +542,7 @@ class PDFReaderViewController: UIViewController, ReaderViewController {
 
     func showToolOptions() {
         if let annotationToolbarController, !annotationToolbarController.view.isHidden, !annotationToolbarController.colorPickerButton.isHidden {
-            showToolOptions(sender: .view(annotationToolbarController.colorPickerButton, nil))
+            showToolOptions(sender: .view(annotationToolbarController.colorPickerButton))
             return
         }
 

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -542,15 +542,15 @@ class PDFReaderViewController: UIViewController, ReaderViewController {
 
     func showToolOptions() {
         if let annotationToolbarController, !annotationToolbarController.view.isHidden, !annotationToolbarController.colorPickerButton.isHidden {
-            showToolOptions(sender: .view(annotationToolbarController.colorPickerButton))
+            showToolOptions(sourceItem: annotationToolbarController.colorPickerButton)
             return
         }
 
         guard let item = navigationItem.rightBarButtonItems?.last else { return }
-        showToolOptions(sender: .item(item))
+        showToolOptions(sourceItem: item)
     }
 
-    func showToolOptions(sender: SourceView) {
+    func showToolOptions(sourceItem: UIPopoverPresentationControllerSourceItem) {
         guard let tool = documentController?.pdfController?.annotationStateManager.state, let toolbarTool = tool.toolbarTool else { return }
 
         let colorHex = viewModel.state.toolColors[tool]?.hexString
@@ -573,7 +573,7 @@ class PDFReaderViewController: UIViewController, ReaderViewController {
             tool: toolbarTool,
             colorHex: colorHex,
             sizeValue: size,
-            sender: sender,
+            sourceItem: sourceItem,
             userInterfaceStyle: viewModel.state.settings.appearanceMode.userInterfaceStyle
         ) { [weak self] newColor, newSize in
             self?.viewModel.process(action: .setToolOptions(color: newColor, size: newSize.flatMap(CGFloat.init), tool: tool))

--- a/Zotero/Scenes/Detail/ReaderCoordinator.swift
+++ b/Zotero/Scenes/Detail/ReaderCoordinator.swift
@@ -263,7 +263,7 @@ extension ReaderCoordinator {
 
         if UIDevice.current.userInterfaceIdiom == .pad {
             navigationController.modalPresentationStyle = .popover
-            navigationController.popoverPresentationController?.barButtonItem = barButton
+            navigationController.popoverPresentationController?.sourceItem = barButton
             navigationController.popoverPresentationController?.permittedArrowDirections = .down
         }
 
@@ -282,8 +282,8 @@ extension ReaderCoordinator {
         } else {
             controller = UINavigationController(rootViewController: baseController)
         }
-        controller.modalPresentationStyle = UIDevice.current.userInterfaceIdiom == .pad ? .popover : .formSheet
-        controller.popoverPresentationController?.barButtonItem = sender
+        controller.modalPresentationStyle = .popover
+        controller.popoverPresentationController?.sourceItem = sender
         controller.preferredContentSize = settings.preferredContentSize
         controller.overrideUserInterfaceStyle = settings.appearance.userInterfaceStyle
         navigationController?.present(controller, animated: true, completion: nil)

--- a/Zotero/Scenes/Detail/ReaderCoordinator.swift
+++ b/Zotero/Scenes/Detail/ReaderCoordinator.swift
@@ -49,7 +49,14 @@ extension ReaderState {
 
 protocol ReaderCoordinatorDelegate: AnyObject {
     func show(error: ReaderError)
-    func showToolSettings(tool: AnnotationTool, colorHex: String?, sizeValue: Float?, sender: SourceView, userInterfaceStyle: UIUserInterfaceStyle, valueChanged: @escaping (String?, Float?) -> Void)
+    func showToolSettings(
+        tool: AnnotationTool,
+        colorHex: String?,
+        sizeValue: Float?,
+        sourceItem: UIPopoverPresentationControllerSourceItem,
+        userInterfaceStyle: UIUserInterfaceStyle,
+        valueChanged: @escaping (String?, Float?) -> Void
+    )
 }
 
 protocol ReaderSidebarCoordinatorDelegate: AnyObject {
@@ -97,7 +104,14 @@ extension ReaderCoordinator {
         navigationController?.present(controller, animated: true)
     }
 
-    func showToolSettings(tool: AnnotationTool, colorHex: String?, sizeValue: Float?, sender: SourceView, userInterfaceStyle: UIUserInterfaceStyle, valueChanged: @escaping (String?, Float?) -> Void) {
+    func showToolSettings(
+        tool: AnnotationTool,
+        colorHex: String?,
+        sizeValue: Float?,
+        sourceItem: UIPopoverPresentationControllerSourceItem,
+        userInterfaceStyle: UIUserInterfaceStyle,
+        valueChanged: @escaping (String?, Float?) -> Void
+    ) {
         DDLogInfo("ReaderCoordinator: show tool settings for \(tool)")
         let state = AnnotationToolOptionsState(tool: tool, colorHex: colorHex, size: sizeValue)
         let handler = AnnotationToolOptionsActionHandler()
@@ -107,13 +121,7 @@ extension ReaderCoordinator {
         case .pad:
             controller.overrideUserInterfaceStyle = userInterfaceStyle
             controller.modalPresentationStyle = .popover
-            switch sender {
-            case .view(let view, _):
-                controller.popoverPresentationController?.sourceView = view
-
-            case .item(let item):
-                controller.popoverPresentationController?.sourceItem = item
-            }
+            controller.popoverPresentationController?.sourceItem = sourceItem
             navigationController?.present(controller, animated: true, completion: nil)
 
         default:
@@ -168,7 +176,7 @@ extension ReaderCoordinator {
 
         if UIDevice.current.userInterfaceIdiom == .pad {
             navigationController.modalPresentationStyle = .popover
-            navigationController.popoverPresentationController?.sourceView = sender
+            navigationController.popoverPresentationController?.sourceItem = sender
             navigationController.popoverPresentationController?.permittedArrowDirections = .left
         }
 

--- a/Zotero/Scenes/Detail/ReaderCoordinator.swift
+++ b/Zotero/Scenes/Detail/ReaderCoordinator.swift
@@ -112,7 +112,7 @@ extension ReaderCoordinator {
                 controller.popoverPresentationController?.sourceView = view
 
             case .item(let item):
-                controller.popoverPresentationController?.barButtonItem = item
+                controller.popoverPresentationController?.sourceItem = item
             }
             navigationController?.present(controller, animated: true, completion: nil)
 

--- a/Zotero/Scenes/Detail/Trash/Views/TrashViewController.swift
+++ b/Zotero/Scenes/Detail/Trash/Views/TrashViewController.swift
@@ -336,12 +336,9 @@ extension TrashViewController: ItemsToolbarControllerDelegate {
 }
 
 extension TrashViewController: DetailCoordinatorAttachmentProvider {
-    func attachment(for key: String, parentKey: String?, libraryId: LibraryIdentifier) -> (Attachment, UIView, CGRect?)? {
-        guard
-            let accessory = viewModel.state.itemDataCache[TrashKey(type: .item, key: parentKey ?? key)]?.accessory,
-            let attachment = accessory.attachment,
-            let (sourceView, sourceRect) = handler?.sourceDataForCell(for: (parentKey ?? key))
-        else { return nil }
-        return (attachment, sourceView, sourceRect)
+    func attachment(for key: String, parentKey: String?, libraryId: LibraryIdentifier) -> (Attachment, UIPopoverPresentationControllerSourceItem)? {
+        guard let accessory = viewModel.state.itemDataCache[TrashKey(type: .item, key: parentKey ?? key)]?.accessory, let attachment = accessory.attachment, let handler else { return nil }
+        let sourceItem = handler.sourceItemForCell(for: (parentKey ?? key))
+        return (attachment, sourceItem)
     }
 }

--- a/Zotero/Scenes/Master/Settings/SettingsCoordinator.swift
+++ b/Zotero/Scenes/Master/Settings/SettingsCoordinator.swift
@@ -423,7 +423,7 @@ extension SettingsCoordinator: DebuggingSettingsSettingsCoordinatorDelegate {
 
         let controller = UIActivityViewController(activityItems: [mainUrl, bundledUrl], applicationActivities: nil)
         controller.modalPresentationStyle = .pageSheet
-        controller.popoverPresentationController?.sourceView = navigationController.view
+        controller.popoverPresentationController?.sourceItem = navigationController.view
         navigationController.present(controller, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
Simplifies popover logic according to latest iOS versions (16+):
- Prefers `popoverPresentationController` `sourceItem`. (Still uses `sourceView` & `sourceRect` where needed).
- Uses just `modalPresentationStyle` `.popover` where applicable, since it implies `formSheet` for horizontally or vertically compact environments.