### PR TITLE
Improve annotation page label default value

### DIFF
--- a/Zotero/Controllers/AnnotationConverter.swift
+++ b/Zotero/Controllers/AnnotationConverter.swift
@@ -60,13 +60,14 @@ struct AnnotationConverter {
         library: Library,
         username: String,
         displayName: String,
+        defaultPageLabel: PDFReaderState.DefaultAnnotationPageLabel?,
         boundingBoxConverter: AnnotationBoundingBoxConverter?
     ) -> PDFDocumentAnnotation? {
         guard let document = annotation.document, AnnotationsConfig.supported.contains(annotation.type) else { return nil }
 
         let key = annotation.key ?? annotation.uuid
         let page = Int(annotation.pageIndex)
-        let pageLabel = document.pageLabelForPage(at: annotation.pageIndex, substituteWithPlainLabel: false) ?? "\(annotation.pageIndex + 1)"
+        let pageLabel = defaultPageLabel?.label(for: Int(annotation.pageIndex)) ?? document.pageLabelForPage(at: annotation.pageIndex, substituteWithPlainLabel: false) ?? "\(annotation.pageIndex + 1)"
         let isAuthor = annotation.user == displayName || annotation.user == username
         let comment = annotation.contents.flatMap({ $0.trimmingCharacters(in: .whitespacesAndNewlines) }) ?? ""
         let sortIndex = self.sortIndex(from: annotation, boundingBoxConverter: boundingBoxConverter)

--- a/Zotero/Scenes/Detail/PDF/Models/PDFReaderState.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/PDFReaderState.swift
@@ -99,6 +99,21 @@ struct PDFReaderState: ViewModelState {
         }
     }
 
+    enum DefaultAnnotationPageLabel {
+        case commonPageOffset(offset: Int)
+        case labelPerPage(labelsByPage: [Int: String])
+
+        func label(for page: Int) -> String? {
+            switch self {
+            case .commonPageOffset(let offset):
+                return "\(page + offset)"
+                
+            case .labelPerPage(let labelsByPage):
+                return labelsByPage[page] ?? "\(page + 1)"
+            }
+        }
+    }
+
     let key: String
     let parentKey: String?
     let document: PSPDFKit.Document
@@ -115,6 +130,7 @@ struct PDFReaderState: ViewModelState {
     var itemToken: NotificationToken?
     var databaseAnnotations: Results<RItem>!
     var documentAnnotations: [String: PDFDocumentAnnotation]
+    var defaultAnnotationPageLabel: DefaultAnnotationPageLabel
     var texts: [String: (String, [UIFont: NSAttributedString])]
     var comments: [String: NSAttributedString]
     var searchTerm: String?
@@ -184,6 +200,7 @@ struct PDFReaderState: ViewModelState {
         self.username = username
         self.sortedKeys = []
         self.documentAnnotations = [:]
+        self.defaultAnnotationPageLabel = .commonPageOffset(offset: 1)
         self.texts = [:]
         self.comments = [:]
         self.visiblePage = 0


### PR DESCRIPTION
Fixes issue reported in https://forums.zotero.org/discussion/126756/page-numbers-don-t-work-on-ipad, 
using a functionally similar heuristic to https://github.com/zotero/reader/blob/master/src/pdf/pdf-view.js#L602-L627.
- If all annotation page labels have the same numerical offset, this is used for new ones.
- If pages have a specific page label in majority, these are used per page, and the default offset of 1, for the rest.
- Otherwise, the default offset of 1 for all.

This value is computed when the reader loads the document, and then recomputed only when needed.