### PR TITLE
Improve item count observation

### DIFF
--- a/Zotero/Controllers/Database/Requests/ReadItemsDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/ReadItemsDbRequest.swift
@@ -78,7 +78,7 @@ struct ReadItemsWithKeysDbRequest: DbResponseRequest {
     }
 }
 
-struct ReadItemsForCollectionCountsDbRequest: DbResponseRequest {
+struct ReadLibraryItemsDbRequest: DbResponseRequest {
     typealias Response = Results<RItem>
 
     let libraryId: LibraryIdentifier
@@ -86,6 +86,6 @@ struct ReadItemsForCollectionCountsDbRequest: DbResponseRequest {
     var needsWrite: Bool { return false }
 
     func process(in database: Realm) throws -> Results<RItem> {
-        return database.objects(RItem.self).filter(.library(with: libraryId))
+        return database.objects(RItem.self).filter(.items(for: libraryId))
     }
 }

--- a/Zotero/Controllers/Database/Requests/ReadItemsDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/ReadItemsDbRequest.swift
@@ -77,3 +77,15 @@ struct ReadItemsWithKeysDbRequest: DbResponseRequest {
         return database.objects(RItem.self).filter(.keys(keys, in: libraryId))
     }
 }
+
+struct ReadItemsForCollectionCountsDbRequest: DbResponseRequest {
+    typealias Response = Results<RItem>
+
+    let libraryId: LibraryIdentifier
+
+    var needsWrite: Bool { return false }
+
+    func process(in database: Realm) throws -> Results<RItem> {
+        return database.objects(RItem.self).filter(.library(with: libraryId))
+    }
+}

--- a/Zotero/Models/Predicates.swift
+++ b/Zotero/Models/Predicates.swift
@@ -228,6 +228,12 @@ extension NSPredicate {
         return predicates
     }
 
+    static func items(for libraryId: LibraryIdentifier) -> NSPredicate {
+        var predicates: [NSPredicate] = [.library(with: libraryId), .notSyncState(.dirty), .deleted(false)]
+        predicates.append(NSPredicate(format: "parent = nil"))
+        return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+    }
+
     static func items(for collectionId: CollectionIdentifier, libraryId: LibraryIdentifier) -> NSPredicate {
         var predicates = self.baseItemPredicates(isTrash: collectionId.isTrash, libraryId: libraryId)
 

--- a/Zotero/Scenes/Master/Collections/Models/CollectionsState.swift
+++ b/Zotero/Scenes/Master/Collections/Models/CollectionsState.swift
@@ -41,10 +41,11 @@ struct CollectionsState: ViewModelState {
     var changes: Changes
     var collectionsToken: NotificationToken?
     var searchesToken: NotificationToken?
-    var itemsToken: NotificationToken?
-    var unfiledToken: NotificationToken?
-    var trashItemsToken: NotificationToken?
-    var trashCollectionsToken: NotificationToken?
+    var allItemsCountToken: NotificationToken?
+    var unfiledItemsCountToken: NotificationToken?
+    var trashItemsCountToken: NotificationToken?
+    var trashCollectionsCountToken: NotificationToken?
+    var itemsChangesToken: NotificationToken?
     var error: CollectionsError?
     // Used when user wants to create bibliography from whole collection.
     var itemKeysForBibliography: Swift.Result<Set<String>, Error>?

--- a/Zotero/Scenes/Master/Collections/ViewModels/CollectionsActionHandler.swift
+++ b/Zotero/Scenes/Master/Collections/ViewModels/CollectionsActionHandler.swift
@@ -241,7 +241,7 @@ final class CollectionsActionHandler: ViewModelActionHandler, BackgroundDbProces
                     guard let self, let viewModel else { return }
                     switch changes {
                     case .update(let objects, _, _, _):
-                        updateCollections(with: objects, includeItemCounts: includeItemCounts, viewModel: viewModel)
+                        updateCollections(with: objects.freeze(), includeItemCounts: includeItemCounts, in: viewModel, handler: self)
 
                     case .initial, .error:
                         break
@@ -349,10 +349,10 @@ final class CollectionsActionHandler: ViewModelActionHandler, BackgroundDbProces
             }
         }
 
-        func updateCollections(with collections: Results<RCollection>, includeItemCounts: Bool, viewModel: ViewModel<CollectionsActionHandler>) {
+        func updateCollections(with collections: Results<RCollection>, includeItemCounts: Bool, in viewModel: ViewModel<CollectionsActionHandler>, handler: CollectionsActionHandler) {
             let tree = CollectionTreeBuilder.collections(from: collections, libraryId: viewModel.state.library.identifier, includeItemCounts: includeItemCounts)
 
-            update(viewModel: viewModel) { state in
+            handler.update(viewModel: viewModel) { state in
                 state.collectionTree.replace(identifiersMatching: { $0.isCollection }, with: tree)
                 state.changes = .results
 

--- a/Zotero/Scenes/Master/Collections/ViewModels/CollectionsActionHandler.swift
+++ b/Zotero/Scenes/Master/Collections/ViewModels/CollectionsActionHandler.swift
@@ -276,12 +276,13 @@ final class CollectionsActionHandler: ViewModelActionHandler, BackgroundDbProces
                 guard let handler, let viewModel else { return }
                 switch changes {
                 case .update(let objects, _, _, _):
+                    let itemsCount = objects.freeze().count
                     switch customType {
                     case .trash:
-                        updateTrashCount(itemsCount: objects.count, collectionsCount: nil, in: viewModel, handler: handler)
+                        updateTrashCount(itemsCount: itemsCount, collectionsCount: nil, in: viewModel, handler: handler)
 
                     case .all, .publications, .unfiled:
-                        updateItemsCount(objects.count, for: customType, in: viewModel, handler: handler)
+                        updateItemsCount(itemsCount, for: customType, in: viewModel, handler: handler)
                     }
 
                 case .initial:
@@ -318,7 +319,8 @@ final class CollectionsActionHandler: ViewModelActionHandler, BackgroundDbProces
                 guard let handler, let viewModel else { return }
                 switch changes {
                 case .update(let objects, _, _, _):
-                    updateTrashCount(itemsCount: nil, collectionsCount: objects.count, in: viewModel, handler: handler)
+                    let collectionsCount = objects.freeze().count
+                    updateTrashCount(itemsCount: nil, collectionsCount: collectionsCount, in: viewModel, handler: handler)
 
                 case .initial:
                     break


### PR DESCRIPTION
Potential fix for crash reported in https://forums.zotero.org/discussion/127210/ios-crash-report-956913126
Also, adds another item changes observer, that will update count when items are deleted, as this action doesn't bring any change to the collection keypaths already observed.