### PR TITLE
Fix item swipe actions

### DIFF
--- a/Zotero/Scenes/Detail/DetailCoordinator.swift
+++ b/Zotero/Scenes/Detail/DetailCoordinator.swift
@@ -35,14 +35,14 @@ protocol DetailCopyBibliographyCoordinatorDelegate: DetailMissingStyleErrorDeleg
 
 protocol DetailItemsCoordinatorDelegate: AnyObject {
     var displayTitle: String { get }
-    func showCollectionsPicker(in library: Library, completed: @escaping (Set<String>) -> Void)
+    func showCollectionsPicker(in library: Library, cancelled: @escaping () -> Void, completed: @escaping (Set<String>) -> Void)
     func showItemDetail(for type: ItemDetailState.DetailType, libraryId: LibraryIdentifier, scrolledToKey childKey: String?, animated: Bool)
     func showAttachmentError(_ error: Error)
     func showAddActions(viewModel: ViewModel<ItemsActionHandler>, button: UIBarButtonItem)
     func show(url: URL)
     func show(doi: String)
     func showDeletionQuestion(count: Int, confirmAction: @escaping () -> Void, cancelAction: @escaping () -> Void)
-    func showRemoveFromCollectionQuestion(count: Int, confirmAction: @escaping () -> Void)
+    func showRemoveFromCollectionQuestion(count: Int, cancelAction: @escaping () -> Void, confirmAction: @escaping () -> Void)
     func showCitation(using presenter: UIViewController?, for itemIds: Set<String>, libraryId: LibraryIdentifier, delegate: DetailCitationCoordinatorDelegate?)
     func copyBibliography(using presenter: UIViewController, for itemIds: Set<String>, libraryId: LibraryIdentifier, delegate: DetailCopyBibliographyCoordinatorDelegate?)
     func showCiteExport(for itemIds: Set<String>, libraryId: LibraryIdentifier)
@@ -579,20 +579,27 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
         self.navigationController?.pushViewController(controller, animated: animated)
     }
 
