### PR TITLE
Fixed possible layout cycle causing a crash

### DIFF
--- a/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationPopoverViewController.swift
+++ b/Zotero/Scenes/Detail/Annotation Popover/Views/AnnotationPopoverViewController.swift
@@ -46,7 +46,7 @@ final class AnnotationPopoverViewController: UIViewController {
         super.viewDidLoad()
 
         setupViews()
-        view.layoutSubviews()
+        view.layoutIfNeeded()
 
         viewModel.stateObservable
             .observe(on: MainScheduler.instance)
@@ -78,6 +78,7 @@ final class AnnotationPopoverViewController: UIViewController {
     private func updatePreferredContentSize() {
         guard var size = containerStackView?.systemLayoutSizeFitting(CGSize(width: AnnotationPopoverLayout.width, height: .greatestFiniteMagnitude)) else { return }
         size.width = AnnotationPopoverLayout.width
+        guard preferredContentSize != size else { return }
         preferredContentSize = size
         navigationController?.preferredContentSize = size
     }


### PR DESCRIPTION
There's a possible layout cycle in `AnnotationPopoverViewController`. `viewWillLayoutSubviews()` calls `updatePreferredContentSize()` which updates those sizes and that may cause another `viewWillLayoutSubviews()` which causes a cycle. 

I also changed `layoutSubviews()` which shouldn't be called directly to `layoutIfNeeded()`

Crash reported in https://forums.zotero.org/discussion/130823/ios-crash-report-762085943