### PR TITLE
Fix collections view controller load when app launches from a URL

### DIFF
--- a/Zotero/Scenes/Main/Views/MainViewController.swift
+++ b/Zotero/Scenes/Main/Views/MainViewController.swift
@@ -36,7 +36,9 @@ final class MainViewController: UISplitViewController {
             if let detailCoordinatorGetter,
                detailCoordinatorGetter.libraryId == nil || detailCoordinatorGetter.libraryId == detailCoordinator.libraryId,
                detailCoordinatorGetter.collectionId == nil || detailCoordinatorGetter.collectionId == detailCoordinator.collection.identifier {
-                detailCoordinatorGetter.completion(detailCoordinator)
+                DispatchQueue.main.async {
+                    detailCoordinatorGetter.completion(detailCoordinator)
+                }
                 self.detailCoordinatorGetter = nil
             }
         }

--- a/Zotero/Scenes/Master/Collections/Models/CollectionsState.swift
+++ b/Zotero/Scenes/Master/Collections/Models/CollectionsState.swift
@@ -36,7 +36,7 @@ struct CollectionsState: ViewModelState {
     var library: Library
     var libraryToken: NotificationToken?
     var collectionTree: CollectionTree
-    var selectedCollectionId: CollectionIdentifier
+    var selectedCollectionId: CollectionIdentifier?
     var editingData: CollectionStateEditingData?
     var changes: Changes
     var collectionsToken: NotificationToken?
@@ -50,7 +50,7 @@ struct CollectionsState: ViewModelState {
     // Used when user wants to create bibliography from whole collection.
     var itemKeysForBibliography: Swift.Result<Set<String>, Error>?
 
-    init(libraryId: LibraryIdentifier, selectedCollectionId: CollectionIdentifier) {
+    init(libraryId: LibraryIdentifier, selectedCollectionId: CollectionIdentifier?) {
         self.selectedCollectionId = selectedCollectionId
         self.changes = []
         self.collectionTree = CollectionTree(nodes: [], collections: [:], collapsed: [:])

--- a/Zotero/Scenes/Master/Collections/ViewModels/CollectionsActionHandler.swift
+++ b/Zotero/Scenes/Master/Collections/ViewModels/CollectionsActionHandler.swift
@@ -150,7 +150,7 @@ final class CollectionsActionHandler: ViewModelActionHandler, BackgroundDbProces
             changedCollections = state.collectionTree.setAll(collapsed: allCollapsed)
             state.changes = .collapsedState
 
-            if allCollapsed && !state.collectionTree.isRoot(identifier: state.selectedCollectionId) {
+            if allCollapsed, let selectedCollectionId = state.selectedCollectionId, !state.collectionTree.isRoot(identifier: selectedCollectionId) {
                 state.selectedCollectionId = .custom(.all)
                 state.changes.insert(.selection)
             }
@@ -175,8 +175,11 @@ final class CollectionsActionHandler: ViewModelActionHandler, BackgroundDbProces
             state.changes = .collapsedState
 
             // If a collection is being collapsed and selected collection is a child of collapsed collection, select currently collapsed collection
-            if state.selectedCollectionId != collection.identifier && newCollapsed && !state.collectionTree.isRoot(identifier: state.selectedCollectionId) &&
-               state.collectionTree.identifier(state.selectedCollectionId, isChildOf: collection.identifier) {
+            if let selectedCollectionId = state.selectedCollectionId,
+               selectedCollectionId != collection.identifier,
+               newCollapsed,
+               !state.collectionTree.isRoot(identifier: selectedCollectionId),
+               state.collectionTree.identifier(selectedCollectionId, isChildOf: collection.identifier) {
                 state.selectedCollectionId = collection.identifier
                 state.changes.insert(.selection)
             }
@@ -421,7 +424,7 @@ final class CollectionsActionHandler: ViewModelActionHandler, BackgroundDbProces
                 state.changes = .results
 
                 // Check whether selection still exists
-                if state.collectionTree.collection(for: state.selectedCollectionId) == nil {
+                if let selectedCollectionId = state.selectedCollectionId, state.collectionTree.collection(for: selectedCollectionId) == nil {
                     state.selectedCollectionId = .custom(.all)
                     state.changes.insert(.selection)
                 }

--- a/Zotero/Scenes/Master/Collections/Views/ExpandableCollectionsCollectionViewHandler.swift
+++ b/Zotero/Scenes/Master/Collections/Views/ExpandableCollectionsCollectionViewHandler.swift
@@ -94,7 +94,7 @@ final class ExpandableCollectionsCollectionViewHandler: NSObject {
         }
     }
 
-    func update(with tree: CollectionTree, selectedId: CollectionIdentifier, animated: Bool, completion: (() -> Void)? = nil) {
+    func update(with tree: CollectionTree, selectedId: CollectionIdentifier?, animated: Bool, completion: (() -> Void)? = nil) {
         guard let dataSource else { return }
         let currentSnapshotItemsCount = dataSource.snapshot(for: collectionsSection).items.count
         let newSnapshot = tree.createSnapshot(selectedId: selectedId)


### PR DESCRIPTION
- Makes `CollectionsViewController` logic more explicit for when to show or not items detail. In iOS 26 split view controller collapse status has proper value when `CollectionsViewController` view loads, which revealed edge cases not properly handled.
- Calls detail coordinator callback in the next run loop, to avoid crash in iOS 26.

Issue reported in https://forums.zotero.org/discussion/127613/ios-crash-report-1786699563