### PR TITLE
Improve lookup

### DIFF
--- a/ZShare/Assets/translation/lookup.js
+++ b/ZShare/Assets/translation/lookup.js
@@ -52,7 +52,7 @@ async function lookup(encodedIdentifiers, saveAttachments) {
     const identifiersInput = decodeBase64(encodedIdentifiers);
     var identifiers = [];
 
-    for (identifier of identifiersInput.split(",")) {
+    for (let identifier of identifiersInput.split(",")) {
         const _identifiers = Zotero.Utilities.extractIdentifiers(identifier);
         identifiers.push(..._identifiers);
     }
@@ -65,30 +65,17 @@ async function lookup(encodedIdentifiers, saveAttachments) {
     Zotero.debug("Extracted identifiers: " + JSON.stringify(identifiers));
     window.webkit.messageHandlers.identifiersHandler.postMessage(identifiers);
 
-    // Set up a translate instance
-    var translate = new Zotero.Translate.Search();
-
-    try {
-        Zotero.debug("Get translators");
-        // Get translators
-        var translators = await translate.getTranslators();
-        translate.setTranslator(translators);
-    } catch (e) {
-        // Continue with other ids on failure
-        Zotero.logError(e);
-        window.webkit.messageHandlers.failureHandler.postMessage(1);
-        return;
-    }
-
-    // Go through all identifiers
-
     for (let identifier of identifiers) {
         Zotero.debug("Process identifier " + JSON.stringify(identifier));
 
         window.webkit.messageHandlers.itemsHandler.postMessage({"identifier": identifier});
 
         try {
+            var translate = new Zotero.Translate.Search();
             translate.setIdentifier(identifier);
+            Zotero.debug("Get translators");
+            var translators = await translate.getTranslators();
+            translate.setTranslator(translators);
             let items = await translate.translate({ libraryID: false, collections: false, saveAttachments: saveAttachments });
             window.webkit.messageHandlers.itemsHandler.postMessage({"identifier": identifier, "data": items});
         } catch (e) {

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -140,6 +140,7 @@
 "items.filters.tags" = "Tags";
 "items.toolbar_saved" = "Saved %d / %d";
 "items.toolbar_downloaded" = "Downloaded %d / %d";
+"items.toolbar_failed" = "Failed %d";
 "items.generating_bib" = "Generating Bibliography";
 "items.creator_summary.and" = "%@ and %@";
 "items.creator_summary.etal" = "%@ et al.";

--- a/Zotero/Controllers/Attachment Downloader/RemoteAttachmentDownloader.swift
+++ b/Zotero/Controllers/Attachment Downloader/RemoteAttachmentDownloader.swift
@@ -44,7 +44,7 @@ final class RemoteAttachmentDownloader {
     private var batchProgress: Progress?
     private var totalBatchCount: Int = 0
 
-    var batchData: (Progress?, Int, Int) {
+    var batchData: (progress: Progress?, remainingCount: Int, totalCount: Int) {
         var progress: Progress?
         var totalBatchCount = 0
         var remainingBatchCount = 0

--- a/Zotero/Controllers/IdentifierLookupController.swift
+++ b/Zotero/Controllers/IdentifierLookupController.swift
@@ -140,15 +140,7 @@ final class IdentifierLookupController {
     }
 
     internal weak var webViewProvider: WebViewProvider?
-    internal weak var presenter: IdentifierLookupPresenter? {
-        didSet {
-            guard presenter == nil, oldValue != nil else { return }
-            cleanupLookupIfNeeded(force: false) { [weak self] cleaned in
-                guard let self, cleaned else { return }
-                observable.on(.next(Update(kind: .finishedAllLookups, lookupData: [])))
-            }
-        }
-    }
+    private weak var presenter: IdentifierLookupPresenter?
     private var lookupWebViewHandlersByLookupSettings: [LookupSettings: LookupWebViewHandler] = [:]
     
     // MARK: Object Lifecycle
@@ -206,7 +198,17 @@ final class IdentifierLookupController {
             lookupData = Array(lookupDataByIdentifier.values)
         }
     }
-    
+
+    func setPresenter(_ newPresenter: IdentifierLookupPresenter?, acknowledgeFailures: Bool) {
+        let oldPresenter = presenter
+        presenter = newPresenter
+        guard newPresenter == nil, oldPresenter != nil else { return }
+        cleanupLookupIfNeeded(force: false, failuresAcknowledged: acknowledgeFailures) { [weak self] cleaned in
+            guard let self, cleaned else { return }
+            observable.on(.next(Update(kind: .finishedAllLookups, lookupData: [])))
+        }
+    }
+
     func lookUp(libraryId: LibraryIdentifier, collectionKeys: Set<String>, identifier: String) {
         let lookupSettings = LookupSettings(libraryIdentifier: libraryId, collectionKeys: collectionKeys)
         guard let lookupWebViewHandler = lookupWebViewHandlersByLookupSettings[lookupSettings] else {
@@ -225,7 +227,7 @@ final class IdentifierLookupController {
                 lookupWebViewHandlersByLookupSettings.removeValue(forKey: key)?.removeFromSuperviewAsynchronously()
             }
             remoteFileDownloader.stop()
-            cleanupLookupIfNeeded(force: true) { [weak self] _ in
+            cleanupLookupIfNeeded(force: true, failuresAcknowledged: false) { [weak self] _ in
                 self?.observable.on(.next(Update(kind: .finishedAllLookups, lookupData: [])))
             }
             let storedItemResponses: [(ItemResponse, LibraryIdentifier)] = lookupDataByIdentifier.values.compactMap {
@@ -248,7 +250,7 @@ final class IdentifierLookupController {
             }
         }
     }
-    
+
     // MARK: Setups
     private func setupObservers() {
         remoteFileDownloader.observable
@@ -286,7 +288,7 @@ final class IdentifierLookupController {
                     break
                 }
                 guard cleanupLookup else { return }
-                cleanupLookupIfNeeded(force: false) { [weak self] _ in
+                cleanupLookupIfNeeded(force: false, failuresAcknowledged: false) { [weak self] _ in
                     guard let self else { return }
                     observable.on(.next(Update(kind: .finishedAllLookups, lookupData: [])))
                 }
@@ -309,7 +311,7 @@ final class IdentifierLookupController {
 
         case .failure(let error):
             DDLogError("IdentifierLookupController: lookup failed - \(error)")
-            cleanupLookupIfNeeded(force: false) { [weak self] _ in
+            cleanupLookupIfNeeded(force: false, failuresAcknowledged: false) { [weak self] _ in
                 guard let self else { return }
                 observable.on(.next(Update(kind: .lookupError(error: error), lookupData: Array(lookupDataByIdentifier.values))))
             }
@@ -322,7 +324,7 @@ final class IdentifierLookupController {
                 enqueueLookup(for: enqueuedIdentifiers) { [weak self] validIdentifiers in
                     guard let self else { return }
                     if validIdentifiers.isEmpty {
-                        cleanupLookupIfNeeded(force: false) { [weak self] _ in
+                        cleanupLookupIfNeeded(force: false, failuresAcknowledged: false) { [weak self] _ in
                             guard let self else { return }
                             observable.on(.next(Update(kind: .identifiersDetected(identifiers: []), lookupData: Array(lookupDataByIdentifier.values))))
                         }
@@ -360,10 +362,6 @@ final class IdentifierLookupController {
                     changeLookup(for: identifier, to: .failed) { [weak self] didChange in
                         guard let self, didChange else { return }
                         observable.on(.next(Update(kind: .lookupFailed(identifier: identifier), lookupData: Array(lookupDataByIdentifier.values))))
-                        cleanupLookupIfNeeded(force: false) { [weak self] cleaned in
-                            guard let self, cleaned else { return }
-                            observable.on(.next(Update(kind: .finishedAllLookups, lookupData: [])))
-                        }
                     }
                     return
                 }
@@ -375,10 +373,6 @@ final class IdentifierLookupController {
                     changeLookup(for: identifier, to: .failed) { [weak self] didChange in
                         guard let self, didChange else { return }
                         observable.on(.next(Update(kind: .parseFailed(identifier: identifier), lookupData: Array(lookupDataByIdentifier.values))))
-                        cleanupLookupIfNeeded(force: false) { [weak self] cleaned in
-                            guard let self, cleaned else { return }
-                            observable.on(.next(Update(kind: .finishedAllLookups, lookupData: [])))
-                        }
                     }
                     return
                 }
@@ -462,10 +456,6 @@ final class IdentifierLookupController {
                                 kind: .itemCreationFailed(identifier: identifier, response: response, attachments: attachments),
                                 lookupData: Array(lookupDataByIdentifier.values))
                             ))
-                            cleanupLookupIfNeeded(force: false) { [weak self] cleaned in
-                                guard let self, cleaned else { return }
-                                observable.on(.next(Update(kind: .finishedAllLookups, lookupData: [])))
-                            }
                         }
                     }
                 }
@@ -492,7 +482,7 @@ final class IdentifierLookupController {
                             ))
                         }
 
-                        cleanupLookupIfNeeded(force: false) { [weak self] cleaned in
+                        cleanupLookupIfNeeded(force: false, failuresAcknowledged: false) { [weak self] cleaned in
                             guard let self, cleaned else { return }
                             observable.on(.next(Update(kind: .finishedAllLookups, lookupData: [])))
                         }
@@ -503,24 +493,29 @@ final class IdentifierLookupController {
     }
 
     // MARK: Lookup Data
-    private func cleanupLookupIfNeeded(force: Bool, completion: @escaping (Bool) -> Void) {
+    private func cleanupLookupIfNeeded(force: Bool, failuresAcknowledged: Bool, completion: @escaping (Bool) -> Void) {
         if DispatchQueue.getSpecific(key: dispatchSpecificKey) == accessQueueLabel {
-            cleanupLookup(force: force, completion: completion)
+            cleanupLookup(force: force, failuresAcknowledged: failuresAcknowledged, completion: completion)
         } else {
             accessQueue.async(flags: .barrier) { [weak self] in
-                self?.cleanupLookup(force: force, completion: completion)
+                self?.cleanupLookup(force: force, failuresAcknowledged: failuresAcknowledged, completion: completion)
             }
         }
     }
 
-    private func cleanupLookup(force: Bool, completion: @escaping (Bool) -> Void) {
+    private func cleanupLookup(force: Bool, failuresAcknowledged: Bool, completion: @escaping (Bool) -> Void) {
         if force {
             // If forced, cleanup and return
             cleanup(completion: completion)
             return
         }
-        guard lookupRemainingCount == 0, remoteFileDownloader.batchData.2 == 0 else {
+        guard lookupRemainingCount == 0, remoteFileDownloader.batchData.totalCount == 0 else {
             // If there are remaining lookups, or downloading attachments, then just return
+            completion(false)
+            return
+        }
+        guard lookupFailedCount == 0 || failuresAcknowledged else {
+            // Failed lookups require an explicit acknowledged cleanup attempt.
             completion(false)
             return
         }

--- a/Zotero/Scenes/Detail/Items/Models/ItemsState.swift
+++ b/Zotero/Scenes/Detail/Items/Models/ItemsState.swift
@@ -64,22 +64,24 @@ struct ItemsState: ViewModelState {
     }
     
     struct IdentifierLookupBatchData: Equatable {
-        static let zero: Self = .init(saved: 0, total: 0)
+        static let zero: Self = .init(saved: 0, total: 0, failed: 0)
         
         let saved: Int
+        let failed: Int
         let total: Int
         
-        init(saved: Int, total: Int) {
+        init(saved: Int, total: Int, failed: Int) {
             self.saved = saved
+            self.failed = failed
             self.total = total
         }
         
         init(batchData: (savedCount: Int, failedCount: Int, totalCount: Int)) {
-            self.init(saved: batchData.savedCount, total: batchData.totalCount - batchData.failedCount)
+            self.init(saved: batchData.savedCount, total: batchData.totalCount, failed: batchData.failedCount)
         }
         
         var isFinished: Bool {
-            saved == total
+            saved + failed == total
         }
     }
 

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
@@ -296,12 +296,20 @@ final class ItemsToolbarController {
                 var progress: Float?
                 let remoteDownloading = remoteDownloadBatchData != nil
                 let defaultAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.label, .font: UIFont.preferredFont(forTextStyle: .footnote)]
-                if identifierLookupBatchData != .zero, !identifierLookupBatchData.isFinished || remoteDownloading {
-                    // Show "Saved x / y" only if lookup hasn't finished, or there are also ongoing remote downloads
+                if identifierLookupBatchData != .zero,
+                   !identifierLookupBatchData.isFinished || identifierLookupBatchData.failed > 0 || remoteDownloading {
+                    // Keep lookup progress visible while it is active, while remote downloads are pending,
+                    // or after hidden failures so the user can reopen lookup from the toolbar.
                     isUserInteractionEnabled = true
                     let identifierLookupText = L10n.Items.toolbarSaved(identifierLookupBatchData.saved, identifierLookupBatchData.total)
                     let identifierLookupAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: Asset.Colors.zoteroBlueWithDarkMode.color, .font: UIFont.preferredFont(forTextStyle: .footnote)]
                     attributedText.append(.init(string: identifierLookupText, attributes: identifierLookupAttributes))
+                    if identifierLookupBatchData.failed > 0 {
+                        let failedText = L10n.Items.toolbarFailed(identifierLookupBatchData.failed)
+                        let failedAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.systemRed, .font: UIFont.preferredFont(forTextStyle: .footnote)]
+                        attributedText.append(.init(string: " - ", attributes: defaultAttributes))
+                        attributedText.append(.init(string: failedText, attributes: failedAttributes))
+                    }
                 }
                 if let combinedDownloadBatchData = ItemsState.DownloadBatchData.combineDownloadBatchData([downloadBatchData, remoteDownloadBatchData]) {
                     if attributedText.length > 0 {

--- a/Zotero/Scenes/Detail/Items/Views/BaseItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/BaseItemsViewController.swift
@@ -290,7 +290,7 @@ class BaseItemsViewController: UIViewController {
             allowsManualSort: true,
             downloadBatchData: nil,
             remoteDownloadBatchData: nil,
-            identifierLookupBatchData: ItemsState.IdentifierLookupBatchData(saved: 0, total: 0),
+            identifierLookupBatchData: .zero,
             itemCount: 0
         )
     }

--- a/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
+++ b/Zotero/Scenes/Detail/Lookup/LookupCoordinator.swift
@@ -18,12 +18,15 @@ enum LookupStartingView {
 
 protocol LookupCoordinatorDelegate: AnyObject {
     func lookupController(restoreLookupState: Bool, hasDarkBackground: Bool) -> LookupViewController?
+
+    var acknowledgeFailures: Bool { get set }
 }
 
 final class LookupCoordinator: NSObject, Coordinator {
     weak var parentCoordinator: Coordinator?
     var childCoordinators: [Coordinator]
     weak var navigationController: UINavigationController?
+    internal var acknowledgeFailures: Bool = false
 
     private let startingView: LookupStartingView
     private unowned let controllers: Controllers
@@ -38,9 +41,10 @@ final class LookupCoordinator: NSObject, Coordinator {
 
         super.init()
 
-        navigationController.dismissHandler = {
-            self.controllers.userControllers?.identifierLookupController.presenter = nil
-            self.parentCoordinator?.childDidFinish(self)
+        navigationController.dismissHandler = { [weak self] in
+            guard let self else { return }
+            controllers.userControllers?.identifierLookupController.setPresenter(nil, acknowledgeFailures: acknowledgeFailures)
+            parentCoordinator?.childDidFinish(self)
         }
     }
 
@@ -77,7 +81,7 @@ final class LookupCoordinator: NSObject, Coordinator {
         let handler = ScannerActionHandler()
         let controller = ScannerViewController(viewModel: ViewModel(initialState: state, handler: handler))
         controller.coordinatorDelegate = self
-        controllers.userControllers?.identifierLookupController.presenter = controller
+        controllers.userControllers?.identifierLookupController.setPresenter(controller, acknowledgeFailures: false)
         return controller
     }
 
@@ -86,7 +90,7 @@ final class LookupCoordinator: NSObject, Coordinator {
         let handler = ManualLookupActionHandler()
         let controller = ManualLookupViewController(viewModel: ViewModel(initialState: state, handler: handler))
         controller.coordinatorDelegate = self
-        controllers.userControllers?.identifierLookupController.presenter = controller
+        controllers.userControllers?.identifierLookupController.setPresenter(controller, acknowledgeFailures: false)
         return controller
     }
 }

--- a/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
+++ b/Zotero/Scenes/Detail/Lookup/ViewModels/LookupActionHandler.swift
@@ -32,7 +32,7 @@ final class LookupActionHandler: ViewModelActionHandler {
 
         case .lookUp(let identifier):
             self.lookUp(identifier: identifier, in: viewModel)
-            
+
         case .cancelAllLookups:
             identifierLookupController.cancelAllLookups()
             self.update(viewModel: viewModel) { state in

--- a/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
@@ -144,7 +144,9 @@ class ManualLookupViewController: UIViewController {
 
         let closeItem = UIBarButtonItem(title: L10n.close, style: .plain, target: nil, action: nil)
         closeItem.rx.tap.subscribe(onNext: { [weak self] in
-            self?.close()
+            guard let self else { return }
+            coordinatorDelegate?.acknowledgeFailures = true
+            close()
         }).disposed(by: self.disposeBag)
         
         let cancelAllItem = UIBarButtonItem(title: L10n.cancelAll, style: .plain, target: nil, action: nil)

--- a/Zotero/Scenes/Detail/Lookup/Views/ScannerViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/ScannerViewController.swift
@@ -128,7 +128,9 @@ final class ScannerViewController: UIViewController {
     private func setupNavigationItems() {
         let cancelItem = UIBarButtonItem(title: L10n.close, style: .plain, target: nil, action: nil)
         cancelItem.rx.tap.subscribe(onNext: { [weak self] in
-            self?.navigationController?.presentingViewController?.dismiss(animated: true)
+            guard let self else { return }
+            coordinatorDelegate?.acknowledgeFailures = true
+            navigationController?.presentingViewController?.dismiss(animated: true)
         }).disposed(by: self.disposeBag)
         self.navigationItem.leftBarButtonItem = cancelItem
     }

--- a/Zotero/Scenes/Detail/Trash/Views/TrashViewController.swift
+++ b/Zotero/Scenes/Detail/Trash/Views/TrashViewController.swift
@@ -226,7 +226,7 @@ final class TrashViewController: BaseItemsViewController {
             allowsManualSort: true,
             downloadBatchData: nil,
             remoteDownloadBatchData: nil,
-            identifierLookupBatchData: .init(saved: 0, total: 0),
+            identifierLookupBatchData: .zero,
             itemCount: state.snapshot.count
         )
     }


### PR DESCRIPTION
* Fixes setup in `lookup.js`
* When there are failed lookups with the lookup window hidden, it is shown prominently in the items toolbar, until user taps to re-open the lookup window and closes, so the failures are acknowledged.