### PR TITLE
Fix PDF reader top anchor for iOS 26

### DIFF
--- a/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFDocumentViewController.swift
@@ -596,10 +596,18 @@ final class PDFDocumentViewController: UIViewController {
 
         NSLayoutConstraint.activate([
             pdfController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            pdfController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             pdfController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             pdfController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor)
         ])
+        if #available(iOS 26.0.0, *) {
+            NSLayoutConstraint.activate([
+                pdfController.view.topAnchor.constraint(equalTo: view.topAnchor)
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                pdfController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
+            ])
+        }
 
         self.pdfController = pdfController
 


### PR DESCRIPTION
Fixes issue reported in https://forums.zotero.org/discussion/127142/ipad-app-pdf-reader-glitch/