### PR TITLE
Fix regex match substring by range when string includes emojis

### DIFF
--- a/Zotero/Controllers/ISBNParser.swift
+++ b/Zotero/Controllers/ISBNParser.swift
@@ -21,9 +21,8 @@ final class ISBNParser {
         var isbns: [String] = []
 
         for match in matches {
-            let startIndex = cleanedString.index(cleanedString.startIndex, offsetBy: match.range.lowerBound)
-            let endIndex = cleanedString.index(cleanedString.startIndex, offsetBy: match.range.upperBound)
-            let isbn = cleanedString[startIndex..<endIndex].replacingOccurrences(of: #"\s+"#, with: "", options: .regularExpression, range: nil)
+            guard let range = Range(match.range, in: cleanedString) else { continue }
+            let isbn = cleanedString[range].replacingOccurrences(of: #"\s+"#, with: "", options: .regularExpression, range: nil)
 
             if isbn.count == 10 ? self.validate(isbn10: isbn) : self.validate(isbn13: isbn) {
                 isbns.append(isbn)

--- a/Zotero/Scenes/Detail/Items/ViewModels/BaseItemsActionHandler.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/BaseItemsActionHandler.swift
@@ -76,22 +76,26 @@ class BaseItemsActionHandler: BackgroundDbProcessingActionHandler {
         }
 
         var components: [String] = []
-        for (idx, match) in matches.enumerated() {
-            if match.range.lowerBound > 0 {
-                let lowerBound = idx == 0 ? 0 : matches[idx - 1].range.upperBound
-                let precedingRange = normalizedSearchTerm.index(normalizedSearchTerm.startIndex, offsetBy: lowerBound)..<normalizedSearchTerm.index(normalizedSearchTerm.startIndex, offsetBy: match.range.lowerBound)
-                let precedingComponents = separateComponents(from: String(normalizedSearchTerm[precedingRange]))
+        var previousMatchEnd = normalizedSearchTerm.startIndex
+        for match in matches {
+            guard let matchRange = Range(match.range, in: normalizedSearchTerm) else { continue }
+
+            if matchRange.lowerBound > previousMatchEnd {
+                let precedingComponents = separateComponents(from: String(normalizedSearchTerm[previousMatchEnd..<matchRange.lowerBound]))
                 components.append(contentsOf: precedingComponents)
             }
 
-            let upperBound = normalizedSearchTerm[normalizedSearchTerm.index(normalizedSearchTerm.startIndex, offsetBy: (match.range.upperBound - 1))] == "\"" ? match.range.upperBound - 1 : match.range.upperBound
-            let range = normalizedSearchTerm.index(normalizedSearchTerm.startIndex, offsetBy: (match.range.lowerBound + 1))..<normalizedSearchTerm.index(normalizedSearchTerm.startIndex, offsetBy: upperBound)
-            components.append(String(normalizedSearchTerm[range]))
+            // Strip the opening quote, and the closing quote if present
+            var innerStart = normalizedSearchTerm.index(after: matchRange.lowerBound)
+            let innerEnd = normalizedSearchTerm[normalizedSearchTerm.index(before: matchRange.upperBound)] == "\"" ? normalizedSearchTerm.index(before: matchRange.upperBound) : matchRange.upperBound
+            if innerStart > innerEnd { innerStart = innerEnd }
+            components.append(String(normalizedSearchTerm[innerStart..<innerEnd]))
+
+            previousMatchEnd = matchRange.upperBound
         }
 
-        if let match = matches.last, match.range.upperBound != (normalizedSearchTerm.count - 1) {
-            let lastRange = normalizedSearchTerm.index(normalizedSearchTerm.startIndex, offsetBy: match.range.upperBound)..<normalizedSearchTerm.endIndex
-            let lastComponents = separateComponents(from: String(normalizedSearchTerm[lastRange]))
+        if previousMatchEnd < normalizedSearchTerm.endIndex {
+            let lastComponents = separateComponents(from: String(normalizedSearchTerm[previousMatchEnd..<normalizedSearchTerm.endIndex]))
             components.append(contentsOf: lastComponents)
         }
 

--- a/Zotero/Scenes/Detail/Lookup/ViewModels/ManualLookupActionHandler.swift
+++ b/Zotero/Scenes/Detail/Lookup/ViewModels/ManualLookupActionHandler.swift
@@ -52,10 +52,9 @@ final class ManualLookupActionHandler: ViewModelActionHandler {
     }
 
     private func getResults(withExpression expression: NSRegularExpression, from text: String) -> [String] {
-        return expression.matches(in: text, range: NSRange(text.startIndex..., in: text)).map { result in
-            let startIndex = text.index(text.startIndex, offsetBy: result.range.lowerBound)
-            let endIndex = text.index(text.startIndex, offsetBy: result.range.upperBound)
-            return String(text[startIndex..<endIndex])
+        return expression.matches(in: text, range: NSRange(text.startIndex..., in: text)).compactMap { result in
+            guard let range = Range(result.range, in: text) else { return nil }
+            return String(text[range])
         }
     }
 }


### PR DESCRIPTION
Fixes regex match substring by range when string includes emojis or and extended grapheme cases, by replacing UTF-16 offset slicing with use of `Range`.
Current use cases in items search, ISBN parsing, and manual lookup identifier parsing. Certainly in the later two cases this is not an issue, but still with an erroneous e.g. paste, the app would crash.