### PR TITLE
Add iCloud attachment storage option

### DIFF
--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -4799,7 +4799,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "swiftgen config lint\nswiftgen config run\n";
+			shellScript = "export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH\"\nswiftgen config lint\nswiftgen config run\n";
 		};
 		6185A1A82D9C266100285385 /* Bundle Utilities */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -4858,7 +4858,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "swiftlint\n";
+			shellScript = "export PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH\"\nswiftlint\n";
 		};
 		B3052A912C412E12008C8596 /* Bundle Reader */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -6382,7 +6382,7 @@
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 8LAYR367YV;
+				DEVELOPMENT_TEAM = TSZBH236CQ;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -6390,7 +6390,7 @@
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = Zotero/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -6421,7 +6421,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8LAYR367YV;
+				DEVELOPMENT_TEAM = TSZBH236CQ;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -6429,7 +6429,7 @@
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = Zotero/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -6707,7 +6707,7 @@
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 8LAYR367YV;
+				DEVELOPMENT_TEAM = TSZBH236CQ;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -6715,7 +6715,7 @@
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = Zotero/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Zotero/Controllers/Attachment Downloader/AttachmentDownloader.swift
+++ b/Zotero/Controllers/Attachment Downloader/AttachmentDownloader.swift
@@ -831,7 +831,6 @@ final class AttachmentDownloader: NSObject {
         let fm = FileManager.default
         guard fm.fileExists(atPath: url.path) else { return false }
 
-        // Use ubiquitousItemDownloadingStatusKey to determine if the iCloud item is downloaded
         let keys: Set<URLResourceKey> = [.isUbiquitousItemKey, .ubiquitousItemDownloadingStatusKey]
         let values = try? url.resourceValues(forKeys: keys)
         let isUbiquitous = values?.isUbiquitousItem == true
@@ -865,7 +864,6 @@ final class AttachmentDownloader: NSObject {
         DispatchQueue.global(qos: .utility).async { [weak self] in
             guard let self else { return }
             let url = file.createUrl()
-            // Poll using ubiquitousItemDownloadingStatusKey until the file is downloaded
             for _ in 0..<50 {
                 let values = try? url.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey])
                 if values?.ubiquitousItemDownloadingStatus == URLUbiquitousItemDownloadingStatus.current {

--- a/Zotero/Controllers/Sync/SyncActions/UploadAttachmentSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/UploadAttachmentSyncAction.swift
@@ -61,6 +61,12 @@ class UploadAttachmentSyncAction: SyncAction {
     }
 
     var result: Single<()> {
+        #if MAINAPP
+        if Defaults.shared.attachmentStoragePreference == .iCloud {
+            return self.iCloudResult
+        }
+        #endif
+
         switch self.libraryId {
         case .custom:
             return self.webDavController.sessionStorage.isEnabled ? self.webDavResult : self.zoteroResult
@@ -180,6 +186,90 @@ class UploadAttachmentSyncAction: SyncAction {
                        DDLogError("UploadAttachmentSyncAction: could not upload - \(error)")
                    })
     }
+
+    #if MAINAPP
+    private var iCloudResult: Single<()> {
+        DDLogInfo("UploadAttachmentSyncAction: store attachment in iCloud")
+
+        return self.checkDatabase()
+                   .flatMap { _ -> Single<UInt64> in
+                       return self.validateFile()
+                   }
+                   .do(onSuccess: { _ in
+                       self.failedBeforeZoteroApiRequest = false
+                   })
+                   .flatMap { _ -> Single<()> in
+                       return self.ensureICloudPresence()
+                   }
+                   .flatMap { _ -> Single<Int> in
+                       return self.submitItemWithHashAndMtime().flatMap({ Single.just($0) })
+                   }
+                   .observe(on: self.scheduler)
+                   .flatMap({ version -> Single<()> in
+                       return self.markAttachmentAsUploaded(version: version)
+                   })
+                   .do(onError: { error in
+                       DDLogError("UploadAttachmentSyncAction: could not store in iCloud - \(error)")
+                   })
+    }
+
+    private func ensureICloudPresence() -> Single<()> {
+        return Single.deferred {
+            guard Defaults.shared.attachmentStoragePreference == .iCloud else {
+                return .just(())
+            }
+
+            guard let iCloudRoot = FileManager.default.url(forUbiquityContainerIdentifier: "iCloud.org.zotero.ios.Zotero")?.appendingPathComponent("Documents", isDirectory: true) else {
+                return .error(NSError(domain: "org.zotero.ios.Zotero.iCloud", code: 1, userInfo: [NSLocalizedDescriptionKey: "iCloud not available."]))
+            }
+
+            let fm = FileManager.default
+            let url = self.file.createUrl()
+
+            do {
+                let directory = url.deletingLastPathComponent()
+                if !fm.fileExists(atPath: directory.path) {
+                    try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+                }
+
+                if !url.path.hasPrefix(iCloudRoot.path) {
+                    // Preserve the relative downloads path under the iCloud root.
+                    let relativePath = trimmedRelativePath(fullPath: url.path, root: self.file.rootPath)
+                    let destination = iCloudRoot.appendingPathComponent(relativePath)
+                    let destinationDir = destination.deletingLastPathComponent()
+                    if !fm.fileExists(atPath: destinationDir.path) {
+                        try fm.createDirectory(at: destinationDir, withIntermediateDirectories: true)
+                    }
+                    if fm.fileExists(atPath: destination.path) {
+                        try fm.removeItem(at: destination)
+                    }
+                    try fm.copyItem(at: url, to: destination)
+
+                    // Move/copy into iCloud and mark as ubiquitous at the destination path.
+                    try? fm.setUbiquitous(true, itemAt: destination, destinationURL: destination)
+                }
+
+                // If already inside the iCloud root, ensure it's marked ubiquitous.
+                if url.path.hasPrefix(iCloudRoot.path) {
+                    try? fm.setUbiquitous(true, itemAt: url, destinationURL: url)
+                }
+
+                return .just(())
+            } catch let error {
+                return .error(error)
+            }
+        }
+
+        func trimmedRelativePath(fullPath: String, root: String) -> String {
+            if fullPath.hasPrefix(root) {
+                let start = fullPath.index(fullPath.startIndex, offsetBy: root.count)
+                let trimmed = fullPath[start...]
+                return trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            }
+            return URL(fileURLWithPath: fullPath).lastPathComponent
+        }
+    }
+    #endif
 
     private func submitItemWithHashAndMtime() -> Single<Int> {
         DDLogInfo("UploadAttachmentSyncAction: submit mtime and md5")

--- a/Zotero/Controllers/Sync/SyncActions/UploadAttachmentSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/UploadAttachmentSyncAction.swift
@@ -233,7 +233,6 @@ class UploadAttachmentSyncAction: SyncAction {
                 }
 
                 if !url.path.hasPrefix(iCloudRoot.path) {
-                    // Preserve the relative downloads path under the iCloud root.
                     let relativePath = trimmedRelativePath(fullPath: url.path, root: self.file.rootPath)
                     let destination = iCloudRoot.appendingPathComponent(relativePath)
                     let destinationDir = destination.deletingLastPathComponent()
@@ -245,11 +244,9 @@ class UploadAttachmentSyncAction: SyncAction {
                     }
                     try fm.copyItem(at: url, to: destination)
 
-                    // Move/copy into iCloud and mark as ubiquitous at the destination path.
                     try? fm.setUbiquitous(true, itemAt: destination, destinationURL: destination)
                 }
 
-                // If already inside the iCloud root, ensure it's marked ubiquitous.
                 if url.path.hasPrefix(iCloudRoot.path) {
                     try? fm.setUbiquitous(true, itemAt: url, destinationURL: url)
                 }

--- a/Zotero/Models/Defaults.swift
+++ b/Zotero/Models/Defaults.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 
+enum AttachmentStoragePreference: String, Codable, Hashable {
+    case appGroup
+    case iCloud
+}
+
 final class Defaults {
     static let shared = Defaults()
 
@@ -41,6 +46,9 @@ final class Defaults {
 
     @OptionalUserDefault(key: "webDavUrl")
     var webDavUrl: String?
+
+    @CodableUserDefault(key: "AttachmentStoragePreference", defaultValue: .appGroup, encoder: Defaults.jsonEncoder, decoder: Defaults.jsonDecoder)
+    var attachmentStoragePreference: AttachmentStoragePreference
 
     // MARK: - Settings
 

--- a/Zotero/Models/ICloudFileProvider.swift
+++ b/Zotero/Models/ICloudFileProvider.swift
@@ -1,0 +1,94 @@
+//
+//  ICloudFileProvider.swift
+//
+//  Created to provide a minimal bridge between your existing File/FileData
+//  abstraction and iCloud Drive (ubiquity container) storage.
+//
+//  Use this helper to decide whether to store under iCloud or local Documents,
+//  construct FileData with the right root path, and ensure directories exist
+//  before writing.
+//
+
+import Foundation
+
+/// Preference for where files should be stored.
+/// - iCloudIfAvailable: Use iCloud Drive if available, otherwise fall back to local.
+/// - localOnly: Always use local Documents directory.
+enum StoragePreference {
+    case iCloudIfAvailable
+    case localOnly
+}
+
+/// Resolves iCloud (ubiquity container) and local roots and helps create FileData
+/// instances that point to the chosen storage location.
+struct ICloudFileProvider {
+    /// Pass a specific container identifier (e.g., "iCloud.com.yourcompany.yourapp").
+    /// If nil, the default container will be used (must be configured in Capabilities).
+    let ubiquityContainerIdentifier: String?
+
+    init(ubiquityContainerIdentifier: String? = nil) {
+        self.ubiquityContainerIdentifier = ubiquityContainerIdentifier
+    }
+
+    /// Indicates whether iCloud is available for this device/account and container.
+    /// Note: The first call can be relatively expensive; consider calling off the main thread.
+    var iCloudAvailable: Bool {
+        FileManager.default.url(forUbiquityContainerIdentifier: ubiquityContainerIdentifier) != nil
+    }
+
+    /// The iCloud container's Documents directory URL, if available.
+    var iCloudRootURL: URL? {
+        guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: ubiquityContainerIdentifier) else {
+            return nil
+        }
+        return containerURL.appendingPathComponent("Documents", isDirectory: true)
+    }
+
+    /// The app's local Documents directory URL.
+    var localRootURL: URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+    }
+
+    /// Returns the root URL matching the given storage preference.
+    func rootURL(preference: StoragePreference) -> URL {
+        switch preference {
+        case .iCloudIfAvailable:
+            return iCloudRootURL ?? localRootURL
+
+        case .localOnly:
+            return localRootURL
+        }
+    }
+
+    /// Returns the root path (string) matching the given storage preference.
+    func rootPath(preference: StoragePreference) -> String {
+        rootURL(preference: preference).path
+    }
+
+    /// Creates a FileData instance rooted at the selected storage location.
+    func makeFile(relativeComponents: [String], name: String, type: FileData.ContentType, preference: StoragePreference = .iCloudIfAvailable) -> FileData {
+        let root = rootPath(preference: preference)
+        return FileData(rootPath: root, relativeComponents: relativeComponents, name: name, type: type)
+    }
+
+    /// Ensures that the parent directory for the given File exists on disk.
+    /// Call before writing the file's contents.
+    func ensureParentDirectory(for file: File) throws {
+        let dirURL = file.createUrl().deletingLastPathComponent()
+        try ensureDirectoryExists(at: dirURL)
+    }
+
+    /// Ensures the directory exists at the provided URL.
+    func ensureDirectoryExists(at url: URL) throws {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: url.path) {
+            try fm.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+    }
+}
+
+extension ICloudFileProvider {
+    static let shared = ICloudFileProvider(
+        ubiquityContainerIdentifier: "iCloud.org.zotero.ios.Zotero"
+    )
+}

--- a/Zotero/Scenes/Master/Settings/Storage/Models/StorageSettingsAction.swift
+++ b/Zotero/Scenes/Master/Settings/Storage/Models/StorageSettingsAction.swift
@@ -12,4 +12,5 @@ enum StorageSettingsAction {
     case loadData
     case deleteAll
     case deleteInLibrary(LibraryIdentifier)
+    case setStoragePreference(AttachmentStoragePreference)
 }

--- a/Zotero/Scenes/Master/Settings/Storage/Models/StorageSettingsState.swift
+++ b/Zotero/Scenes/Master/Settings/Storage/Models/StorageSettingsState.swift
@@ -12,11 +12,18 @@ struct StorageSettingsState: ViewModelState {
     var libraries: [Library]
     var storageData: [LibraryIdentifier: DirectoryData]
     var totalStorageData: DirectoryData
+    var storagePreference: AttachmentStoragePreference
+    var iCloudAvailable: Bool
 
-    init(storageData: [LibraryIdentifier: DirectoryData]? = nil) {
+    init(storageData: [LibraryIdentifier: DirectoryData]? = nil,
+         storagePreference: AttachmentStoragePreference = Defaults.shared.attachmentStoragePreference,
+         iCloudAvailable: Bool = (FileManager.default.ubiquityIdentityToken != nil &&
+                                  FileManager.default.url(forUbiquityContainerIdentifier: "iCloud.org.zotero.ios.Zotero") != nil)) {
         self.storageData = storageData ?? [:]
         self.totalStorageData = DirectoryData(fileCount: 0, mbSize: 0)
         self.libraries = []
+        self.storagePreference = storagePreference
+        self.iCloudAvailable = iCloudAvailable
     }
 
     func cleanup() {}

--- a/Zotero/Scenes/Master/Settings/Storage/Views/StorageSettingsListView.swift
+++ b/Zotero/Scenes/Master/Settings/Storage/Views/StorageSettingsListView.swift
@@ -15,6 +15,24 @@ struct StorageSettingsListView: View {
 
     var body: some View {
         Form {
+            Section(header: Text("Attachment storage")) {
+                Picker("Attachment storage", selection: Binding(get: {
+                    self.viewModel.state.storagePreference
+                }, set: { newValue in
+                    self.viewModel.process(action: .setStoragePreference(newValue))
+                })) {
+                    Text("On this device").tag(AttachmentStoragePreference.appGroup)
+                    Text("iCloud").tag(AttachmentStoragePreference.iCloud).disabled(!self.viewModel.state.iCloudAvailable)
+                }
+                .pickerStyle(SegmentedPickerStyle())
+
+                if !self.viewModel.state.iCloudAvailable {
+                    Text("iCloud is unavailable for this account/device.")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
+            }
+
             Section {
                 ForEach(self.viewModel.state.libraries) { library in
                     StorageSettingsRow(title: library.name, data: self.viewModel.state.storageData[library.identifier], deleteAction: {


### PR DESCRIPTION
- Added a user setting to choose where attachment files live (on device vs iCloud Drive), stored in Defaults
- When iCloud is toggled and available, attachment paths (downloads/uploads/temp) point to the iCloud container; otherwise they stay in the app group
- Storage settings now show a picker for that choice and indicate when iCloud isn’t available
- Downloads first check for an iCloud copy and asks the system to fetch it; only hit Zotero/WebDAV if it’s missing
- Uploads can place the file into the same path under the iCloud container and still submit metadata to Zotero

Note: 
- Built/Run in simulator
- iCloud path requires a real device with iCloud entitlements and iCloud Drive enabled (not validated here)