### PR TITLE
Improve iOS 26 focus logic

### DIFF
--- a/Zotero/AppDelegate.swift
+++ b/Zotero/AppDelegate.swift
@@ -183,6 +183,11 @@ final class AppDelegate: UIResponder {
         UIButton.appearance().tintColor = Asset.Colors.zoteroBlue.color
         // Search bar
         UISearchBar.appearance().tintColor = Asset.Colors.zoteroBlue.color
+        if #available(iOS 26.0.0, *) {
+            // Potential fix for NSInternalInconsistencyException crashes, with reason "Invalid parameter not satisfying: parentEnvironment != nil"
+            UITableView.appearance().selectionFollowsFocus = false
+            UICollectionView.appearance().selectionFollowsFocus = false
+        }
     }
 
     private func setupExportDefaults() {


### PR DESCRIPTION
Potential fix for crashes with:
```
Application Specific Information:
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Invalid parameter not satisfying: parentEnvironment != nil'
```
Without design compatibility similar crashes happened, that were fixed with this defensive change. 
While we have enabled design compatibility, recent changes might have affected UIKit layout/focus timing on iPadOS 26, to eventually cause this.
We can test this change, and see if similar reports decrease.
