### PR TITLE
Fix deletable object orphan users cleanup

### DIFF
--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		6144B5DB2A4ADEEB00914B3C /* SearchResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1EDF0250242F700D8BC1E /* SearchResponseSpec.swift */; };
 		6144B5DC2A4ADF1F00914B3C /* StorageSettingsActionHandlerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1C58526651E2A00883597 /* StorageSettingsActionHandlerSpec.swift */; };
 		6144B5DD2A4AE0F200914B3C /* SyncActionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B307E55D22D4A87B00592B3C /* SyncActionsSpec.swift */; };
+		61DE1A1B2FBD000100C0DE01 /* DeletableObjectSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DE1A1C2FBD000100C0DE01 /* DeletableObjectSpec.swift */; };
 		6144B5DF2A4AE48F00914B3C /* SyncControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34F274E220E20370038B3B1 /* SyncControllerSpec.swift */; };
 		6144B5E02A4AE49800914B3C /* TranslatorsControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F47C00243B339F004F8B1E /* TranslatorsControllerSpec.swift */; };
 		6144B5E12A4AE95E00914B3C /* WebDavControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3202C6B271048FF00485BE4 /* WebDavControllerSpec.swift */; };
@@ -1407,6 +1408,7 @@
 		61ABA7502A6137D1002A4219 /* ShareableImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableImage.swift; sourceTree = "<group>"; };
 		61AD977C2D67F42A000FDF45 /* DocumentWorkerControllerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentWorkerControllerSpec.swift; sourceTree = "<group>"; };
 		61BD13942A5831EF008A0704 /* TextKit1TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextKit1TextView.swift; sourceTree = "<group>"; };
+		61DE1A1C2FBD000100C0DE01 /* DeletableObjectSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletableObjectSpec.swift; sourceTree = "<group>"; };
 		61DE64D42C5BD0250096776C /* FormattedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattedTextView.swift; sourceTree = "<group>"; };
 		61E24DCB2ABB385E00D75F50 /* OpenItemsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenItemsController.swift; sourceTree = "<group>"; };
 		61E3CD4F2D9545DF00ACA004 /* CitationWebViewHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CitationWebViewHandler.swift; sourceTree = "<group>"; };
@@ -3216,6 +3218,7 @@
 				B3B1EDEE250242E700D8BC1E /* CollectionResponseSpec.swift */,
 				B34F9FA223743C36004ED34C /* CreatorSummaryFormatterSpec.swift */,
 				B32A3C79247FFF14009E2C5D /* DateParserSpec.swift */,
+				61DE1A1C2FBD000100C0DE01 /* DeletableObjectSpec.swift */,
 				61A86CA52FA1CDF0003E4421 /* DefaultAnnotationPageLabelSpec.swift */,
 				61AD977C2D67F42A000FDF45 /* DocumentWorkerControllerSpec.swift */,
 				B3EFC60A2B0F503E00CB71A0 /* EmojiExtractorSpec.swift */,
@@ -6185,6 +6188,7 @@
 				6144B5DA2A4ADEBD00914B3C /* WebDavCredentials.swift in Sources */,
 				6144B5DC2A4ADF1F00914B3C /* StorageSettingsActionHandlerSpec.swift in Sources */,
 				6144B5D72A4ADD8400914B3C /* TestControllers.swift in Sources */,
+				61DE1A1B2FBD000100C0DE01 /* DeletableObjectSpec.swift in Sources */,
 				6144B5DD2A4AE0F200914B3C /* SyncActionsSpec.swift in Sources */,
 				6144B5DB2A4ADEEB00914B3C /* SearchResponseSpec.swift in Sources */,
 				6144B5D62A4ADD7E00914B3C /* ItemResponseSpec.swift in Sources */,

