### PR TITLE
Improve PDF document load

### DIFF
--- a/Zotero/Models/AnnotationsConfig.swift
+++ b/Zotero/Models/AnnotationsConfig.swift
@@ -45,6 +45,7 @@ struct AnnotationsConfig {
     // Size of note annotation in PDF document.
     static let noteAnnotationSize: CGSize = CGSize(width: 22, height: 22)
     static let supported: PSPDFKit.Annotation.Kind = [.note, .highlight, .square, .ink, .underline, .freeText]
+    static let editableAnnotationTypes: Set<PSPDFKit.Annotation.Tool> = Set([.note, .highlight, .square, .ink, .underline, .freeText])
 
     static func colors(for type: AnnotationType) -> [String] {
         switch type {

--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
@@ -2130,6 +2130,10 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
 
         var annotations: [String: PDFDocumentAnnotation] = [:]
         for pdfAnnotation in documentAnnotations {
+            if pdfAnnotation is LinkAnnotation {
+                // Ignored Link Annotation, as they are not editable, and if numerous they can create a noticeable hang the first time the document lazily evaluates dirty annotations.
+                continue
+            }
             pdfAnnotation.flags.update(with: .locked)
 
             // Unsupported annotations aren't visible in sidebar

--- a/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
@@ -634,6 +634,7 @@ final class PDFDocumentViewController: UIViewController {
                 builder.overrideClass(PSPDFKit.AnnotationManager.self, with: AnnotationManager.self)
                 builder.overrideClass(PSPDFKitUI.FreeTextAnnotationView.self, with: FreeTextAnnotationView.self)
                 builder.propertiesForAnnotations = [.freeText: []]
+                builder.editableAnnotationTypes = AnnotationsConfig.editableAnnotationTypes
             }
 
             let controller = PDFViewController(document: document, configuration: pdfConfiguration)

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -41,7 +41,7 @@ class PDFReaderViewController: UIViewController, ReaderViewController {
     weak var annotationToolbarController: AnnotationToolbarViewController?
     private var documentTop: NSLayoutConstraint!
     var annotationToolbarHandler: AnnotationToolbarHandler?
-    private var intraDocumentNavigationHandler: IntraDocumentNavigationButtonsHandler!
+    private var intraDocumentNavigationHandler: IntraDocumentNavigationButtonsHandler?
     private var selectedText: String?
     private(set) var isCompactWidth: Bool
     @CodableUserDefault(key: "PDFReaderToolbarState", defaultValue: AnnotationToolbarHandler.State(position: .leading, visible: true), encoder: Defaults.jsonEncoder, decoder: Defaults.jsonDecoder)
@@ -890,7 +890,7 @@ extension PDFReaderViewController: PDFDocumentDelegate {
         }
 
         statusBarVisible = !isHidden
-        intraDocumentNavigationHandler.interfaceIsVisible = !isHidden
+        intraDocumentNavigationHandler?.interfaceIsVisible = !isHidden
         annotationToolbarHandler?.interfaceVisibilityDidChange()
 
         UIView.animate(withDuration: 0.15, animations: { [weak self] in


### PR DESCRIPTION
Fixes hang issue mentioned in https://forums.zotero.org/discussion/126895/text-annotation-and-selection-issues-on-ipad

When loading a document with numerous link annotations, (8000+ in this case), setting all to locked will mark annotations as dirty. Upon clicking a link action for the first time, the document will try to save dirty annotations, causing a flurry of notificaitons and saves that use barriers. It seems that link annotations can be ignored, as they don't seem to be editable. 
Made more explicit with a relevant document builder configuration.