-    func showCollectionsPicker(in library: Library, completed: @escaping (Set<String>) -> Void) {
-        guard let dbStorage = self.controllers.userControllers?.dbStorage else { return }
+    func showCollectionsPicker(in library: Library, cancelled: @escaping () -> Void, completed: @escaping (Set<String>) -> Void) {
+        guard let dbStorage = controllers.userControllers?.dbStorage else {
+            cancelled()
+            return
+        }
 
         DDLogInfo("DetailCoordinator: show collection picker")
 
         let state = CollectionsPickerState(library: library, excludedKeys: [], selected: [])
         let handler = CollectionsPickerActionHandler(dbStorage: dbStorage)
         let viewModel = ViewModel(initialState: state, handler: handler)
-        let controller = CollectionsPickerViewController(mode: .multiple(selected: completed), viewModel: viewModel)
+        let controller = CollectionsPickerViewController(mode: .multiple(selected: completed, cancelled: cancelled), viewModel: viewModel)
 
         let navigationController = UINavigationController(rootViewController: controller)
         navigationController.isModalInPresentation = true
         navigationController.modalPresentationStyle = .formSheet
-        self.navigationController?.present(navigationController, animated: true, completion: nil)
+        guard let presenter = self.navigationController else {
+            cancelled()
+            return
+        }
+        presenter.present(navigationController, animated: true, completion: nil)
     }
 
     func showDeletionQuestion(count: Int, confirmAction: @escaping () -> Void, cancelAction: @escaping () -> Void) {
@@ -600,12 +607,16 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
         self.ask(question: question, title: L10n.delete, isDestructive: true, confirm: confirmAction, cancel: cancelAction)
     }
 
-    func showRemoveFromCollectionQuestion(count: Int, confirmAction: @escaping () -> Void) {
+    func showRemoveFromCollectionQuestion(count: Int, cancelAction: @escaping () -> Void, confirmAction: @escaping () -> Void) {
         let question = L10n.Items.removeFromCollectionQuestion(count)
-        self.ask(question: question, title: L10n.Items.removeFromCollectionTitle, isDestructive: false, confirm: confirmAction)
+        ask(question: question, title: L10n.Items.removeFromCollectionTitle, isDestructive: false, confirm: confirmAction, cancel: cancelAction)
     }
 
     private func ask(question: String, title: String, isDestructive: Bool, confirm: @escaping () -> Void, cancel: (() -> Void)? = nil) {
+        guard let navigationController else {
+            cancel?()
+            return
+        }
         let controller = UIAlertController(title: title, message: question, preferredStyle: .alert)
         controller.addAction(UIAlertAction(title: L10n.yes, style: (isDestructive ? .destructive : .default), handler: { _ in
             confirm()
@@ -613,7 +624,7 @@ extension DetailCoordinator: DetailItemsCoordinatorDelegate {
         controller.addAction(UIAlertAction(title: L10n.no, style: .cancel, handler: { _ in
             cancel?()
         }))
-        self.navigationController?.present(controller, animated: true, completion: nil)
+        navigationController.present(controller, animated: true, completion: nil)
     }
 
     func showCitation(using presenter: UIViewController?, for itemIds: Set<String>, libraryId: LibraryIdentifier, delegate: DetailCitationCoordinatorDelegate?) {

--- a/Zotero/Scenes/Detail/Items/Views/ItemsTableViewHandler.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsTableViewHandler.swift
@@ -12,12 +12,14 @@ import CocoaLumberjackSwift
 import RealmSwift
 import RxSwift
 
+typealias ItemContextualActionCompletion = (Bool) -> Void
+
 protocol ItemsTableViewHandlerDelegate: AnyObject {
     var isInViewHierarchy: Bool { get }
     var collectionKey: String? { get }
     var library: Library { get }
 
-    func process(action: ItemAction.Kind, at indexPath: IndexPath, completionAction: ((Bool) -> Void)?)
+    func process(action: ItemAction.Kind, at indexPath: IndexPath, contextualActionCompletion: ItemContextualActionCompletion?)
     func process(tapAction action: ItemsTableViewHandler.TapAction)
     func process(dragAndDropAction action: ItemsTableViewHandler.DragAndDropAction)
 }
@@ -103,7 +105,7 @@ final class ItemsTableViewHandler: NSObject {
     private func createContextMenu(at indexPath: IndexPath) -> UIMenu {
         let actions: [UIAction] = dataSource.createContextMenuActions(at: indexPath.row).map({ action in
             return UIAction(title: action.title, image: action.image, attributes: (action.isDestructive ? .destructive : [])) { [weak self] _ in
-                self?.delegate.process(action: action.type, at: indexPath, completionAction: nil)
+                self?.delegate.process(action: action.type, at: indexPath, contextualActionCompletion: nil)
             }
         })
         return UIMenu(title: "", children: actions)
@@ -117,7 +119,7 @@ final class ItemsTableViewHandler: NSObject {
                     completion(false)
                     return
                 }
-                delegate.process(action: action.type, at: indexPath, completionAction: completion)
+                delegate.process(action: action.type, at: indexPath, contextualActionCompletion: completion)
             })
             contextualAction.image = action.image
             switch action.type {

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -248,17 +248,30 @@ final class ItemsViewController: BaseItemsViewController {
         self.viewModel.process(action: .search(term))
     }
 
-    private func process(action: ItemAction.Kind, for selectedKeys: Set<String>, button: UIBarButtonItem?, completionAction: ((Bool) -> Void)?) {
+    private func process(action: ItemAction.Kind, for selectedKeys: Set<String>, button: UIBarButtonItem?, contextualActionCompletion: ItemContextualActionCompletion?) {
+        var completed: Bool? = false
+        defer {
+            if let contextualActionCompletion, let completed {
+                contextualActionCompletion(completed)
+            }
+        }
         switch action {
         case .delete, .restore, .sort, .debugReader, .filter:
             break
 
         case .addToCollection:
             guard !selectedKeys.isEmpty else { return }
-            coordinatorDelegate?.showCollectionsPicker(in: library, completed: { [weak self] collections in
-                self?.viewModel.process(action: .assignItemsToCollections(items: selectedKeys, collections: collections))
-                completionAction?(true)
-            })
+            completed = nil
+            coordinatorDelegate?.showCollectionsPicker(
+                in: library,
+                cancelled: {
+                    contextualActionCompletion?(false)
+                },
+                completed: { [weak self] collections in
+                    self?.viewModel.process(action: .assignItemsToCollections(items: selectedKeys, collections: collections))
+                    contextualActionCompletion?(true)
+                }
+            )
 
         case .createParent:
             guard let key = selectedKeys.first, case .attachment(let attachment, _) = viewModel.state.itemAccessories[key] else { return }
@@ -268,6 +281,7 @@ final class ItemsViewController: BaseItemsViewController {
                 scrolledToKey: nil,
                 animated: true
             )
+            completed = true
 
         case .retrieveMetadata:
             guard let key = selectedKeys.first,
@@ -289,47 +303,65 @@ final class ItemsViewController: BaseItemsViewController {
                     coordinatorDelegate?.showAttachmentError(error)
                 }
             }
+            completed = true
 
         case .duplicate:
             guard let key = selectedKeys.first else { return }
             viewModel.process(action: .loadItemToDuplicate(key))
+            completed = true
 
         case .removeFromCollection:
             guard !selectedKeys.isEmpty else { return }
+            completed = nil
             coordinatorDelegate?.showRemoveFromCollectionQuestion(
-                count: viewModel.state.selectedItems.count
-            ) { [weak self] in
-                self?.viewModel.process(action: .deleteItemsFromCollection(selectedKeys))
-                completionAction?(true)
-            }
+                count: viewModel.state.selectedItems.count,
+                cancelAction: {
+                    contextualActionCompletion?(false)
+                },
+                confirmAction: { [weak self] in
+                    self?.viewModel.process(action: .deleteItemsFromCollection(selectedKeys))
+                    contextualActionCompletion?(true)
+                }
+            )
 
         case .trash:
             guard !selectedKeys.isEmpty else { return }
             viewModel.process(action: .trashItems(selectedKeys))
+            completed = true
 
         case .share:
             guard !selectedKeys.isEmpty else { return }
             coordinatorDelegate?.showCiteExport(for: selectedKeys, libraryId: library.identifier)
+            completed = true
 
         case .copyBibliography:
+            guard !selectedKeys.isEmpty else { return }
             var presenter: UIViewController = self
             if let searchController = navigationItem.searchController, searchController.isActive {
                 presenter = searchController
             }
             coordinatorDelegate?.copyBibliography(using: presenter, for: selectedKeys, libraryId: library.identifier, delegate: nil)
+            completed = true
 
         case .copyCitation:
+            guard !selectedKeys.isEmpty else { return }
             coordinatorDelegate?.showCitation(using: nil, for: selectedKeys, libraryId: library.identifier, delegate: nil)
+            completed = true
 
         case .download:
+            guard !selectedKeys.isEmpty else { return }
             viewModel.process(action: .download(selectedKeys))
+            completed = true
 
         case .removeDownload:
+            guard !selectedKeys.isEmpty else { return }
             viewModel.process(action: .removeDownloads(selectedKeys))
+            completed = true
 
         case .removeFromRecentlyRead:
             guard !selectedKeys.isEmpty else { return }
             viewModel.process(action: .removeFromRecentlyRead(selectedKeys))
+            completed = true
         }
     }
 
@@ -471,16 +503,23 @@ extension ItemsViewController: ItemsTableViewHandlerDelegate {
         }
     }
 
-    func process(action: ItemAction.Kind, at indexPath: IndexPath, completionAction: ((Bool) -> Void)?) {
+    func process(action: ItemAction.Kind, at indexPath: IndexPath, contextualActionCompletion: ItemContextualActionCompletion?) {
         if action == .debugReader {
-            guard let tapAction = dataSource.tapAction(for: indexPath) else { return }
+            guard let tapAction = dataSource.tapAction(for: indexPath) else {
+                contextualActionCompletion?(false)
+                return
+            }
             processDebugReaderAction(tapAction: tapAction) { [weak self] in
                 self?.process(tapAction: tapAction)
+                contextualActionCompletion?(true)
             }
             return
         }
-        guard let object = dataSource.object(at: indexPath.row) else { return }
-        process(action: action, for: [object.key], button: nil, completionAction: completionAction)
+        guard let object = dataSource.object(at: indexPath.row) else {
+            contextualActionCompletion?(false)
+            return
+        }
+        process(action: action, for: [object.key], button: nil, contextualActionCompletion: contextualActionCompletion)
     }
 
     func process(dragAndDropAction action: ItemsTableViewHandler.DragAndDropAction) {
@@ -496,7 +535,7 @@ extension ItemsViewController: ItemsTableViewHandlerDelegate {
 
 extension ItemsViewController: ItemsToolbarControllerDelegate {
     func process(action: ItemAction.Kind, button: UIBarButtonItem) {
-        process(action: action, for: viewModel.state.selectedItems, button: button, completionAction: nil)
+        process(action: action, for: viewModel.state.selectedItems, button: button, contextualActionCompletion: nil)
     }
 
     func showLookup() {

--- a/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
+++ b/Zotero/Scenes/Detail/Items/Views/ItemsViewController.swift
@@ -260,9 +260,9 @@ final class ItemsViewController: BaseItemsViewController {
             break
 
         case .addToCollection:
-            guard !selectedKeys.isEmpty else { return }
+            guard !selectedKeys.isEmpty, let coordinatorDelegate else { return }
             completed = nil
-            coordinatorDelegate?.showCollectionsPicker(
+            coordinatorDelegate.showCollectionsPicker(
                 in: library,
                 cancelled: {
                     contextualActionCompletion?(false)
@@ -311,9 +311,9 @@ final class ItemsViewController: BaseItemsViewController {
             completed = true
 
         case .removeFromCollection:
-            guard !selectedKeys.isEmpty else { return }
+            guard !selectedKeys.isEmpty, let coordinatorDelegate else { return }
             completed = nil
-            coordinatorDelegate?.showRemoveFromCollectionQuestion(
+            coordinatorDelegate.showRemoveFromCollectionQuestion(
                 count: viewModel.state.selectedItems.count,
                 cancelAction: {
                     contextualActionCompletion?(false)

--- a/Zotero/Scenes/Detail/Trash/Views/TrashViewController.swift
+++ b/Zotero/Scenes/Detail/Trash/Views/TrashViewController.swift
@@ -149,7 +149,14 @@ final class TrashViewController: BaseItemsViewController {
         viewModel.process(action: .search(term))
     }
 
-    private func process(action: ItemAction.Kind, for selectedKeys: Set<TrashKey>, button: UIBarButtonItem?, completionAction: ((Bool) -> Void)?) {
+    private func process(action: ItemAction.Kind, for selectedKeys: Set<TrashKey>, button: UIBarButtonItem?, contextualActionCompletion: ItemContextualActionCompletion?) {
+        var completed: Bool? = false
+        defer {
+            if let contextualActionCompletion, let completed {
+                contextualActionCompletion(completed)
+            }
+        }
+
         switch action {
         case .createParent, .retrieveMetadata, .duplicate, .trash, .copyBibliography, .copyCitation, .share, .addToCollection, .removeFromCollection, .removeFromRecentlyRead,
              .filter, .sort, .debugReader:
@@ -158,26 +165,32 @@ final class TrashViewController: BaseItemsViewController {
 
         case .delete:
             guard !selectedKeys.isEmpty else { return }
+            completed = nil
             coordinatorDelegate?.showDeletionQuestion(
                 count: selectedKeys.count,
                 confirmAction: { [weak self] in
                     self?.viewModel.process(action: .deleteObjects(selectedKeys))
+                    contextualActionCompletion?(true)
                 },
                 cancelAction: {
-                    completionAction?(false)
+                    contextualActionCompletion?(false)
                 }
             )
 
         case .restore:
             guard !selectedKeys.isEmpty else { return }
             viewModel.process(action: .restoreItems(selectedKeys))
-            completionAction?(true)
+            completed = true
 
         case .download:
+            guard !selectedKeys.isEmpty else { return }
             viewModel.process(action: .download(selectedKeys))
+            completed = true
 
         case .removeDownload:
+            guard !selectedKeys.isEmpty else { return }
             viewModel.process(action: .removeDownloads(selectedKeys))
+            completed = true
         }
     }
 
@@ -261,16 +274,23 @@ extension TrashViewController: ItemsTableViewHandlerDelegate {
         return nil
     }
 
-    func process(action: ItemAction.Kind, at indexPath: IndexPath, completionAction: ((Bool) -> Void)?) {
+    func process(action: ItemAction.Kind, at indexPath: IndexPath, contextualActionCompletion: ItemContextualActionCompletion?) {
         if action == .debugReader {
-            guard let tapAction = dataSource.tapAction(for: indexPath) else { return }
+            guard let tapAction = dataSource.tapAction(for: indexPath) else {
+                contextualActionCompletion?(false)
+                return
+            }
             processDebugReaderAction(tapAction: tapAction) { [weak self] in
                 self?.process(tapAction: tapAction)
+                contextualActionCompletion?(true)
             }
             return
         }
-        guard let key = dataSource.key(at: indexPath.row) else { return }
-        process(action: action, for: [key], button: nil, completionAction: completionAction)
+        guard let key = dataSource.key(at: indexPath.row) else {
+            contextualActionCompletion?(false)
+            return
+        }
+        process(action: action, for: [key], button: nil, contextualActionCompletion: contextualActionCompletion)
     }
 
     func process(tapAction action: ItemsTableViewHandler.TapAction) {
@@ -322,7 +342,7 @@ extension TrashViewController: ItemsTableViewHandlerDelegate {
 
 extension TrashViewController: ItemsToolbarControllerDelegate {
     func process(action: ItemAction.Kind, button: UIBarButtonItem) {
-        process(action: action, for: viewModel.state.selectedItems, button: button, completionAction: nil)
+        process(action: action, for: viewModel.state.selectedItems, button: button, contextualActionCompletion: nil)
     }
 
     func showLookup() {

--- a/Zotero/Scenes/Detail/Trash/Views/TrashViewController.swift
+++ b/Zotero/Scenes/Detail/Trash/Views/TrashViewController.swift
@@ -164,9 +164,9 @@ final class TrashViewController: BaseItemsViewController {
             break
 
         case .delete:
-            guard !selectedKeys.isEmpty else { return }
+            guard !selectedKeys.isEmpty, let coordinatorDelegate else { return }
             completed = nil
-            coordinatorDelegate?.showDeletionQuestion(
+            coordinatorDelegate.showDeletionQuestion(
                 count: selectedKeys.count,
                 confirmAction: { [weak self] in
                     self?.viewModel.process(action: .deleteObjects(selectedKeys))

--- a/Zotero/Scenes/General/Views/CollectionsPickerViewController.swift
+++ b/Zotero/Scenes/General/Views/CollectionsPickerViewController.swift
@@ -13,7 +13,7 @@ import RxSwift
 class CollectionsPickerViewController: UICollectionViewController {
     enum Mode {
         case single(title: String, selected: (Collection) -> Void)
-        case multiple(selected: (Set<String>) -> Void)
+        case multiple(selected: (Set<String>) -> Void, cancelled: () -> Void)
     }
 
     private enum TitleType {
@@ -34,6 +34,7 @@ class CollectionsPickerViewController: UICollectionViewController {
     private let titleType: TitleType
     private let collectionSelected: ((Collection) -> Void)?
     private let keysSelected: ((Set<String>) -> Void)?
+    private let cancelled: (() -> Void)?
     private let multipleSelectionAllowed: Bool
     private let updateQueue: DispatchQueue
 
@@ -51,12 +52,14 @@ class CollectionsPickerViewController: UICollectionViewController {
             titleType = .fixed(title)
             collectionSelected = selected
             keysSelected = nil
+            cancelled = nil
 
-        case .multiple(let selected):
+        case .multiple(let selected, let cancelled):
             multipleSelectionAllowed = true
             titleType = .dynamic
             keysSelected = selected
             collectionSelected = nil
+            self.cancelled = cancelled
         }
 
         super.init(collectionViewLayout: UICollectionViewFlowLayout())
@@ -97,6 +100,11 @@ class CollectionsPickerViewController: UICollectionViewController {
     private func confirmSelection() {
         guard let keysSelected else { return }
         keysSelected(viewModel.state.selected)
+        close()
+    }
+
+    private func cancelSelection() {
+        cancelled?()
         close()
     }
 
@@ -212,7 +220,7 @@ class CollectionsPickerViewController: UICollectionViewController {
 
         let cancel = UIBarButtonItem(barButtonSystemItem: .cancel, target: nil, action: nil)
         cancel.rx.tap.subscribe(onNext: { [weak self] in
-            self?.close()
+            self?.cancelSelection()
         }).disposed(by: disposeBag)
         navigationItem.leftBarButtonItem = cancel
 


### PR DESCRIPTION
When an item swipe action is performed, its contextual action completion now is always called with proper completion value. Ignoring it in those cases before didn't cause any issues, but from the user reports it seems to matter when accesibility features are used to interact with the swipe action.

Potential fix for issue reported in https://forums.zotero.org/discussion/131580/ios-crash-report-1487292071 & https://forums.zotero.org/discussion/131397/ios-crash-report-901955906