--- a/Zotero/Controllers/Database/Requests/DeleteFailedItemsDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/DeleteFailedItemsDbRequest.swift
@@ -24,8 +24,7 @@ struct DeleteFailedItemsDbRequest: DbRequest {
     private func deleteItemAndChildrenAsNeeded(item: RItem, in database: Realm) {
         if !item.changes.isEmpty {
             // Item did not sync yet, delete with children
-            item.willRemove(in: database)
-            database.delete(item)
+            database.delete(deletable: item)
             return
         }
 

--- a/Zotero/Controllers/Database/Requests/DeleteGroupDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/DeleteGroupDbRequest.swift
@@ -37,10 +37,6 @@ struct DeleteGroupDbRequest: DbRequest {
 
     private func deleteObjects<Obj: DeletableObject>(of type: Obj.Type, with predicate: NSPredicate, database: Realm) {
         let objects = database.objects(type).filter(predicate)
-        for object in objects {
-            guard !object.isInvalidated else { continue }
-            object.willRemove(in: database)
-        }
-        database.delete(objects)
+        database.delete(deletable: objects)
     }
 }

--- a/Zotero/Controllers/Database/Requests/DeleteObjectsDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/DeleteObjectsDbRequest.swift
@@ -18,10 +18,6 @@ struct DeleteObjectsDbRequest<Obj: DeletableObject>: DbRequest {
 
     func process(in database: Realm) throws {
         let objects = database.objects(Obj.self).filter(.keys(self.keys, in: self.libraryId))
-        for object in objects {
-            guard !object.isInvalidated else { continue }
-            object.willRemove(in: database)
-        }
-        database.delete(objects)
+        database.delete(deletable: objects)
     }
 }

--- a/Zotero/Controllers/Database/Requests/MarkAllLibraryObjectChangesAsSyncedDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/MarkAllLibraryObjectChangesAsSyncedDbRequest.swift
@@ -37,10 +37,6 @@ struct MarkAllLibraryObjectChangesAsSyncedDbRequest: DbRequest {
 
     private func deleteObjects<Obj: DeletableObject>(of type: Obj.Type, with predicate: NSPredicate, database: Realm) {
         let objects = database.objects(type).filter(predicate)
-        for object in objects {
-            guard !object.isInvalidated else { continue }
-            object.willRemove(in: database)
-        }
-        database.delete(objects)
+        database.delete(deletable: objects)
     }
 }

--- a/Zotero/Controllers/Database/Requests/PerformDeletionsDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/PerformDeletionsDbRequest.swift
@@ -31,6 +31,7 @@ struct PerformItemDeletionsDbRequest: DbResponseRequest {
     func process(in database: Realm) throws -> [(String, String)] {
         let objects = database.objects(RItem.self).filter(.keys(keys, in: libraryId))
         var conflicts: [(String, String)] = []
+        let context = DeletionContext()
 
         for object in objects {
             guard !object.isInvalidated else { continue } // If object is invalidated it has already been removed by some parent before
@@ -53,9 +54,9 @@ struct PerformItemDeletionsDbRequest: DbResponseRequest {
                 break
             }
 
-            object.willRemove(in: database)
-            database.delete(object)
+            context.delete(object, in: database)
         }
+        context.cleanup(in: database)
 
         return conflicts
     }
@@ -76,8 +77,7 @@ struct PerformCollectionDeletionsDbRequest: DbRequest {
                 // this collection is new and it will be reinserted by sync
                 object.markAsChanged(in: database)
             } else {
-                object.willRemove(in: database)
-                database.delete(object)
+                database.delete(deletable: object)
             }
         }
     }
@@ -98,8 +98,7 @@ struct PerformSearchDeletionsDbRequest: DbRequest {
                 // this search is new and it will be reinserted by sync
                 object.markAsChanged(in: database)
             } else {
-                object.willRemove(in: database)
-                database.delete(object)
+                database.delete(deletable: object)
             }
         }
     }
