### PR TITLE
Hide full sync option behind multi-tap gesture

### DIFF
--- a/Zotero/Scenes/Master/Settings/Debugging/Models/DebuggingAction.swift
+++ b/Zotero/Scenes/Master/Settings/Debugging/Models/DebuggingAction.swift
@@ -18,4 +18,5 @@ enum DebuggingAction {
     case clearLogs
     case showLogs
     case showFullSyncDebugging
+    case setAdvancedVisible(Bool)
 }

--- a/Zotero/Scenes/Master/Settings/Debugging/Models/DebuggingState.swift
+++ b/Zotero/Scenes/Master/Settings/Debugging/Models/DebuggingState.swift
@@ -13,9 +13,11 @@ import RxSwift
 struct DebuggingState: ViewModelState {
     var isLogging: Bool
     var numberOfLines: Int
+    var advancedVisible: Bool
     var disposeBag: DisposeBag?
 
     init(isLogging: Bool, numberOfLines: Int) {
+        advancedVisible = false
         self.isLogging = isLogging
         self.numberOfLines = numberOfLines
     }

--- a/Zotero/Scenes/Master/Settings/Debugging/ViewModels/DebuggingActionHandler.swift
+++ b/Zotero/Scenes/Master/Settings/Debugging/ViewModels/DebuggingActionHandler.swift
@@ -73,6 +73,11 @@ struct DebuggingActionHandler: ViewModelActionHandler {
 
         case .showFullSyncDebugging:
             coordinatorDelegate.showFullSyncDebugging()
+            
+        case .setAdvancedVisible(let visible):
+            update(viewModel: viewModel) { state in
+                state.advancedVisible = visible
+            }
         }
     }
 

--- a/Zotero/Scenes/Master/Settings/Debugging/Views/DebuggingView.swift
+++ b/Zotero/Scenes/Master/Settings/Debugging/Views/DebuggingView.swift
@@ -70,14 +70,19 @@ struct DebuggingView: View {
                 }
             }
 
-            Section {
-                Button {
-                    viewModel.process(action: .showFullSyncDebugging)
-                } label: {
-                    SettingsListButtonRow(text: L10n.Settings.fullSyncDebug, detailText: nil, enabled: true)
+            if viewModel.state.advancedVisible {
+                Section {
+                    Button {
+                        viewModel.process(action: .showFullSyncDebugging)
+                    } label: {
+                        SettingsListButtonRow(text: L10n.Settings.fullSyncDebug, detailText: nil, enabled: true)
+                    }
                 }
             }
         }
+        .onTapGesture(count: 6, perform: {
+            self.viewModel.process(action: .setAdvancedVisible(true))
+        })
         .navigationBarTitle(L10n.Settings.debug)
     }
 }


### PR DESCRIPTION
@dstillman fyi, if you ever tell someone to run full sync, they have to tap the setting background 6 times first. Just tap anywhere in the "Debug Output Logging" screen. People were using full sync just to send us regular Debug IDs, which defeated the purpose sometime.