### PR TITLE
Properly cancel document search on debounce, increase debounce

### DIFF
--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFSearchHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFSearchHandler.swift
@@ -42,6 +42,8 @@ extension PDFSearchHandler: DocumentSearchHandler {
             delegate?.set(footer: nil)
         }
 
+        cancel()
+
         let search = TextSearch(document: document)
         search.delegate = self
         search.comparisonOptions = [.caseInsensitive, .diacriticInsensitive]
@@ -55,6 +57,7 @@ extension PDFSearchHandler: DocumentSearchHandler {
     }
 
     private func finishSearch(with results: [SearchResult]) {
+        cancel()
         delegate?.stopSearchLoadingIndicator()
         self.results = results
         documentController.highlightSearchResults(results)
@@ -63,6 +66,7 @@ extension PDFSearchHandler: DocumentSearchHandler {
 
     func cancel() {
         currentSearch?.cancelAllOperations()
+        currentSearch = nil
     }
 }
 
@@ -86,6 +90,7 @@ extension PDFSearchHandler: TextSearchDelegate {
     }
 
     func didCancel(_ textSearch: TextSearch, term searchTerm: String, isFullSearch: Bool) {
+        guard currentSearch == nil else { return }
         delegate?.stopSearchLoadingIndicator()
     }
 }

--- a/Zotero/Scenes/General/Views/DocumentSearchViewController.swift
+++ b/Zotero/Scenes/General/Views/DocumentSearchViewController.swift
@@ -121,7 +121,7 @@ final class DocumentSearchViewController: UIViewController {
                 .text
                 .observe(on: MainScheduler.instance)
                 .skip(1)
-                .debounce(.milliseconds(150), scheduler: MainScheduler.instance)
+                .debounce(.milliseconds(250), scheduler: MainScheduler.instance)
                 .subscribe(onNext: { [weak self] text in
                     self?.text = text
                 })


### PR DESCRIPTION
@dstillman I increased to debounce to 250 ms. Also I now properly cancel document search when new search starts, it might help with performance on big documents.

Closes #1266