@@ -135,8 +134,7 @@ struct PerformPageIndexDeletionsDbRequest: DbRequest {
                 // this pageIndex is new and it will be reinserted by sync
                 object.markAsChanged(in: database)
             } else {
-                object.willRemove(in: database)
-                database.delete(object)
+                database.delete(deletable: object)
             }
         }
     }
@@ -166,8 +164,7 @@ struct PerformLastReadDeletionsDbRequest: DbRequest {
                     // this lastRead is new and it will be reinserted by sync
                     object.markAsChanged(in: database)
                 } else {
-                    object.willRemove(in: database)
-                    database.delete(object)
+                    database.delete(deletable: object)
                 }
             }
         }

--- a/Zotero/Controllers/Database/Requests/SplitAnnotationsDbRequest.swift
+++ b/Zotero/Controllers/Database/Requests/SplitAnnotationsDbRequest.swift
@@ -23,12 +23,13 @@ struct SplitAnnotationsDbRequest: DbRequest {
 
     func process(in database: Realm) throws {
         let items = database.objects(RItem.self).filter(.keys(self.keys, in: self.libraryId))
+        let context = DeletionContext()
 
         for item in items {
             self.split(item: item, database: database)
-            item.willRemove(in: database)
-            database.delete(item)
+            context.delete(item, in: database)
         }
+        context.cleanup(in: database)
     }
 
     /// Splits database annotation if it exceedes position limit.

--- a/Zotero/Models/DeletableObject.swift
+++ b/Zotero/Models/DeletableObject.swift
@@ -12,14 +12,62 @@ import RealmSwift
 
 typealias DeletableObject = Deletable&Object
 
+final class DeletionContext {
+    private var userIdsToCheck: Set<Int> = []
+
+    func collect(user: RUser?) {
+        guard let user, !user.isInvalidated else { return }
+        userIdsToCheck.insert(user.identifier)
+    }
+
+    func delete<Obj: DeletableObject>(_ object: Obj, in database: Realm) {
+        guard !object.isInvalidated else { return }
+        object.willRemove(in: database, context: self)
+        database.delete(object)
+    }
+
+    func delete<Obj: DeletableObject>(_ objects: Results<Obj>, in database: Realm) {
+        for object in objects {
+            guard !object.isInvalidated else { continue }
+            object.willRemove(in: database, context: self)
+        }
+        database.delete(objects)
+    }
+
+    func cleanup(in database: Realm) {
+        for identifier in userIdsToCheck {
+            guard let user = database.object(ofType: RUser.self, forPrimaryKey: identifier),
+                  !user.isInvalidated,
+                  user.createdBy.isEmpty,
+                  user.modifiedBy.isEmpty else { continue }
+
+            database.delete(user)
+        }
+    }
+}
+
 protocol Deletable: AnyObject {
     var deleted: Bool { get set }
 
-    func willRemove(in database: Realm)
+    func willRemove(in database: Realm, context: DeletionContext)
+}
+
+extension Realm {
+    func delete<Obj: DeletableObject>(deletable object: Obj) {
+        let context = DeletionContext()
+        context.delete(object, in: self)
+        context.cleanup(in: self)
+    }
+
+    func delete<Obj: DeletableObject>(deletable objects: Results<Obj>) {
+        let context = DeletionContext()
+        context.delete(objects, in: self)
+        context.cleanup(in: self)
+    }
 }
 
 extension RCollection: Deletable {
-    func willRemove(in database: Realm) {
+    func willRemove(in database: Realm, context: DeletionContext) {
         guard let libraryId = self.libraryId else { return }
         if !changes.isInvalidated {
             database.delete(changes)
@@ -28,7 +76,7 @@ extension RCollection: Deletable {
         if !children.isInvalidated {
             for child in children {
                 guard !child.isInvalidated else { continue }
-                child.willRemove(in: database)
+                child.willRemove(in: database, context: context)
             }
             database.delete(children)
         }
@@ -36,14 +84,17 @@ extension RCollection: Deletable {
 }
 
 extension RItem: Deletable {
-    func willRemove(in database: Realm) {
+    func willRemove(in database: Realm, context: DeletionContext) {
+        context.collect(user: createdBy)
+        context.collect(user: lastModifiedBy)
+
         if !changes.isInvalidated {
             database.delete(changes)
         }
         if !self.children.isInvalidated {
             for child in self.children {
                 guard !child.isInvalidated else { continue }
-                child.willRemove(in: database)
+                child.willRemove(in: database, context: context)
             }
             database.delete(self.children)
         }
@@ -52,20 +103,6 @@ extension RItem: Deletable {
             database.delete(self.tags)
             if !baseTagsToRemove.isEmpty {
                 database.delete(database.objects(RTag.self).filter(.name(in: baseTagsToRemove)))
-            }
-        }
-
-        if let createdByUser = self.createdBy, !createdByUser.isInvalidated, let lastModifiedByUser = self.lastModifiedBy, !lastModifiedByUser.isInvalidated,
-           createdByUser.identifier == lastModifiedByUser.identifier &&
-           createdByUser.createdBy.count == 1 &&
-           createdByUser.modifiedBy.count == 1 {
-            database.delete(createdByUser)
-        } else {
-            if let user = self.createdBy, !user.isInvalidated, user.createdBy.count == 1 && (user.modifiedBy.isInvalidated || user.modifiedBy.isEmpty) {
-                database.delete(user)
-            }
-            if let user = self.lastModifiedBy, !user.isInvalidated, (user.createdBy.isInvalidated || user.createdBy.isEmpty) && user.modifiedBy.count == 1 {
-                database.delete(user)
             }
         }
 
@@ -125,7 +162,7 @@ extension RItem: Deletable {
 }
 
 extension RSearch: Deletable {
-    func willRemove(in database: Realm) {
+    func willRemove(in database: Realm, context: DeletionContext) {
         if !changes.isInvalidated {
             database.delete(changes)
         }
@@ -133,7 +170,7 @@ extension RSearch: Deletable {
 }
 
 extension RLastReadDate: Deletable {
-    func willRemove(in database: Realm) {
+    func willRemove(in database: Realm, context: DeletionContext) {
         if !changes.isInvalidated {
             database.delete(changes)
         }
@@ -144,7 +181,7 @@ extension RLastReadDate: Deletable {
 }
 
 extension RPageIndex: Deletable {
-    func willRemove(in database: Realm) {
+    func willRemove(in database: Realm, context: DeletionContext) {
         if !changes.isInvalidated {
             database.delete(changes)
         }

--- a/ZoteroTests/DeletableObjectSpec.swift
+++ b/ZoteroTests/DeletableObjectSpec.swift
@@ -1,0 +1,128 @@
+//
+//  DeletableObjectSpec.swift
+//  ZoteroTests
+//
+//  Created by Miltiadis Vasilakis on 19/5/26.
+//  Copyright © 2026 Corporation for Digital Scholarship. All rights reserved.
+//
+
+import Foundation
+
+@testable import Zotero
+
+import Nimble
+import Quick
+import RealmSwift
+
+final class DeletableObjectSpec: QuickSpec {
+    override class func spec() {
+        describe("a deletable object") {
+            let libraryId: LibraryIdentifier = .custom(.myLibrary)
+            var realm: Realm!
+
+            beforeEach {
+                let config = Realm.Configuration(inMemoryIdentifier: UUID().uuidString)
+                realm = try! Realm(configuration: config)
+
+                try! realm.write {
+                    let library = RCustomLibrary()
+                    library.type = .myLibrary
+                    realm.add(library)
+                }
+            }
+
+            func createUser(identifier: Int) -> RUser {
+                let user = RUser()
+                user.identifier = identifier
+                user.name = "User \(identifier)"
+                user.username = "user\(identifier)"
+                return user
+            }
+
+            func createItem(key: String, rawType: String = "journalArticle", parent: RItem? = nil, user: RUser? = nil) -> RItem {
+                let item = RItem()
+                item.key = key
+                item.rawType = rawType
+                item.customLibraryKey = .myLibrary
+                item.parent = parent
+                item.createdBy = user
+                item.lastModifiedBy = user
+                return item
+            }
+
+            it("deletes users orphaned by remote item tree deletions") {
+                let userId = 1
+                let parentKey = "PARENT01"
+                let childKey = "CHILD001"
+
+                try! realm.write {
+                    let user = createUser(identifier: userId)
+                    let parent = createItem(key: parentKey, user: user)
+                    let child = createItem(key: childKey, rawType: ItemTypes.note, parent: parent, user: user)
+
+                    realm.add(user)
+                    realm.add(parent)
+                    realm.add(child)
+                }
+
+                try! realm.write {
+                    let request = PerformItemDeletionsDbRequest(libraryId: libraryId, keys: [parentKey], conflictMode: .deleteConflicts)
+                    _ = try! request.process(in: realm)
+                }
+
+                expect(realm.objects(RItem.self).filter(.key(parentKey, in: libraryId)).first).to(beNil())
+                expect(realm.objects(RItem.self).filter(.key(childKey, in: libraryId)).first).to(beNil())
+                expect(realm.object(ofType: RUser.self, forPrimaryKey: userId)).to(beNil())
+            }
+
+            it("keeps users still referenced after remote item tree deletions") {
+                let userId = 1
+                let parentKey = "PARENT01"
+                let childKey = "CHILD001"
+                let remainingKey = "REMAIN01"
+
+                try! realm.write {
+                    let user = createUser(identifier: userId)
+                    let parent = createItem(key: parentKey, user: user)
+                    let child = createItem(key: childKey, rawType: ItemTypes.note, parent: parent, user: user)
+                    let remaining = createItem(key: remainingKey, user: user)
+
+                    realm.add(user)
+                    realm.add(parent)
+                    realm.add(child)
+                    realm.add(remaining)
+                }
+
+                try! realm.write {
+                    let request = PerformItemDeletionsDbRequest(libraryId: libraryId, keys: [parentKey], conflictMode: .deleteConflicts)
+                    _ = try! request.process(in: realm)
+                }
+
+                expect(realm.objects(RItem.self).filter(.key(parentKey, in: libraryId)).first).to(beNil())
+                expect(realm.objects(RItem.self).filter(.key(childKey, in: libraryId)).first).to(beNil())
+                expect(realm.objects(RItem.self).filter(.key(remainingKey, in: libraryId)).first).toNot(beNil())
+                expect(realm.object(ofType: RUser.self, forPrimaryKey: userId)).toNot(beNil())
+            }
+
+            it("deletes orphaned users through generic item deletions") {
+                let userId = 1
+                let itemKey = "ITEM0001"
+
+                try! realm.write {
+                    let user = createUser(identifier: userId)
+                    let item = createItem(key: itemKey, user: user)
+
+                    realm.add(user)
+                    realm.add(item)
+                }
+
+                try! realm.write {
+                    try! DeleteObjectsDbRequest<RItem>(keys: [itemKey], libraryId: libraryId).process(in: realm)
+                }
+
+                expect(realm.objects(RItem.self).filter(.key(itemKey, in: libraryId)).first).to(beNil())
+                expect(realm.object(ofType: RUser.self, forPrimaryKey: userId)).to(beNil())
+            }
+        }
+    }
+}


### PR DESCRIPTION
Potential fix for crash in https://forums.zotero.org/discussion/131532/ios-crash-report-668675363

Stores potentially orphaned users in the deletion context, and cleanups after affected objects have been deleted. Previously there were edge cases where a backlink resolved against an item that was in the middle of being invalidated.