### PR TITLE
Fix PDF reader memory leak

### DIFF
--- a/Zotero/Scenes/Detail/PDF/Views/AnnotationCell.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/AnnotationCell.swift
@@ -40,6 +40,10 @@ final class AnnotationCell: UITableViewCell {
         disposeBag?.dispose()
     }
 
+    deinit {
+        disposeBag?.dispose()
+    }
+
     // MARK: - Actions
 
     func updatePreview(image: UIImage?) {

--- a/Zotero/Scenes/Detail/PDF/Views/PDFAnnotationsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFAnnotationsViewController.swift
@@ -17,7 +17,7 @@ typealias AnnotationsViewControllerAction = (AnnotationView.Action, Annotation, 
 
 final class PDFAnnotationsViewController: UIViewController {
     private static let cellId = "AnnotationCell"
-    private unowned let viewModel: ViewModel<PDFReaderActionHandler>
+    private let viewModel: ViewModel<PDFReaderActionHandler>
     private let updateQueue: DispatchQueue
     private let disposeBag: DisposeBag
 

--- a/Zotero/Scenes/Detail/PDF/Views/PDFSidebarViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFSidebarViewController.swift
@@ -40,7 +40,7 @@ class PDFSidebarViewController: UIViewController {
         }
     }
 
-    private unowned let viewModel: ViewModel<PDFReaderActionHandler>
+    private let viewModel: ViewModel<PDFReaderActionHandler>
     private let disposeBag: DisposeBag
 
     private weak var picker: UISegmentedControl!


### PR DESCRIPTION
Fixes potential crash reported in https://forums.zotero.org/discussion/126827/ios-crash-report-1397306611

* Fixes `AnnotationCell` memory leak, due to `disposeBag` not being disposed when an instance was deinitialized.
* Improves memory management of `ViewModel<PDFReaderActionHandler>` instances.