### PR TITLE
Make last read watcher store async

### DIFF
--- a/Zotero/Controllers/LastReadWatcher.swift
+++ b/Zotero/Controllers/LastReadWatcher.swift
@@ -71,6 +71,9 @@ final class LastReadWatcher {
     private func flushPendingAndStop(sync: Bool = false) {
         if let pendingUpdate {
             store(key: pendingUpdate.key, libraryId: pendingUpdate.libraryId, date: pendingUpdate.date, sync: sync)
+        } else if sync {
+            // Since sync is asked, but no pending update exists, add an empty sync work to force any already async stores to be executed.
+            dbQueue.sync { }
         }
         pendingUpdate = nil
         lastUpdate = nil

--- a/Zotero/Controllers/LastReadWatcher.swift
+++ b/Zotero/Controllers/LastReadWatcher.swift
@@ -21,7 +21,8 @@ final class LastReadWatcher {
     init(dbStorage: DbStorage) {
         self.dbStorage = dbStorage
         let block: ((Notification) -> Void) = { [weak self] _ in
-            self?.flushPendingAndStop()
+            guard let self else { return }
+            flushPendingAndStop(sync: true)
         }
         observers = [
             NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: .main, using: block),
@@ -67,23 +68,28 @@ final class LastReadWatcher {
         }
     }
 
-    private func flushPendingAndStop() {
+    private func flushPendingAndStop(sync: Bool = false) {
         if let pendingUpdate {
-            store(key: pendingUpdate.key, libraryId: pendingUpdate.libraryId, date: pendingUpdate.date)
+            store(key: pendingUpdate.key, libraryId: pendingUpdate.libraryId, date: pendingUpdate.date, sync: sync)
         }
         pendingUpdate = nil
         lastUpdate = nil
         timer = nil
     }
 
-    private func store(key: String, libraryId: LibraryIdentifier, date: Date?) {
-        dbQueue.async { [weak self] in
+    private func store(key: String, libraryId: LibraryIdentifier, date: Date?, sync: Bool = false) {
+        let work: () -> Void = { [weak self] in
             guard let self else { return }
             do {
                 try dbStorage.perform(request: StoreLastReadDateDbRequest(key: key, libraryId: libraryId, date: date), on: dbQueue)
             } catch {
                 DDLogError("LastReadWatcher: can't store last read date - \(error)")
             }
+        }
+        if sync {
+            dbQueue.sync(execute: work)
+        } else {
+            dbQueue.async(execute: work)
         }
     }
 }

--- a/Zotero/Controllers/LastReadWatcher.swift
+++ b/Zotero/Controllers/LastReadWatcher.swift
@@ -12,6 +12,7 @@ import CocoaLumberjackSwift
 
 final class LastReadWatcher {
     private unowned let dbStorage: DbStorage
+    private let dbQueue = DispatchQueue(label: "org.zotero.LastReadWatcher.DbQueue", qos: .utility)
     private var lastUpdate: (key: String, libraryId: LibraryIdentifier)?
     private var pendingUpdate: (key: String, libraryId: LibraryIdentifier, date: Date?)?
     private var timer: BackgroundTimer?
@@ -76,10 +77,13 @@ final class LastReadWatcher {
     }
 
     private func store(key: String, libraryId: LibraryIdentifier, date: Date?) {
-        do {
-            try dbStorage.perform(request: StoreLastReadDateDbRequest(key: key, libraryId: libraryId, date: date), on: .main)
-        } catch {
-            DDLogError("LastReadWatcher: can't store last read date - \(error)")
+        dbQueue.async { [weak self] in
+            guard let self else { return }
+            do {
+                try dbStorage.perform(request: StoreLastReadDateDbRequest(key: key, libraryId: libraryId, date: date), on: dbQueue)
+            } catch {
+                DDLogError("LastReadWatcher: can't store last read date - \(error)")
+            }
         }
     }
 }


### PR DESCRIPTION
- Makes last read watcher store async, so in case e.g. of the sync controller making a database request at the same time the user closes the reader, the database request in main doesn't cause the app to hang.

Issue reported in https://forums.zotero.org/discussion/131532/ios-crash-report-668675363
It also contains a crash in the sync controller request that is not addressed in this PR.
