### PR TITLE
Improve share extension web view handler

### DIFF
--- a/ZShare/View Controllers/ShareViewController.swift
+++ b/ZShare/View Controllers/ShareViewController.swift
@@ -540,6 +540,9 @@ final class ShareViewController: UIViewController {
                 return L10n.Errors.Shareext.forbidden(groupName)
             }
 
+        case .requiresBrowser:
+            return L10n.Errors.Shareext.requiresBrowser
+
         case .downloadedFileNotPdf, .md5Missing, .mtimeMissing:
             return nil
         }

--- a/ZShare/ViewModels/ExtensionViewModel.swift
+++ b/ZShare/ViewModels/ExtensionViewModel.swift
@@ -72,6 +72,7 @@ final class ExtensionViewModel {
                 case webDavFailure
                 case md5Missing
                 case mtimeMissing
+                case requiresBrowser
 
                 var isFatal: Bool {
                     switch self {
@@ -82,7 +83,8 @@ final class ExtensionViewModel {
                          .parseError,
                          .schemaError,
                          .md5Missing,
-                         .mtimeMissing:
+                         .mtimeMissing,
+                         .requiresBrowser:
                         return true
 
                     case .apiFailure,
@@ -1265,6 +1267,13 @@ final class ExtensionViewModel {
         }
         if let alamoError = error as? AFError {
             return alamoErrorRequiresAbort(alamoError, url: nil, libraryId: libraryId)
+        }
+        let nsError = error as NSError
+        if nsError.domain == "WebKitErrorDomain",
+           nsError.code == 102,
+           let failingUrl = nsError.userInfo["NSErrorFailingURLStringKey"] as? String,
+           failingUrl.starts(with: "x-safari-https://") || failingUrl.starts(with: "x-safari-http://") {
+            return .requiresBrowser
         }
         return .unknown
 

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -487,6 +487,7 @@
 "errors.shareext.group_quota_reached" = "The group “%@” has reached its Zotero Storage quota, and the file could not be uploaded. The group owner can view their account settings for additional storage options.\n\nThe file was saved to the local library.";
 "errors.shareext.forbidden" = "You don’t have necessary rights to submit this item to %@.";
 "errors.shareext.webdav_not_verified" = "WebDAV verification error";
+"errors.shareext.requires_browser" = "This page or app requires to be loaded in a browser in order to be shared with Zotero. Open it in your browser and use the browser's Share action.";
 "errors.db_failure" = "Error creating database. Please try logging in again.";
 "errors.logging.title" = "Debugging Error";
 "errors.logging.start" = "Unable to start debug logging";

--- a/Zotero/Controllers/Web View Handling/WebViewHandler.swift
+++ b/Zotero/Controllers/Web View Handling/WebViewHandler.swift
@@ -40,6 +40,8 @@ class WebViewHandler: NSObject {
     private(set) var referer: String?
     private var initializationState: BehaviorRelay<InitializationState>
     private let disposeBag: DisposeBag
+    private static let webKitPrefix = "AppleWebKit/"
+    private static let safariVersionPrefix = "Mobile Safari/"
 
     // MARK: - Lifecycle
 
@@ -60,7 +62,15 @@ class WebViewHandler: NSObject {
         super.init()
 
         webView.navigationDelegate = self
-        let userAgent = webView.value(forKey: "userAgent") ?? ""
+        var userAgent = ""
+        if let webViewUserAgent = webView.value(forKey: "userAgent") as? String {
+            userAgent = webViewUserAgent + " Version/" + UIDevice.current.systemVersion
+            if let safariVersion = webViewUserAgent.components(separatedBy: " ")
+                .first(where: { $0.starts(with: Self.webKitPrefix) })?
+                .replacingOccurrences(of: Self.webKitPrefix, with: Self.safariVersionPrefix) {
+                userAgent += " " + safariVersion
+            }
+        }
         webView.customUserAgent = "\(userAgent) Zotero_iOS/\(DeviceInfoProvider.versionString ?? "")-\(DeviceInfoProvider.buildString ?? "")"
 
         javascriptHandlers?.forEach { handler in

--- a/Zotero/Controllers/Web View Handling/WebViewHandler.swift
+++ b/Zotero/Controllers/Web View Handling/WebViewHandler.swift
@@ -268,6 +268,11 @@ extension WebViewHandler: WKNavigationDelegate {
         DDLogError("WebViewHandler: did fail - \(error)")
         webDidLoad?(.failure(error))
     }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Swift.Error) {
+        DDLogError("WebViewHandler: did fail provisional navigation - \(error)")
+        webDidLoad?(.failure(error))
+    }
 }
 
 /// Communication with JS in `webView`. The `webView` sends a message through one of the registered `JSHandlers`, which is received here.


### PR DESCRIPTION
* Logs and reports as failure provisional navigation errors.
* Uses specific fatal error when an app/site requires a browser explicitly.
* Improves web view handler custom user agent to potentially overcome such app/sites requirement.