### PR TITLE
Add iCloud Drive as a file-storage backend

### DIFF
--- a/ZShare/View Controllers/ShareViewController.swift
+++ b/ZShare/View Controllers/ShareViewController.swift
@@ -756,6 +756,7 @@ final class ShareViewController: UIViewController {
         let translatorsController = TranslatorsAndStylesController(apiClient: apiClient, bundledDataStorage: bundledDataStorage, fileStorage: fileStorage)
         let secureStorage = KeychainSecureStorage()
         let webDavController = WebDavControllerImpl(dbStorage: dbStorage, fileStorage: fileStorage, sessionStorage: SecureWebDavSessionStorage(secureStorage: secureStorage))
+        let iCloudController = ICloudController(dbStorage: dbStorage, fileStorage: fileStorage, transport: ICloudTransportController())
         let documentWorkerController = DocumentWorkerController(fileStorage: fileStorage)
 
         apiClient.set(authToken: ("Bearer " + session.apiToken))
@@ -770,11 +771,11 @@ final class ShareViewController: UIViewController {
         self.secureStorage = secureStorage
 
         self.viewModel = self.createViewModel(for: session.userId, dbStorage: dbStorage, apiClient: apiClient, schemaController: schemaController, fileStorage: fileStorage,
-                                              webDavController: webDavController, translatorsController: translatorsController)
+                                              webDavController: webDavController, iCloudController: iCloudController, translatorsController: translatorsController)
     }
 
     private func createViewModel(for userId: Int, dbStorage: DbStorage, apiClient: ApiClient, schemaController: SchemaController, fileStorage: FileStorage, webDavController: WebDavController,
-                                 translatorsController: TranslatorsAndStylesController) -> ExtensionViewModel {
+                                 iCloudController: ICloudController, translatorsController: TranslatorsAndStylesController) -> ExtensionViewModel {
         let dateParser = DateParser()
         let requestProvider = BackgroundUploaderRequestProvider(fileStorage: fileStorage)
         let backgroundUploadContext = BackgroundUploaderContext()
@@ -782,9 +783,9 @@ final class ShareViewController: UIViewController {
         let backgroundProcessor = BackgroundUploadProcessor(apiClient: apiClient, dbStorage: dbStorage, fileStorage: fileStorage, webDavController: webDavController)
         let backgroundTaskController = BackgroundTaskController()
         let backgroundUploadObserver = BackgroundUploadObserver(context: backgroundUploadContext, processor: backgroundProcessor, backgroundTaskController: backgroundTaskController)
-        let attachmentDownloader = AttachmentDownloader(userId: userId, apiClient: apiClient, fileStorage: fileStorage, dbStorage: dbStorage, webDavController: webDavController)
+        let attachmentDownloader = AttachmentDownloader(userId: userId, apiClient: apiClient, fileStorage: fileStorage, dbStorage: dbStorage, webDavController: webDavController, iCloudController: iCloudController)
         let syncController = SyncController(userId: userId, apiClient: apiClient, dbStorage: dbStorage, fileStorage: fileStorage, schemaController: schemaController, dateParser: dateParser,
-                                            backgroundUploaderContext: backgroundUploadContext, webDavController: webDavController, attachmentDownloader: attachmentDownloader, syncDelayIntervals: DelayIntervals.sync, maxRetryCount: DelayIntervals.retry.count)
+                                            backgroundUploaderContext: backgroundUploadContext, webDavController: webDavController, iCloudController: iCloudController, attachmentDownloader: attachmentDownloader, syncDelayIntervals: DelayIntervals.sync, maxRetryCount: DelayIntervals.retry.count)
         let recognizerController = RecognizerController(
             documentWorkerController: documentWorkerController,
             apiClient: apiClient,
@@ -805,6 +806,7 @@ final class ShareViewController: UIViewController {
             dbStorage: dbStorage,
             schemaController: schemaController,
             webDavController: webDavController,
+            iCloudController: iCloudController,
             dateParser: dateParser,
             fileStorage: fileStorage,
             syncController: syncController,

--- a/ZShare/ViewModels/ExtensionViewModel.swift
+++ b/ZShare/ViewModels/ExtensionViewModel.swift
@@ -339,6 +339,7 @@ final class ExtensionViewModel {
     private let fileStorage: FileStorage
     private let schemaController: SchemaController
     private let webDavController: WebDavController
+    private let iCloudController: ICloudController
     private let dateParser: DateParser
     private let translationHandler: TranslationWebViewHandler
     private let backgroundUploader: BackgroundUploader
@@ -365,6 +366,7 @@ final class ExtensionViewModel {
         dbStorage: DbStorage,
         schemaController: SchemaController,
         webDavController: WebDavController,
+        iCloudController: ICloudController,
         dateParser: DateParser,
         fileStorage: FileStorage,
         syncController: SyncController,
@@ -395,6 +397,7 @@ final class ExtensionViewModel {
         self.fileStorage = fileStorage
         self.schemaController = schemaController
         self.webDavController = webDavController
+        self.iCloudController = iCloudController
         self.dateParser = dateParser
         self.translationHandler = TranslationWebViewHandler(webView: webView, translatorsController: translatorsController)
         self.backgroundQueue = queue
@@ -1434,9 +1437,14 @@ final class ExtensionViewModel {
     /// - parameter dbStorage: Database storage
     /// - parameter fileStorage: File storage
     private func upload(data: State.UploadData, apiClient: ApiClient, dbStorage: DbStorage, fileStorage: FileStorage, webDavController: WebDavController) {
-        if Defaults.shared.webDavEnabled {
+        switch Defaults.shared.fileSyncType {
+        case .webDav:
             uploadToWebDav(data: data, apiClient: apiClient, dbStorage: dbStorage, fileStorage: fileStorage, webDavController: webDavController)
-        } else {
+
+        case .iCloud:
+            uploadToICloud(data: data, apiClient: apiClient, dbStorage: dbStorage, fileStorage: fileStorage, iCloudController: self.iCloudController)
+
+        case .zotero:
             uploadToZotero(data: data, apiClient: apiClient, dbStorage: dbStorage, fileStorage: fileStorage)
         }
 
@@ -1571,6 +1579,102 @@ final class ExtensionViewModel {
                 handleSubmission(error: attachmentError(from: error, libraryId: data.libraryId), parentKey: data.parentKey, libraryId: data.libraryId)
             })
             .disposed(by: disposeBag)
+        }
+
+        func uploadToICloud(data: State.UploadData, apiClient: ApiClient, dbStorage: DbStorage, fileStorage: FileStorage, iCloudController: ICloudController) {
+            var zipFile: File?
+            let prepare = submit(data: data, apiClient: apiClient, dbStorage: dbStorage, fileStorage: fileStorage)
+                .flatMap { [weak self] submissionData -> Single<(FileUploadResult, SubmissionData)> in
+                    guard let self else { return Single.error(State.AttachmentState.Error.expired) }
+                    return iCloudController.prepareForUpload(key: data.attachment.key, mtime: submissionData.mtime, hash: submissionData.md5, file: data.file, queue: backgroundQueue)
+                        .flatMap({ return Single.just(($0, submissionData)) })
+                }
+
+            prepare.flatMap { [weak self] response, submissionData -> Single<()> in
+                guard let self else { return Single.error(State.AttachmentState.Error.expired) }
+
+                switch response {
+                case .exists:
+                    DDLogInfo("ExtensionViewModel: file exists in iCloud")
+                    do {
+                        let request = MarkAttachmentUploadedDbRequest(libraryId: data.libraryId, key: data.attachment.key, version: nil)
+                        try dbStorage.perform(request: request, on: backgroundQueue)
+                        return Single.just(())
+                    } catch let error {
+                        return Single.error(error)
+                    }
+
+                case .new(let file):
+                    DDLogInfo("ExtensionViewModel: upload to iCloud")
+                    zipFile = file
+                    // iCloud has no background `URLSession`; the coordinated write below replicates via the ubiquity daemon even when backgrounded.
+                    return iCloudController.upload(key: data.attachment.key, file: file, mtime: submissionData.mtime, hash: submissionData.md5, queue: backgroundQueue)
+                        .flatMap { iCloudController.finishUpload(key: data.attachment.key, result: .success((submissionData.mtime, submissionData.md5)), file: file, queue: self.backgroundQueue) }
+                        .flatMap { [weak self] _ -> Single<()> in
+                            guard let self else { return Single.error(State.AttachmentState.Error.expired) }
+                            return submitItemWithHashAndMtime(key: data.attachment.key, libraryId: data.libraryId, userId: data.userId)
+                                .flatMap { version -> Single<()> in
+                                    do {
+                                        let request = MarkAttachmentUploadedDbRequest(libraryId: data.libraryId, key: data.attachment.key, version: version)
+                                        try dbStorage.perform(request: request, on: self.backgroundQueue)
+                                        return Single.just(())
+                                    } catch let error {
+                                        return Single.error(error)
+                                    }
+                                }
+                        }
+                }
+            }
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] _ in
+                self?.state.isDone = true
+            }, onFailure: { [weak self] error in
+                guard let self else { return }
+                if let zipFile { _ = iCloudController.finishUpload(key: data.attachment.key, result: .failure(error), file: zipFile, queue: self.backgroundQueue).subscribe() }
+                DDLogError("ExtensionViewModel: could not submit item or attachment to iCloud - \(error)")
+                handleSubmission(error: attachmentError(from: error, libraryId: data.libraryId), parentKey: data.parentKey, libraryId: data.libraryId)
+            })
+            .disposed(by: disposeBag)
+        }
+
+        /// Registers the uploaded file's mtime+hash with the Zotero API (data layer is always server-mediated), returning the new version.
+        func submitItemWithHashAndMtime(key: String, libraryId: LibraryIdentifier, userId: Int) -> Single<Int> {
+            let loadParameters: Single<[String: Any]> = Single.create { [weak self] subscriber -> Disposable in
+                guard let self else { return Disposables.create() }
+                do {
+                    let item = try dbStorage.perform(request: ReadItemDbRequest(libraryId: libraryId, key: key), on: backgroundQueue)
+                    let parameters = item.mtimeAndHashParameters
+                    item.realm?.invalidate()
+                    subscriber(.success(parameters))
+                } catch let error {
+                    subscriber(.failure(error))
+                }
+                return Disposables.create()
+            }
+
+            return loadParameters.flatMap { [weak self] params -> Single<(Int, Error?)> in
+                guard let self else { return Single.error(State.AttachmentState.Error.expired) }
+                return SubmitUpdateSyncAction(
+                    parameters: [params],
+                    changeUuids: [:],
+                    sinceVersion: nil,
+                    object: .item,
+                    libraryId: libraryId,
+                    userId: userId,
+                    updateLibraryVersion: false,
+                    apiClient: apiClient,
+                    dbStorage: dbStorage,
+                    fileStorage: fileStorage,
+                    schemaController: schemaController,
+                    dateParser: dateParser,
+                    queue: backgroundQueue,
+                    scheduler: backgroundScheduler
+                ).result
+            }
+            .flatMap { version, error -> Single<Int> in
+                if let error { return Single.error(error) }
+                return Single.just(version)
+            }
         }
 
         func submit(data: State.UploadData, apiClient: ApiClient, dbStorage: DbStorage, fileStorage: FileStorage) -> Single<SubmissionData> {

--- a/ZShare/ZShare.entitlements
+++ b/ZShare/ZShare.entitlements
@@ -2,6 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.org.zotero.ios.Zotero</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
+	<key>com.apple.developer.ubiquity-container-identifiers</key>
+	<array>
+		<string>iCloud.org.zotero.ios.Zotero</string>
+	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>

--- a/Zotero.xcodeproj/project.pbxproj
+++ b/Zotero.xcodeproj/project.pbxproj
@@ -917,6 +917,10 @@
 		B398142E257A649D002C755C /* TextContentEditCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B398142C257A649D002C755C /* TextContentEditCell.swift */; };
 		B3981B76258399AA00F8D15A /* NoteAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3981B75258399AA00F8D15A /* NoteAnnotation.swift */; };
 		B398A915270C6A4300968EE8 /* WebDavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B398A914270C6A4300968EE8 /* WebDavController.swift */; };
+		FE51C0DE0000000000020001 /* FileSyncType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE51C0DE0000000000010001 /* FileSyncType.swift */; };
+		FE51C0DE0000000000020002 /* FileSyncBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE51C0DE0000000000010002 /* FileSyncBackend.swift */; };
+		FE51C0DE0000000000020003 /* ICloudTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE51C0DE0000000000010003 /* ICloudTransport.swift */; };
+		FE51C0DE0000000000020004 /* ICloudController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE51C0DE0000000000010004 /* ICloudController.swift */; };
 		B398A917270C6A5B00968EE8 /* WebDavSessionStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B398A916270C6A5B00968EE8 /* WebDavSessionStorage.swift */; };
 		B398D6C02A77F9C60049A296 /* FontSizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B398D6BF2A77F9C60049A296 /* FontSizeView.swift */; };
 		B399A9172CC67F1600731B21 /* TrashKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B399A9162CC67F1400731B21 /* TrashKey.swift */; };
@@ -1275,6 +1279,10 @@
 		B3FBAC1924570BDE00AA00C0 /* AnnotationPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FBAC1824570BDE00AA00C0 /* AnnotationPreviewController.swift */; };
 		B3FC7431272181E500F55531 /* WebDavWriteRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FC7430272181E500F55531 /* WebDavWriteRequest.swift */; };
 		B3FC74322721857C00F55531 /* WebDavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B398A914270C6A4300968EE8 /* WebDavController.swift */; };
+		FE51C0DE0000000000030001 /* FileSyncType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE51C0DE0000000000010001 /* FileSyncType.swift */; };
+		FE51C0DE0000000000030002 /* FileSyncBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE51C0DE0000000000010002 /* FileSyncBackend.swift */; };
+		FE51C0DE0000000000030003 /* ICloudTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE51C0DE0000000000010003 /* ICloudTransport.swift */; };
+		FE51C0DE0000000000030004 /* ICloudController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE51C0DE0000000000010004 /* ICloudController.swift */; };
 		B3FC74332721858000F55531 /* WebDavPropParserDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A351E427157EC6002E597A /* WebDavPropParserDelegate.swift */; };
 		B3FC74342721858200F55531 /* WebDavSessionStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B398A916270C6A5B00968EE8 /* WebDavSessionStorage.swift */; };
 		B3FC7435272195D600F55531 /* WebDavDeleteRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A351E2271578B1002E597A /* WebDavDeleteRequest.swift */; };
@@ -2168,6 +2176,10 @@
 		B398142C257A649D002C755C /* TextContentEditCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextContentEditCell.swift; sourceTree = "<group>"; };
 		B3981B75258399AA00F8D15A /* NoteAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteAnnotation.swift; sourceTree = "<group>"; };
 		B398A914270C6A4300968EE8 /* WebDavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebDavController.swift; sourceTree = "<group>"; };
+		FE51C0DE0000000000010001 /* FileSyncType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSyncType.swift; sourceTree = "<group>"; };
+		FE51C0DE0000000000010002 /* FileSyncBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSyncBackend.swift; sourceTree = "<group>"; };
+		FE51C0DE0000000000010003 /* ICloudTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudTransport.swift; sourceTree = "<group>"; };
+		FE51C0DE0000000000010004 /* ICloudController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudController.swift; sourceTree = "<group>"; };
 		B398A916270C6A5B00968EE8 /* WebDavSessionStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDavSessionStorage.swift; sourceTree = "<group>"; };
 		B398D6BF2A77F9C60049A296 /* FontSizeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeView.swift; sourceTree = "<group>"; };
 		B399A9162CC67F1400731B21 /* TrashKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashKey.swift; sourceTree = "<group>"; };
@@ -2619,6 +2631,7 @@
 				B305649F23FC051E003304F2 /* Sync */,
 				B39E0130283276470091CE4A /* Web View Handling */,
 				B398A913270C6A4300968EE8 /* WebDAV */,
+				FE51C0DE00000000000A0001 /* FileStorage */,
 				B3D0793527CCF63800C454D6 /* AnnotationBoundingBoxCalculator.swift */,
 				B34ACC792514EAAB00040C17 /* AnnotationColorGenerator.swift */,
 				B34A9F6725BF1D27007C9A4A /* AnnotationConverter.swift */,
@@ -3027,6 +3040,7 @@
 				B3BC6B1C250F797B006A8B9C /* FieldKeys.swift */,
 				B305654123FC051E003304F2 /* File.swift */,
 				B305653E23FC051E003304F2 /* Files.swift */,
+				FE51C0DE0000000000010001 /* FileSyncType.swift */,
 				B305654323FC051E003304F2 /* ItemTypes.swift */,
 				B305653823FC051E003304F2 /* KeyedResponse.swift */,
 				B305653923FC051E003304F2 /* Library.swift */,
@@ -3916,6 +3930,16 @@
 				B398A916270C6A5B00968EE8 /* WebDavSessionStorage.swift */,
 			);
 			path = WebDAV;
+			sourceTree = "<group>";
+		};
+		FE51C0DE00000000000A0001 /* FileStorage */ = {
+			isa = PBXGroup;
+			children = (
+				FE51C0DE0000000000010002 /* FileSyncBackend.swift */,
+				FE51C0DE0000000000010004 /* ICloudController.swift */,
+				FE51C0DE0000000000010003 /* ICloudTransport.swift */,
+			);
+			path = FileStorage;
 			sourceTree = "<group>";
 		};
 		B39E0130283276470091CE4A /* Web View Handling */ = {
@@ -5863,6 +5887,10 @@
 				B30565CA23FC051E003304F2 /* PerformDeletionsDbRequest.swift in Sources */,
 				B36181FE24C9A7C000B30D56 /* OnboardingLayout.swift in Sources */,
 				B398A915270C6A4300968EE8 /* WebDavController.swift in Sources */,
+				FE51C0DE0000000000020001 /* FileSyncType.swift in Sources */,
+				FE51C0DE0000000000020002 /* FileSyncBackend.swift in Sources */,
+				FE51C0DE0000000000020003 /* ICloudTransport.swift in Sources */,
+				FE51C0DE0000000000020004 /* ICloudController.swift in Sources */,
 				B3A17D1927FC33B800322CAD /* LowPowerModeController.swift in Sources */,
 				B31CC57B286468780055C114 /* ManualLookupViewController.swift in Sources */,
 				B3863FC82AD819AB005082F0 /* EndItemCreationDbRequest.swift in Sources */,
@@ -6500,6 +6528,10 @@
 				B305670123FC089F003304F2 /* MarkObjectsAsSyncedDbRequest.swift in Sources */,
 				B36459E726441A1800A0C2C0 /* TagRow.swift in Sources */,
 				B3FC74322721857C00F55531 /* WebDavController.swift in Sources */,
+				FE51C0DE0000000000030001 /* FileSyncType.swift in Sources */,
+				FE51C0DE0000000000030002 /* FileSyncBackend.swift in Sources */,
+				FE51C0DE0000000000030003 /* ICloudTransport.swift in Sources */,
+				FE51C0DE0000000000030004 /* ICloudController.swift in Sources */,
 				B3B78C47266FB11D00E91D02 /* WKWebView+Extensions.swift in Sources */,
 				B3B557182C8860E600BD6325 /* CitationMetadata.swift in Sources */,
 				B305677023FC0A58003304F2 /* Alamofire+RxSwift.swift in Sources */,

--- a/Zotero/AppDelegate.swift
+++ b/Zotero/AppDelegate.swift
@@ -87,11 +87,12 @@ final class AppDelegate: UIResponder {
             guard !contents.isEmpty else { return }
 
             let backgroundUploads = userControllers.backgroundUploadObserver.context.uploads
-            let webDavEnabled = userControllers.webDavController.sessionStorage.isEnabled
+            // Non-ZFS backends (WebDAV, iCloud) stage `<key>.zip` files in the uploads dir before sending; preserve those still pending upload.
+            let usesZippedUploads = Defaults.shared.fileSyncType != .zotero
             var keysForUpload: Set<String> = []
             var filesToDelete: [File] = []
 
-            if webDavEnabled {
+            if usesZippedUploads {
                 let forUploadResults = try userControllers.dbStorage.perform(request: ReadAllItemsForUploadDbRequest(), on: queue)
                 keysForUpload = Set(forUploadResults.map({ $0.key }))
                 forUploadResults.first?.realm?.invalidate()
@@ -100,7 +101,7 @@ final class AppDelegate: UIResponder {
             for file in contents {
                 if file.name.isEmpty && file.mimeType.isEmpty {
                     // Background Zotero upload
-                    if !webDavEnabled && backgroundUploads.contains(where: { $0.fileUrl.lastPathComponent == file.relativeComponents.last }) {
+                    if !usesZippedUploads && backgroundUploads.contains(where: { $0.fileUrl.lastPathComponent == file.relativeComponents.last }) {
                         // If file is being uploaded in background, don't delete
                         continue
                     }
@@ -109,8 +110,8 @@ final class AppDelegate: UIResponder {
                 }
 
                 if file.ext == "zip" && !file.name.isEmpty {
-                    // Background/foreground WebDAV upload
-                    if webDavEnabled && (backgroundUploads.contains(where: { $0.fileUrl.deletingPathExtension().lastPathComponent == file.name }) || keysForUpload.contains(file.name)) {
+                    // Background/foreground WebDAV or iCloud upload (both stage `<key>.zip`)
+                    if usesZippedUploads && (backgroundUploads.contains(where: { $0.fileUrl.deletingPathExtension().lastPathComponent == file.name }) || keysForUpload.contains(file.name)) {
                         // If file is being uploaded in background or queued to upload during sync, don't delete
                         continue
                     }

--- a/Zotero/Assets/en.lproj/Localizable.strings
+++ b/Zotero/Assets/en.lproj/Localizable.strings
@@ -309,6 +309,8 @@
 "settings.sync.directory_not_found.title" = "Directory not found";
 "settings.sync.directory_not_found.message" = "%@ does not exist.\n\nDo you want to create it now?";
 "settings.sync.verified" = "Verified";
+"settings.sync.i_cloud" = "iCloud Drive";
+"settings.sync.i_cloud_message" = "Store attachment files in iCloud Drive. Files sync automatically across your devices signed in to the same iCloud account.";
 "settings.permission" = "User Permission";
 "settings.permission_subtitle" = "Ask for user permission for each write action";
 "settings.translators" = "Translators";
@@ -468,6 +470,9 @@
 "errors.settings.webdav.internet_connection" = "Unable to connect to the network. Please try again.";
 "errors.settings.webdav.host_not_found" = "Could not connect to WebDAV server";
 "errors.settings.webdav.ats" = "Due to iOS restrictions, you must use HTTPS to connect to a non-local WebDAV server.";
+"errors.settings.icloud.account_unavailable" = "No iCloud account is signed in. Sign in to iCloud in the Settings app to use iCloud Drive syncing.";
+"errors.settings.icloud.container_unavailable" = "Could not access the app's iCloud Drive container. Make sure iCloud Drive is enabled for Zotero.";
+"errors.settings.icloud.probe_failed" = "Could not read and write to iCloud Drive. Please try again.";
 "errors.shareext.logged_out" = "Please log into the app before using this extension.";
 "errors.shareext.cant_load_data" = "Failed to load data. Please try again.";
 "errors.shareext.unknown" = "An unknown error occurred.";

--- a/Zotero/Controllers/Attachment Downloader/AttachmentDownloader.swift
+++ b/Zotero/Controllers/Attachment Downloader/AttachmentDownloader.swift
@@ -96,6 +96,7 @@ final class AttachmentDownloader: NSObject {
     private unowned let fileStorage: FileStorage
     private unowned let dbStorage: DbStorage
     private unowned let webDavController: WebDavController
+    private unowned let iCloudController: ICloudController
     private let accessQueue: DispatchQueue
     private let dbQueue: DispatchQueue
     private let unzipQueue: DispatchQueue
@@ -107,6 +108,9 @@ final class AttachmentDownloader: NSObject {
     private var activeDownloads: [Download: ActiveDownload]
     private var taskIdToDownload: [Int: Download]
     private var extractions: [Download: Extraction]
+    // iCloud downloads don't use `URLSession`; they're materialized via the ubiquity daemon. Tracked here with synthetic (negative) task ids.
+    private var iCloudDownloads: [Download: Disposable]
+    private var nextICloudTaskId: Int
     private var totalCount: Int
     private var errors: [Download: Swift.Error]
     private var initialErrors: [Int: Swift.Error]
@@ -128,16 +132,19 @@ final class AttachmentDownloader: NSObject {
         return (progress, remainingBatchCount, totalBatchCount)
     }
 
-    init(userId: Int, apiClient: ApiClient, fileStorage: FileStorage, dbStorage: DbStorage, webDavController: WebDavController) {
+    init(userId: Int, apiClient: ApiClient, fileStorage: FileStorage, dbStorage: DbStorage, webDavController: WebDavController, iCloudController: ICloudController) {
         self.userId = userId
         self.fileStorage = fileStorage
         self.apiClient = apiClient
         self.dbStorage = dbStorage
         self.webDavController = webDavController
+        self.iCloudController = iCloudController
         queue = []
         activeDownloads = [:]
         taskIdToDownload = [:]
         extractions = [:]
+        iCloudDownloads = [:]
+        nextICloudTaskId = -1
         totalCount = 0
         errors = [:]
         initialErrors = [:]
@@ -604,6 +611,10 @@ final class AttachmentDownloader: NSObject {
         accessQueue.sync(flags: .barrier) { [weak self] in
             guard let self else { return }
             for download in downloads {
+                if let disposable = iCloudDownloads[download] {
+                    disposable.dispose()
+                    iCloudDownloads[download] = nil
+                }
                 if let activeDownload = activeDownloads[download] {
                     activeDownloads[download] = nil
                     taskIdToDownload[activeDownload.taskId] = nil
@@ -644,6 +655,8 @@ final class AttachmentDownloader: NSObject {
                 observable.on(.next(Update(download: download, kind: .cancelled)))
             }
 
+            iCloudDownloads.values.forEach { $0.dispose() }
+            iCloudDownloads = [:]
             queue = []
             activeDownloads = [:]
             taskIdToDownload = [:]
@@ -715,7 +728,7 @@ final class AttachmentDownloader: NSObject {
     private func createDownloadTask(for download: Download, file: File, progress: Progress, extractAfterDownload: Bool, retryIfNeeded: Bool, attempt: Int) -> (URLSessionTask, ActiveDownload)? {
         do {
             let request: URLRequest
-            if case .custom = download.libraryId, webDavController.sessionStorage.isEnabled {
+            if case .custom = download.libraryId, Defaults.shared.fileSyncType == .webDav {
                 guard let url = webDavController.currentUrl?.appendingPathComponent("\(download.key).zip") else { return nil }
                 let apiRequest = FileRequest(webDavUrl: url, destination: file)
                 request = try webDavController.createURLRequest(from: apiRequest)
@@ -803,8 +816,74 @@ final class AttachmentDownloader: NSObject {
     private func startNextDownloadIfPossible() {
         while activeDownloads.count < Self.maxConcurrentDownloads && !queue.isEmpty {
             let enqueuedDownload = queue.removeFirst()
-            startDownloadTask(for: enqueuedDownload.download, downloadTaskTuple: createDownloadTask(from: enqueuedDownload))
+            if isICloudDownload(libraryId: enqueuedDownload.download.libraryId) {
+                startICloudDownload(enqueuedDownload)
+            } else {
+                startDownloadTask(for: enqueuedDownload.download, downloadTaskTuple: createDownloadTask(from: enqueuedDownload))
+            }
         }
+    }
+
+    /// iCloud backs only My Library (custom); group libraries always use Zotero File Storage.
+    private func isICloudDownload(libraryId: LibraryIdentifier) -> Bool {
+        if case .custom = libraryId, Defaults.shared.fileSyncType == .iCloud {
+            return true
+        }
+        return false
+    }
+
+    /// Materializes `<key>.zip` from the iCloud container (no `URLSession`), then feeds the existing unzip/extract pipeline.
+    private func startICloudDownload(_ enqueuedDownload: EnqueuedDownload) {
+        let download = enqueuedDownload.download
+        let file = enqueuedDownload.file
+        let taskId = nextICloudTaskId
+        nextICloudTaskId -= 1
+
+        let activeDownload = ActiveDownload(
+            taskId: taskId,
+            file: file,
+            progress: enqueuedDownload.progress,
+            extractAfterDownload: enqueuedDownload.extractAfterDownload,
+            retryIfNeeded: false,
+            logData: nil,
+            attempt: 0
+        )
+        activeDownloads[download] = activeDownload
+        taskIdToDownload[taskId] = download
+
+        let disposable = iCloudController.download(key: download.key, file: file, queue: unzipQueue)
+            .subscribe(on: ConcurrentDispatchQueueScheduler(queue: unzipQueue))
+            .subscribe(onNext: { [weak self] progress in
+                guard let self else { return }
+                accessQueue.async(flags: .barrier) { [weak self] in
+                    guard let self, let active = activeDownloads[download] else { return }
+                    active.progress.completedUnitCount = progress.completedUnitCount
+                    observable.on(.next(Update(download: download, kind: .progress)))
+                }
+            }, onError: { [weak self] error in
+                guard let self else { return }
+                accessQueue.async(flags: .barrier) { [weak self] in
+                    guard let self else { return }
+                    iCloudDownloads[download] = nil
+                    finish(activeDownload: activeDownload, download: download, compressed: nil, result: .failure(error), retryDelay: nil)
+                }
+            }, onCompleted: { [weak self] in
+                guard let self else { return }
+                // The materialized `<key>.zip` is now at `file.copy(withExt: "zip")`. Mark downloaded (compressed) and extract.
+                dbQueue.sync { [weak self] in
+                    guard let self else { return }
+                    let request = MarkFileAsDownloadedDbRequest(key: download.key, libraryId: download.libraryId, downloaded: true, compressed: true)
+                    try? dbStorage.perform(request: request, on: dbQueue)
+                }
+                accessQueue.sync(flags: .barrier) { [weak self] in
+                    guard let self else { return }
+                    iCloudDownloads[download] = nil
+                    // Don't notify observer yet — extraction will emit `.ready` when the zip is unpacked.
+                    finish(activeDownload: activeDownload, download: download, compressed: true, result: .success(false), retryDelay: nil)
+                }
+                extract(zipFile: file.copy(withExt: "zip"), toFile: file, download: download)
+            })
+        iCloudDownloads[download] = disposable
     }
 
     private func retryDownload(_ download: Download, after activeDownload: ActiveDownload) {
@@ -941,7 +1020,7 @@ extension AttachmentDownloader: URLSessionDownloadDelegate {
 
         var zipFile: File?
         var shouldExtractAfterDownload = activeDownload.extractAfterDownload
-        var isCompressed = webDavController.sessionStorage.isEnabled && !download.libraryId.isGroupLibrary
+        var isCompressed = Defaults.shared.fileSyncType == .webDav && !download.libraryId.isGroupLibrary
         if let response = downloadTask.response as? HTTPURLResponse {
             let _isCompressed = response.value(forHTTPHeaderField: "Content-Type") == "application/zip"
             isCompressed = isCompressed || _isCompressed
@@ -1034,7 +1113,7 @@ extension AttachmentDownloader: URLSessionTaskDelegate {
     ) {
         let sessionStorage = webDavController.sessionStorage
         let protectionSpace = challenge.protectionSpace
-        guard sessionStorage.isEnabled,
+        guard Defaults.shared.fileSyncType == .webDav,
               sessionStorage.isVerified,
               protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic || protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPDigest,
               protectionSpace.host == sessionStorage.host,

--- a/Zotero/Controllers/AttachmentCreator.swift
+++ b/Zotero/Controllers/AttachmentCreator.swift
@@ -305,15 +305,16 @@ struct AttachmentCreator {
         // If file storage is not specified, we don't care about location anyway. Let's just return `.remote`.
         guard let fileStorage = fileStorage else { return .remote }
 
-        let webDavEnabled = Defaults.shared.webDavEnabled
+        // Non-ZFS backends (WebDAV, iCloud) keep the local payload as a `<key>.zip`, so a zip on disk also counts as present.
+        let usesRemoteFileStorage = Defaults.shared.fileSyncType != .zotero
 
-        if fileStorage.has(file) || (webDavEnabled && fileStorage.has(file.copy(withExt: "zip"))) {
+        if fileStorage.has(file) || (usesRemoteFileStorage && fileStorage.has(file.copy(withExt: "zip"))) {
             if !item.backendMd5.isEmpty, let md5 = cachedMD5(from: file.createUrl(), using: fileStorage.fileManager), item.backendMd5 != md5 {
                 return .localAndChangedRemotely
             } else {
                 return .local
             }
-        } else if webDavEnabled || item.links.contains(where: { $0.type == LinkType.enclosure.rawValue }) {
+        } else if usesRemoteFileStorage || item.links.contains(where: { $0.type == LinkType.enclosure.rawValue }) {
             return .remote
         } else {
             return .remoteMissing

--- a/Zotero/Controllers/Controllers.swift
+++ b/Zotero/Controllers/Controllers.swift
@@ -311,6 +311,7 @@ final class UserControllers {
     let citationController: CitationController
     let dragDropController: DragDropController
     let webDavController: WebDavController
+    let iCloudController: ICloudController
     let customUrlController: CustomURLController
     let fullSyncDebugger: FullSyncDebugger
     let lastReadWatcher: LastReadWatcher
@@ -330,10 +331,18 @@ final class UserControllers {
         let dbStorage = try UserControllers.createDbStorage(for: userId, sessionId: sessionId, controllers: controllers)
         let webDavSession = SecureWebDavSessionStorage(secureStorage: controllers.secureStorage)
         let webDavController = WebDavControllerImpl(dbStorage: dbStorage, fileStorage: controllers.fileStorage, sessionStorage: webDavSession)
+        let iCloudController = ICloudController(dbStorage: dbStorage, fileStorage: controllers.fileStorage, transport: ICloudTransportController())
         let backgroundUploadContext = BackgroundUploaderContext()
         let backgroundUploadProcessor = BackgroundUploadProcessor(apiClient: controllers.apiClient, dbStorage: dbStorage, fileStorage: controllers.fileStorage, webDavController: webDavController)
         let backgroundUploadObserver = BackgroundUploadObserver(context: backgroundUploadContext, processor: backgroundUploadProcessor, backgroundTaskController: controllers.backgroundTaskController)
-        let fileDownloader = AttachmentDownloader(userId: userId, apiClient: controllers.apiClient, fileStorage: controllers.fileStorage, dbStorage: dbStorage, webDavController: webDavController)
+        let fileDownloader = AttachmentDownloader(
+            userId: userId,
+            apiClient: controllers.apiClient,
+            fileStorage: controllers.fileStorage,
+            dbStorage: dbStorage,
+            webDavController: webDavController,
+            iCloudController: iCloudController
+        )
         let syncController = SyncController(
             userId: userId,
             apiClient: controllers.apiClient,
@@ -343,6 +352,7 @@ final class UserControllers {
             dateParser: controllers.dateParser,
             backgroundUploaderContext: backgroundUploadContext,
             webDavController: webDavController,
+            iCloudController: iCloudController,
             attachmentDownloader: fileDownloader,
             syncDelayIntervals: DelayIntervals.sync,
             maxRetryCount: DelayIntervals.retry.count
@@ -382,6 +392,7 @@ final class UserControllers {
         self.dbStorage = dbStorage
         syncScheduler = SyncScheduler(controller: syncController, retryIntervals: DelayIntervals.retry)
         self.webDavController = webDavController
+        self.iCloudController = iCloudController
         changeObserver = RealmObjectUserChangeObserver(dbStorage: dbStorage)
         itemLocaleController = RItemLocaleController(schemaController: controllers.schemaController, dbStorage: dbStorage)
         self.backgroundUploadObserver = backgroundUploadObserver

--- a/Zotero/Controllers/FileStorage/FileSyncBackend.swift
+++ b/Zotero/Controllers/FileStorage/FileSyncBackend.swift
@@ -1,0 +1,76 @@
+//
+//  FileSyncBackend.swift
+//  Zotero
+//
+//  Created by Claude on 30.05.2026.
+//  Copyright © 2026 Corporation for Digital Scholarship. All rights reserved.
+//
+
+import Foundation
+
+import RxSwift
+
+/// Result of `prepareForUpload`. The `<key>.zip`/`<key>.prop` scheme is shared by all non-ZFS backends.
+/// - `exists`: the remote already has an up-to-date copy (matching mtime + hash), no upload needed.
+/// - `new`: the file (a freshly created zip) needs to be uploaded.
+enum FileUploadResult {
+    case exists
+    case new(File)
+}
+
+/// Aggregated result of a deferred remote deletion pass. (`WebDavDeletionResult` is a typealias of this.)
+struct FileDeletionResult {
+    let succeeded: Set<String>
+    let missing: Set<String>
+    let failed: Set<String>
+}
+
+/// Backend-agnostic contract for the file-storage layer. The active backend moves the *bytes* of attachment files; the *data* layer
+/// (which item has which file version) is always server-mediated through the Zotero API by the caller.
+///
+/// This protocol captures only the operations that are genuinely uniform across backends — selection, verification and deferred deletion.
+/// The upload/download *transport* differs fundamentally per backend (WebDAV/ZFS use a background `URLSession` driven by
+/// `AttachmentDownloader`/`BackgroundUploader`; iCloud uses the OS ubiquity daemon via `NSFileCoordinator`/`NSMetadataQuery`), so those
+/// flows stay on the concrete controllers and call sites branch on `FileSyncType`.
+protocol FileSyncBackend: AnyObject {
+    /// The backend this controller represents (never `.zotero`; ZFS is the implicit inline path).
+    var type: FileSyncType { get }
+    /// Whether the backend has been verified and is ready to use.
+    var isVerified: Bool { get }
+
+    /// Verifies the backend is reachable/usable (credentials, container, account, writability). Marks it verified on success.
+    func verify(queue: DispatchQueue) -> Single<()>
+    /// Clears the verified state.
+    func resetVerification()
+    /// Removes `<key>.zip`/`<key>.prop` (and placeholders) for the given keys.
+    func delete(keys: [String], queue: DispatchQueue) -> Single<FileDeletionResult>
+}
+
+/// Resolves the active file-storage backend from `Defaults.shared.fileSyncType`. Returns `nil` for `.zotero` (ZFS inline path).
+final class FileSyncBackendProvider {
+    private unowned let webDavController: WebDavController
+    private unowned let iCloudController: ICloudController
+
+    init(webDavController: WebDavController, iCloudController: ICloudController) {
+        self.webDavController = webDavController
+        self.iCloudController = iCloudController
+    }
+
+    /// The active backend, or `nil` when ZFS (Zotero Storage) should be used inline.
+    func current() -> FileSyncBackend? {
+        return controller(for: Defaults.shared.fileSyncType)
+    }
+
+    func controller(for type: FileSyncType) -> FileSyncBackend? {
+        switch type {
+        case .zotero:
+            return nil
+
+        case .webDav:
+            return webDavController
+
+        case .iCloud:
+            return iCloudController
+        }
+    }
+}

--- a/Zotero/Controllers/FileStorage/ICloudController.swift
+++ b/Zotero/Controllers/FileStorage/ICloudController.swift
@@ -1,0 +1,298 @@
+//
+//  ICloudController.swift
+//  Zotero
+//
+//  Created by Claude on 30.05.2026.
+//  Copyright © 2026 Corporation for Digital Scholarship. All rights reserved.
+//
+
+import Foundation
+
+import CocoaLumberjackSwift
+import RxSwift
+import ZIPFoundation
+
+enum ICloudError {
+    enum Verification: Swift.Error {
+        case accountUnavailable
+        case containerUnavailable
+        case probeFailed
+
+        var message: String {
+            switch self {
+            case .accountUnavailable:
+                return L10n.Errors.Settings.Icloud.accountUnavailable
+
+            case .containerUnavailable:
+                return L10n.Errors.Settings.Icloud.containerUnavailable
+
+            case .probeFailed:
+                return L10n.Errors.Settings.Icloud.probeFailed
+            }
+        }
+    }
+
+    enum Download: Swift.Error {
+        case itemPropInvalid(String)
+    }
+
+    static func message(for error: Error) -> String {
+        if let error = error as? ICloudError.Verification {
+            return error.message
+        }
+        return error.localizedDescription
+    }
+}
+
+/// `FileSyncBackend` backed by the app's iCloud Drive ubiquitous container. Keeps the `<key>.zip` + `<key>.prop` layout (identical to
+/// WebDAV/desktop), so a file uploaded by another client lands in the same logical place and the mtime/hash conflict logic ports directly.
+/// iCloud only moves the bytes; the data layer (file versions) is registered with the Zotero API by the caller, exactly like WebDAV.
+final class ICloudController: FileSyncBackend {
+    private enum MetadataResult {
+        case unchanged
+        case mtimeChanged(Int)
+        case changed
+        case new
+    }
+
+    private unowned let dbStorage: DbStorage
+    private unowned let fileStorage: FileStorage
+    let transport: ICloudTransport
+
+    init(dbStorage: DbStorage, fileStorage: FileStorage, transport: ICloudTransport) {
+        self.dbStorage = dbStorage
+        self.fileStorage = fileStorage
+        self.transport = transport
+    }
+
+    var type: FileSyncType { return .iCloud }
+
+    var isVerified: Bool { return Defaults.shared.iCloudVerified }
+
+    var isAvailable: Bool { return transport.isAccountAvailable }
+
+    func resetVerification() {
+        Defaults.shared.iCloudVerified = false
+    }
+
+    func verify(queue: DispatchQueue) -> Single<()> {
+        return Single.create { [weak self] subscriber in
+            guard let self else { return Disposables.create() }
+            guard transport.isAccountAvailable else {
+                subscriber(.failure(ICloudError.Verification.accountUnavailable))
+                return Disposables.create()
+            }
+            do {
+                _ = try transport.storageDirectory()
+            } catch {
+                subscriber(.failure(ICloudError.Verification.containerUnavailable))
+                return Disposables.create()
+            }
+            subscriber(.success(()))
+            return Disposables.create()
+        }
+        .flatMap { [weak self] _ -> Single<()> in
+            guard let self else { return .error(ICloudError.Verification.containerUnavailable) }
+            // Probe: write + read + delete a small file to confirm read/write access.
+            let probeName = ".zotero-probe"
+            guard let data = "ok".data(using: .utf8) else { return .error(ICloudError.Verification.probeFailed) }
+            return transport.write(data: data, toItemNamed: probeName)
+                .flatMap { self.transport.readData(fromItemNamed: probeName) }
+                .flatMap { read -> Single<()> in
+                    guard read == data else { return .error(ICloudError.Verification.probeFailed) }
+                    return self.transport.remove(itemNamed: probeName).flatMap { _ in .just(()) }
+                }
+        }
+        .do(onSuccess: { _ in
+            Defaults.shared.iCloudVerified = true
+            DDLogInfo("ICloudController: verified")
+        }, onError: { error in
+            DDLogError("ICloudController: verification failed - \(error)")
+            Defaults.shared.iCloudVerified = false
+        })
+    }
+
+    func download(key: String, file: File, queue: DispatchQueue) -> Observable<Progress> {
+        let zipName = key + ".zip"
+        let localZip = file.copy(withExt: "zip")
+        return transport.materialize(name: zipName, queue: queue)
+            .concat(Observable.deferred { [weak self] () -> Observable<Progress> in
+                guard let self else { return .empty() }
+                return copyZipLocally(zipName: zipName, localZip: localZip).asObservable().flatMap { _ in Observable<Progress>.empty() }
+            })
+
+        func copyZipLocally(zipName: String, localZip: File) -> Single<()> {
+            return Single.create { [weak self] subscriber in
+                guard let self else { return Disposables.create() }
+                do {
+                    try fileStorage.createDirectories(for: localZip)
+                    try? fileStorage.remove(localZip)
+                } catch let error {
+                    subscriber(.failure(error))
+                    return Disposables.create()
+                }
+                return transport.copyItem(named: zipName, to: localZip.createUrl())
+                    .subscribe(onSuccess: { subscriber(.success(())) }, onFailure: { subscriber(.failure($0)) })
+            }
+        }
+    }
+
+    func prepareForUpload(key: String, mtime: Int, hash: String, file: File, queue: DispatchQueue) -> Single<FileUploadResult> {
+        DDLogInfo("ICloudController: prepare for upload \(key)")
+        return checkMetadata(key: key, mtime: mtime, hash: hash, queue: queue)
+            .flatMap { [weak self] result -> Single<FileUploadResult> in
+                guard let self else { return .error(ICloudError.Verification.containerUnavailable) }
+                switch result {
+                case .unchanged:
+                    return .just(.exists)
+
+                case .mtimeChanged(let remoteMtime):
+                    return updateMtime(remoteMtime, key: key, queue: queue).flatMap { .just(.exists) }
+
+                case .new:
+                    return zip(file: file, key: key).flatMap { .just(.new($0)) }
+
+                case .changed:
+                    return removeExistingProp(key: key)
+                        .flatMap { self.zip(file: file, key: key) }
+                        .flatMap { .just(.new($0)) }
+                }
+            }
+    }
+
+    func upload(key: String, file: File, mtime: Int, hash: String, queue: DispatchQueue) -> Single<()> {
+        DDLogInfo("ICloudController: upload \(key)")
+        return transport.copy(localFile: file.createUrl(), toItemNamed: key + ".zip")
+    }
+
+    func finishUpload(key: String, result: Result<(Int, String), Swift.Error>, file: File?, queue: DispatchQueue) -> Single<()> {
+        switch result {
+        case .success((let mtime, let hash)):
+            DDLogInfo("ICloudController: finish successful upload \(key)")
+            return uploadMetadata(key: key, mtime: mtime, hash: hash)
+                .flatMap { [weak self] _ in
+                    self?.remove(file: file) ?? .just(())
+                }
+
+        case .failure(let error):
+            DDLogError("ICloudController: finish failed upload \(key) - \(error)")
+            return remove(file: file)
+        }
+    }
+
+    func delete(keys: [String], queue: DispatchQueue) -> Single<FileDeletionResult> {
+        let singles = keys.map { key -> Single<(String, Bool, Bool)> in
+            Single.zip(transport.remove(itemNamed: key + ".zip"), transport.remove(itemNamed: key + ".prop"))
+                .map { (key, $0.0, $0.1) }
+                .catch { _ in .just((key, false, false)) }
+        }
+        guard !singles.isEmpty else {
+            return .just(FileDeletionResult(succeeded: [], missing: [], failed: []))
+        }
+        return Single.zip(singles).map { results in
+            var succeeded: Set<String> = []
+            var missing: Set<String> = []
+            for (key, zipRemoved, propRemoved) in results {
+                if zipRemoved || propRemoved {
+                    succeeded.insert(key)
+                } else {
+                    // Nothing to remove — treat as already gone.
+                    missing.insert(key)
+                }
+            }
+            return FileDeletionResult(succeeded: succeeded, missing: missing, failed: [])
+        }
+    }
+
+    /// iOS analog of `purgeOrphanedStorageFiles`: removes container `<KEY>.zip`/`.prop` whose key has no surviving attachment.
+    func purgeOrphans(validKeys: Set<String>, queue: DispatchQueue) -> Single<()> {
+        return transport.listItemNames().flatMap { [weak self] names -> Single<()> in
+            guard let self else { return .just(()) }
+            var orphanKeys: Set<String> = []
+            for name in names {
+                guard name.hasSuffix(".zip") || name.hasSuffix(".prop") else { continue }
+                let key = String(name.dropLast(name.hasSuffix(".zip") ? 4 : 5))
+                guard key.count == KeyGenerator.length, !validKeys.contains(key) else { continue }
+                orphanKeys.insert(key)
+            }
+            guard !orphanKeys.isEmpty else { return .just(()) }
+            DDLogInfo("ICloudController: purge \(orphanKeys.count) orphaned files")
+            return delete(keys: Array(orphanKeys), queue: queue).flatMap { _ in .just(()) }
+        }
+    }
+
+    // MARK: - Metadata
+
+    private func checkMetadata(key: String, mtime: Int, hash: String, queue: DispatchQueue) -> Single<MetadataResult> {
+        return transport.readData(fromItemNamed: key + ".prop")
+            .flatMap { data -> Single<MetadataResult> in
+                guard let data, !data.isEmpty else { return .just(.new) }
+
+                let delegate = WebDavPropParserDelegate()
+                let parser = XMLParser(data: data)
+                parser.delegate = delegate
+
+                guard parser.parse(), let remoteMtime = delegate.mtime, let remoteHash = delegate.fileHash else {
+                    DDLogError("ICloudController: \(key) prop invalid")
+                    return .error(ICloudError.Download.itemPropInvalid(String(data: data, encoding: .utf8) ?? ""))
+                }
+
+                if hash == remoteHash {
+                    return .just(mtime == remoteMtime ? .unchanged : .mtimeChanged(remoteMtime))
+                }
+                return .just(.changed)
+            }
+    }
+
+    private func uploadMetadata(key: String, mtime: Int, hash: String) -> Single<()> {
+        let prop = "<properties version=\"1\"><mtime>\(mtime)</mtime><hash>\(hash)</hash></properties>"
+        guard let data = prop.data(using: .utf8) else { return .error(ICloudError.Download.itemPropInvalid(prop)) }
+        return transport.write(data: data, toItemNamed: key + ".prop")
+    }
+
+    private func removeExistingProp(key: String) -> Single<()> {
+        return transport.remove(itemNamed: key + ".prop").flatMap { _ in .just(()) }
+    }
+
+    private func updateMtime(_ mtime: Int, key: String, queue: DispatchQueue) -> Single<()> {
+        return Single.create { [weak self] subscriber in
+            guard let self else { return Disposables.create() }
+            do {
+                try dbStorage.perform(request: StoreMtimeForAttachmentDbRequest(mtime: mtime, key: key, libraryId: .custom(.myLibrary)), on: queue)
+                subscriber(.success(()))
+            } catch let error {
+                DDLogError("ICloudController: can't update mtime - \(error)")
+                subscriber(.failure(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    // MARK: - Files
+
+    private func zip(file: File, key: String) -> Single<File> {
+        return Single.create { [weak self] subscriber in
+            guard let self else { return Disposables.create() }
+            DDLogInfo("ICloudController: zip file for upload \(key)")
+            do {
+                let tmpFile = Files.temporaryZipUploadFile(key: key)
+                try fileStorage.createDirectories(for: tmpFile)
+                try? fileStorage.remove(tmpFile)
+                try FileManager.default.zipItem(at: file.createUrl(), to: tmpFile.createUrl())
+                subscriber(.success(tmpFile))
+            } catch let error {
+                DDLogError("ICloudController: can't zip file - \(error)")
+                subscriber(.failure(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    private func remove(file: File?) -> Single<()> {
+        return Single.create { [weak self] subscriber in
+            if let file { try? self?.fileStorage.remove(file) }
+            subscriber(.success(()))
+            return Disposables.create()
+        }
+    }
+}

--- a/Zotero/Controllers/FileStorage/ICloudTransport.swift
+++ b/Zotero/Controllers/FileStorage/ICloudTransport.swift
@@ -1,0 +1,390 @@
+//
+//  ICloudTransport.swift
+//  Zotero
+//
+//  Created by Claude on 30.05.2026.
+//  Copyright © 2026 Corporation for Digital Scholarship. All rights reserved.
+//
+
+import Foundation
+
+import CocoaLumberjackSwift
+import RxSwift
+
+/// Low-level helper that talks to the app's iCloud Drive ubiquitous container. All container I/O is funnelled through `NSFileCoordinator`
+/// to avoid racing the iCloud sync daemon, and evicted file contents are materialized with `startDownloadingUbiquitousItem` + `NSMetadataQuery`.
+///
+/// This type is intentionally transport-only: it knows nothing about `<key>.zip`/`<key>.prop` semantics, mtime/hash, or the Zotero API. That
+/// lives in `ICloudController`.
+protocol ICloudTransport: AnyObject {
+    /// Whether an iCloud account is signed in on the device.
+    var isAccountAvailable: Bool { get }
+
+    /// Resolves the `Documents/storage` directory inside the ubiquity container, creating it if needed. Blocking — must be called off the main thread.
+    func storageDirectory() throws -> URL
+    /// Container URL for `name` (e.g. `<KEY>.zip`) inside `Documents/storage`.
+    func url(forItemNamed name: String) throws -> URL
+    /// Whether the item's contents are present locally (not an evicted placeholder).
+    func isDownloaded(name: String) -> Bool
+    /// Coordinated write of `data` to `name` (replacing any existing item).
+    func write(data: Data, toItemNamed name: String) -> Single<()>
+    /// Coordinated read of `name`. Emits `nil` when the item doesn't exist.
+    func readData(fromItemNamed name: String) -> Single<Data?>
+    /// Coordinated copy of a local file into the container as `name` (replacing any existing item).
+    func copy(localFile: URL, toItemNamed name: String) -> Single<()>
+    /// Coordinated copy of container item `name` out to a local file (replacing any existing local file). Item must already be materialized.
+    func copyItem(named name: String, to localFile: URL) -> Single<()>
+    /// Materializes an evicted item, emitting download `Progress` and completing once contents are present.
+    func materialize(name: String, queue: DispatchQueue) -> Observable<Progress>
+    /// Coordinated removal of `name` (and its placeholder, if any). Reports whether the item existed.
+    func remove(itemNamed name: String) -> Single<Bool>
+    /// Enumerates item names (logical, e.g. `<KEY>.zip`) currently present in `Documents/storage`.
+    func listItemNames() -> Single<[String]>
+}
+
+final class ICloudTransportController: ICloudTransport {
+    enum Error: Swift.Error {
+        case containerUnavailable
+        case accountUnavailable
+        case materializationTimeout
+        case coordination(NSError)
+    }
+
+    static let containerIdentifier = "iCloud.org.zotero.ios.Zotero"
+    private static let materializationTimeout: DispatchTimeInterval = .seconds(120)
+
+    private let containerIdentifier: String?
+
+    init(containerIdentifier: String? = ICloudTransportController.containerIdentifier) {
+        self.containerIdentifier = containerIdentifier
+    }
+
+    var isAccountAvailable: Bool {
+        return FileManager.default.ubiquityIdentityToken != nil
+    }
+
+    func storageDirectory() throws -> URL {
+        guard isAccountAvailable else { throw Error.accountUnavailable }
+        // `url(forUbiquityContainerIdentifier:)` is blocking and must run off the main thread.
+        guard let base = FileManager.default.url(forUbiquityContainerIdentifier: containerIdentifier) else {
+            throw Error.containerUnavailable
+        }
+        let storage = base.appendingPathComponent("Documents/storage", isDirectory: true)
+        if !FileManager.default.fileExists(atPath: storage.path) {
+            try FileManager.default.createDirectory(at: storage, withIntermediateDirectories: true)
+        }
+        return storage
+    }
+
+    func url(forItemNamed name: String) throws -> URL {
+        return try storageDirectory().appendingPathComponent(name)
+    }
+
+    func isDownloaded(name: String) -> Bool {
+        guard let url = try? url(forItemNamed: name) else { return false }
+        guard FileManager.default.fileExists(atPath: url.path) else { return false }
+        let values = try? url.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey])
+        if let status = values?.ubiquitousItemDownloadingStatus {
+            return status == .current
+        }
+        // Non-ubiquitous (or attribute unavailable) but file exists on disk.
+        return true
+    }
+
+    func write(data: Data, toItemNamed name: String) -> Single<()> {
+        return Single.create { [weak self] subscriber in
+            guard let self else { return Disposables.create() }
+            do {
+                let url = try url(forItemNamed: name)
+                try coordinatedWrite(to: url, options: .forReplacing) { coordinatedUrl in
+                    try data.write(to: coordinatedUrl, options: .atomic)
+                }
+                subscriber(.success(()))
+            } catch let error {
+                DDLogError("ICloudTransport: can't write \(name) - \(error)")
+                subscriber(.failure(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    func readData(fromItemNamed name: String) -> Single<Data?> {
+        return Single.create { [weak self] subscriber in
+            guard let self else { return Disposables.create() }
+            do {
+                let url = try url(forItemNamed: name)
+                guard FileManager.default.fileExists(atPath: url.path) else {
+                    subscriber(.success(nil))
+                    return Disposables.create()
+                }
+                var result: Data?
+                try coordinatedRead(at: url) { coordinatedUrl in
+                    result = try Data(contentsOf: coordinatedUrl)
+                }
+                subscriber(.success(result))
+            } catch let error {
+                DDLogError("ICloudTransport: can't read \(name) - \(error)")
+                subscriber(.failure(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    func copy(localFile: URL, toItemNamed name: String) -> Single<()> {
+        return Single.create { [weak self] subscriber in
+            guard let self else { return Disposables.create() }
+            do {
+                let url = try url(forItemNamed: name)
+                try coordinatedWrite(to: url, options: .forReplacing) { coordinatedUrl in
+                    if FileManager.default.fileExists(atPath: coordinatedUrl.path) {
+                        try FileManager.default.removeItem(at: coordinatedUrl)
+                    }
+                    try FileManager.default.copyItem(at: localFile, to: coordinatedUrl)
+                }
+                subscriber(.success(()))
+            } catch let error {
+                DDLogError("ICloudTransport: can't copy into \(name) - \(error)")
+                subscriber(.failure(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    func copyItem(named name: String, to localFile: URL) -> Single<()> {
+        return Single.create { [weak self] subscriber in
+            guard let self else { return Disposables.create() }
+            do {
+                let url = try url(forItemNamed: name)
+                try coordinatedRead(at: url) { coordinatedUrl in
+                    if FileManager.default.fileExists(atPath: localFile.path) {
+                        try FileManager.default.removeItem(at: localFile)
+                    }
+                    try FileManager.default.copyItem(at: coordinatedUrl, to: localFile)
+                }
+                subscriber(.success(()))
+            } catch let error {
+                DDLogError("ICloudTransport: can't copy out \(name) - \(error)")
+                subscriber(.failure(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    func remove(itemNamed name: String) -> Single<Bool> {
+        return Single.create { [weak self] subscriber in
+            guard let self else { return Disposables.create() }
+            do {
+                let url = try url(forItemNamed: name)
+                guard FileManager.default.fileExists(atPath: url.path) else {
+                    subscriber(.success(false))
+                    return Disposables.create()
+                }
+                try coordinatedWrite(to: url, options: .forDeleting) { coordinatedUrl in
+                    try FileManager.default.removeItem(at: coordinatedUrl)
+                }
+                subscriber(.success(true))
+            } catch let error {
+                DDLogError("ICloudTransport: can't remove \(name) - \(error)")
+                subscriber(.failure(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    func listItemNames() -> Single<[String]> {
+        return Single.create { [weak self] subscriber in
+            guard let self else { return Disposables.create() }
+            do {
+                let dir = try storageDirectory()
+                let urls = try FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil, options: [])
+                let names = urls.map { url -> String in
+                    var name = url.lastPathComponent
+                    // Normalize evicted placeholders: ".<KEY>.zip.icloud" -> "<KEY>.zip"
+                    if name.hasSuffix(".icloud") {
+                        name = String(name.dropLast(".icloud".count))
+                        if name.hasPrefix(".") {
+                            name = String(name.dropFirst())
+                        }
+                    }
+                    return name
+                }
+                subscriber(.success(Array(Set(names))))
+            } catch let error {
+                DDLogError("ICloudTransport: can't list storage - \(error)")
+                subscriber(.failure(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    func materialize(name: String, queue: DispatchQueue) -> Observable<Progress> {
+        return Observable.create { [weak self] subscriber in
+            guard let self else {
+                subscriber.onCompleted()
+                return Disposables.create()
+            }
+
+            let url: URL
+            do {
+                url = try self.url(forItemNamed: name)
+            } catch let error {
+                subscriber.onError(error)
+                return Disposables.create()
+            }
+
+            if self.isDownloaded(name: name) {
+                let progress = Progress(totalUnitCount: 100)
+                progress.completedUnitCount = 100
+                subscriber.onNext(progress)
+                subscriber.onCompleted()
+                return Disposables.create()
+            }
+
+            do {
+                try FileManager.default.startDownloadingUbiquitousItem(at: url)
+            } catch let error {
+                subscriber.onError(error)
+                return Disposables.create()
+            }
+
+            let observer = ICloudDownloadObserver(url: url, fileName: name) { event in
+                switch event {
+                case .progress(let fraction):
+                    let progress = Progress(totalUnitCount: 100)
+                    progress.completedUnitCount = Int64(fraction * 100)
+                    subscriber.onNext(progress)
+
+                case .completed:
+                    let progress = Progress(totalUnitCount: 100)
+                    progress.completedUnitCount = 100
+                    subscriber.onNext(progress)
+                    subscriber.onCompleted()
+
+                case .failed(let error):
+                    subscriber.onError(error)
+                }
+            }
+            observer.start()
+
+            // Timeout in case the file never arrives (offline / removed remotely).
+            let timeout = DispatchWorkItem {
+                observer.stop()
+                subscriber.onError(Error.materializationTimeout)
+            }
+            queue.asyncAfter(deadline: .now() + ICloudTransportController.materializationTimeout, execute: timeout)
+
+            return Disposables.create {
+                timeout.cancel()
+                observer.stop()
+            }
+        }
+    }
+
+    // MARK: - NSFileCoordinator helpers
+
+    private func coordinatedWrite(to url: URL, options: NSFileCoordinator.WritingOptions, block: (URL) throws -> Void) throws {
+        var coordinatorError: NSError?
+        var blockError: Swift.Error?
+        NSFileCoordinator(filePresenter: nil).coordinate(writingItemAt: url, options: options, error: &coordinatorError) { coordinatedUrl in
+            do {
+                try block(coordinatedUrl)
+            } catch let error {
+                blockError = error
+            }
+        }
+        if let coordinatorError {
+            throw Error.coordination(coordinatorError)
+        }
+        if let blockError {
+            throw blockError
+        }
+    }
+
+    private func coordinatedRead(at url: URL, block: (URL) throws -> Void) throws {
+        var coordinatorError: NSError?
+        var blockError: Swift.Error?
+        NSFileCoordinator(filePresenter: nil).coordinate(readingItemAt: url, options: [], error: &coordinatorError) { coordinatedUrl in
+            do {
+                try block(coordinatedUrl)
+            } catch let error {
+                blockError = error
+            }
+        }
+        if let coordinatorError {
+            throw Error.coordination(coordinatorError)
+        }
+        if let blockError {
+            throw blockError
+        }
+    }
+}
+
+/// Observes download completion of a single ubiquitous item via `NSMetadataQuery`. The query is started on the main run loop (required for
+/// notification delivery) and reports progress/completion back through `handler`.
+private final class ICloudDownloadObserver {
+    enum Event {
+        case progress(Double)
+        case completed
+        case failed(Swift.Error)
+    }
+
+    private let url: URL
+    private let fileName: String
+    private let handler: (Event) -> Void
+    private var query: NSMetadataQuery?
+    private var tokens: [NSObjectProtocol] = []
+    private var finished = false
+
+    init(url: URL, fileName: String, handler: @escaping (Event) -> Void) {
+        self.url = url
+        self.fileName = fileName
+        self.handler = handler
+    }
+
+    func start() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            let query = NSMetadataQuery()
+            query.searchScopes = [NSMetadataQueryUbiquitousDocumentsScope]
+            query.predicate = NSPredicate(format: "%K == %@", NSMetadataItemFSNameKey, fileName)
+            query.valueListAttributes = [NSMetadataUbiquitousItemDownloadingStatusKey, NSMetadataUbiquitousItemPercentDownloadedKey]
+
+            let center = NotificationCenter.default
+            let onUpdate: (Notification) -> Void = { [weak self] _ in self?.evaluate(query: query) }
+            tokens.append(center.addObserver(forName: .NSMetadataQueryDidFinishGathering, object: query, queue: .main) { note in onUpdate(note) })
+            tokens.append(center.addObserver(forName: .NSMetadataQueryDidUpdate, object: query, queue: .main) { note in onUpdate(note) })
+
+            self.query = query
+            query.start()
+        }
+    }
+
+    func stop() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            tokens.forEach { NotificationCenter.default.removeObserver($0) }
+            tokens = []
+            query?.stop()
+            query = nil
+        }
+    }
+
+    private func evaluate(query: NSMetadataQuery) {
+        guard !finished else { return }
+        query.disableUpdates()
+        defer { query.enableUpdates() }
+
+        guard query.resultCount > 0, let item = query.result(at: 0) as? NSMetadataItem else { return }
+
+        if let percent = item.value(forAttribute: NSMetadataUbiquitousItemPercentDownloadedKey) as? Double {
+            handler(.progress(percent / 100))
+        }
+
+        if let status = item.value(forAttribute: NSMetadataUbiquitousItemDownloadingStatusKey) as? String,
+           status == NSMetadataUbiquitousItemDownloadingStatusCurrent {
+            finished = true
+            handler(.completed)
+            stop()
+        }
+    }
+}

--- a/Zotero/Controllers/Sync/SyncActions/DeleteWebDavFilesSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/DeleteWebDavFilesSyncAction.swift
@@ -16,13 +16,13 @@ struct DeleteWebDavFilesSyncAction: SyncAction {
 
     let libraryId: LibraryIdentifier
     unowned let dbStorage: DbStorage
-    unowned let webDavController: WebDavController
+    unowned let controller: FileSyncBackend
     let queue: DispatchQueue
 
     var result: Single<Set<String>> {
         return self.loadDeletions()
-                   .flatMap({ keys -> Single<WebDavDeletionResult> in
-                       return self.webDavController.delete(keys: keys, queue: self.queue)
+                   .flatMap({ keys -> Single<FileDeletionResult> in
+                       return self.controller.delete(keys: keys, queue: self.queue)
                    })
                    .flatMap({ result -> Single<Set<String>> in
                        if result.succeeded.isEmpty && result.missing.isEmpty {

--- a/Zotero/Controllers/Sync/SyncActions/UploadAttachmentSyncAction.swift
+++ b/Zotero/Controllers/Sync/SyncActions/UploadAttachmentSyncAction.swift
@@ -28,6 +28,7 @@ class UploadAttachmentSyncAction: SyncAction {
     unowned let dbStorage: DbStorage
     unowned let fileStorage: FileStorage
     unowned let webDavController: WebDavController
+    unowned let iCloudController: ICloudController
     unowned let schemaController: SchemaController
     unowned let dateParser: DateParser
     let queue: DispatchQueue
@@ -39,7 +40,8 @@ class UploadAttachmentSyncAction: SyncAction {
     var failedBeforeZoteroApiRequest: Bool
 
     init(key: String, file: File, filename: String, md5: String, mtime: Int, libraryId: LibraryIdentifier, userId: Int, oldMd5: String?, apiClient: ApiClient, dbStorage: DbStorage,
-         fileStorage: FileStorage, webDavController: WebDavController, schemaController: SchemaController, dateParser: DateParser, queue: DispatchQueue, scheduler: SchedulerType, disposeBag: DisposeBag) {
+         fileStorage: FileStorage, webDavController: WebDavController, iCloudController: ICloudController, schemaController: SchemaController, dateParser: DateParser, queue: DispatchQueue,
+         scheduler: SchedulerType, disposeBag: DisposeBag) {
         self.key = key
         self.file = file
         self.filename = filename
@@ -52,6 +54,7 @@ class UploadAttachmentSyncAction: SyncAction {
         self.dbStorage = dbStorage
         self.fileStorage = fileStorage
         self.webDavController = webDavController
+        self.iCloudController = iCloudController
         self.schemaController = schemaController
         self.dateParser = dateParser
         self.queue = queue
@@ -63,9 +66,19 @@ class UploadAttachmentSyncAction: SyncAction {
     var result: Single<()> {
         switch self.libraryId {
         case .custom:
-            return self.webDavController.sessionStorage.isEnabled ? self.webDavResult : self.zoteroResult
+            switch Defaults.shared.fileSyncType {
+            case .zotero:
+                return self.zoteroResult
+
+            case .webDav:
+                return self.webDavResult
+
+            case .iCloud:
+                return self.iCloudResult
+            }
 
         case .group:
+            // Group libraries always use Zotero File Storage; iCloud/WebDAV cover My Library only.
             return self.zoteroResult
         }
     }
@@ -178,6 +191,62 @@ class UploadAttachmentSyncAction: SyncAction {
                            }
                        }
                        DDLogError("UploadAttachmentSyncAction: could not upload - \(error)")
+                   })
+    }
+
+    private var iCloudResult: Single<()> {
+        DDLogInfo("UploadAttachmentSyncAction: upload to iCloud")
+
+        var file: File?
+        return self.checkDatabase()
+                   .flatMap { _ -> Single<UInt64> in
+                       return self.validateFile()
+                   }
+                   .flatMap { _ -> Single<FileUploadResult> in
+                       return self.iCloudController.prepareForUpload(key: self.key, mtime: self.mtime, hash: self.md5, file: self.file, queue: self.queue)
+                   }
+                   .observe(on: self.scheduler)
+                   .flatMap { response -> Single<()> in
+                       switch response {
+                       case .exists:
+                           DDLogInfo("UploadAttachmentSyncAction: file exists in iCloud")
+                           return self.markAttachmentAsUploaded(version: nil).flatMap({ Single.error(SyncActionError.attachmentAlreadyUploaded) })
+
+                       case .new(let newFile):
+                           DDLogInfo("UploadAttachmentSyncAction: file needs upload to iCloud")
+                           file = newFile
+                           // Enqueue the coordinated write; the OS ubiquity daemon replicates the bytes even if the app is backgrounded.
+                           return self.iCloudController.upload(key: self.key, file: newFile, mtime: self.mtime, hash: self.md5, queue: self.queue)
+                       }
+                   }
+                   .observe(on: self.scheduler)
+                   .do(onError: { error in
+                       guard let file = file else { return }
+                       // If something broke during upload, remove tmp zip file
+                       self.iCloudController.finishUpload(key: self.key, result: .failure(error), file: file, queue: self.queue)
+                           .subscribe(on: self.scheduler)
+                           .subscribe()
+                           .disposed(by: self.disposeBag)
+                   })
+                   .flatMap({ _ -> Single<()> in
+                       return self.iCloudController.finishUpload(key: self.key, result: .success((self.mtime, self.md5)), file: file, queue: self.queue)
+                   })
+                   .flatMap({ _ -> Single<Int> in
+                       // The data layer is always server-mediated: register mtime+hash with the Zotero API so other clients learn the file changed.
+                       return self.submitItemWithHashAndMtime().flatMap({ Single.just($0) })
+                   })
+                   .observe(on: self.scheduler)
+                   .flatMap({ version -> Single<()> in
+                       return self.markAttachmentAsUploaded(version: version)
+                   })
+                   .do(onError: { error in
+                       if let error = error as? SyncActionError {
+                           switch error {
+                           case .attachmentAlreadyUploaded: return
+                           default: break
+                           }
+                       }
+                       DDLogError("UploadAttachmentSyncAction: could not upload to iCloud - \(error)")
                    })
     }
 

--- a/Zotero/Controllers/Sync/SyncController.swift
+++ b/Zotero/Controllers/Sync/SyncController.swift
@@ -191,6 +191,7 @@ final class SyncController: SynchronizationController {
     private unowned let dateParser: DateParser
     private unowned let backgroundUploaderContext: BackgroundUploaderContext
     private unowned let webDavController: WebDavController
+    private unowned let iCloudController: ICloudController
     // Handler for reporting sync progress to observers.
     private let progressHandler: SyncProgressHandler
     // Id of currently logged in user.
@@ -254,6 +255,7 @@ final class SyncController: SynchronizationController {
         dateParser: DateParser,
         backgroundUploaderContext: BackgroundUploaderContext,
         webDavController: WebDavController,
+        iCloudController: ICloudController,
         attachmentDownloader: AttachmentDownloader,
         syncDelayIntervals: [Double],
         maxRetryCount: Int
@@ -280,6 +282,7 @@ final class SyncController: SynchronizationController {
         self.dateParser = dateParser
         self.backgroundUploaderContext = backgroundUploaderContext
         self.webDavController = webDavController
+        self.iCloudController = iCloudController
         self.syncDelayIntervals = syncDelayIntervals
         self.didEnqueueWriteActionsToZoteroBackend = false
         self.enqueuedUploads = 0
@@ -803,7 +806,7 @@ final class SyncController: SynchronizationController {
             type: libraries,
             fetchUpdates: (options != .onlyDownloads),
             loadVersions: (self.type != .full),
-            webDavEnabled: self.webDavController.sessionStorage.isEnabled,
+            webDavEnabled: (Defaults.shared.fileSyncType != .zotero),
             dbStorage: self.dbStorage,
             queue: self.workQueue
         ).result
@@ -1540,6 +1543,7 @@ final class SyncController: SynchronizationController {
             dbStorage: self.dbStorage,
             fileStorage: self.fileStorage,
             webDavController: self.webDavController,
+            iCloudController: self.iCloudController,
             schemaController: self.schemaController,
             dateParser: self.dateParser,
             queue: self.workQueue,
@@ -1602,7 +1606,7 @@ final class SyncController: SynchronizationController {
             version: batch.version,
             libraryId: batch.libraryId,
             userId: self.userId,
-            webDavEnabled: self.webDavController.sessionStorage.isEnabled,
+            webDavEnabled: (Defaults.shared.fileSyncType != .zotero),
             apiClient: self.apiClient,
             dbStorage: self.dbStorage,
             queue: self.workQueue,
@@ -1928,7 +1932,9 @@ final class SyncController: SynchronizationController {
     }
 
     private func performWebDavDeletions(libraryId: LibraryIdentifier) {
-        let result = DeleteWebDavFilesSyncAction(libraryId: libraryId, dbStorage: self.dbStorage, webDavController: self.webDavController, queue: self.workQueue).result
+        // Route deferred deletions to whichever file backend is active (deletions are only ever enqueued for non-ZFS backends).
+        let controller: FileSyncBackend = Defaults.shared.fileSyncType == .iCloud ? self.iCloudController : self.webDavController
+        let result = DeleteWebDavFilesSyncAction(libraryId: libraryId, dbStorage: self.dbStorage, controller: controller, queue: self.workQueue).result
         result.subscribe(on: self.workScheduler)
               .subscribe(onSuccess: { [weak self] failures in
                   self?.accessQueue.async(flags: .barrier) { [weak self] in

--- a/Zotero/Controllers/WebDAV/WebDavController.swift
+++ b/Zotero/Controllers/WebDAV/WebDavController.swift
@@ -133,13 +133,10 @@ enum WebDavError {
     }
 }
 
-struct WebDavDeletionResult {
-    let succeeded: Set<String>
-    let missing: Set<String>
-    let failed: Set<String>
-}
+// Structurally identical to the backend-agnostic `FileDeletionResult`; kept as an alias so existing WebDAV call sites read naturally.
+typealias WebDavDeletionResult = FileDeletionResult
 
-protocol WebDavController: AnyObject {
+protocol WebDavController: FileSyncBackend {
     var sessionStorage: WebDavSessionStorage { get }
     var currentUrl: URL? { get }
 
@@ -150,9 +147,7 @@ protocol WebDavController: AnyObject {
     func prepareForUpload(key: String, mtime: Int, hash: String, file: File, queue: DispatchQueue) -> Single<WebDavUploadResult>
     func upload(request: AttachmentUploadRequest, fromFile file: File, queue: DispatchQueue) -> Single<(Data?, HTTPURLResponse)>
     func finishUpload(key: String, result: Result<(Int, String, URL), Swift.Error>, file: File?, queue: DispatchQueue) -> Single<()>
-    func delete(keys: [String], queue: DispatchQueue) -> Single<WebDavDeletionResult>
     func cancelDeletions()
-    func resetVerification()
 }
 
 final class WebDavControllerImpl: WebDavController {
@@ -187,6 +182,17 @@ final class WebDavControllerImpl: WebDavController {
         if self.sessionStorage.isVerified {
             self.apiClient.set(credentials: (self.sessionStorage.username, self.sessionStorage.password))
         }
+    }
+
+    // MARK: - FileSyncBackend
+
+    var type: FileSyncType { return .webDav }
+
+    var isVerified: Bool { return self.sessionStorage.isVerified }
+
+    /// Backend-agnostic verification entry point. WebDAV verification is `checkServer` (which also returns the resolved URL).
+    func verify(queue: DispatchQueue) -> Single<()> {
+        return self.checkServer(queue: queue).flatMap({ _ in Single.just(()) })
     }
 
     func resetVerification() {

--- a/Zotero/Models/Defaults.swift
+++ b/Zotero/Models/Defaults.swift
@@ -28,6 +28,20 @@ final class Defaults {
     @OptionalUserDefault(key: "sessionId")
     var sessionId: String?
 
+    // MARK: - File Syncing
+
+    // Active attachment-file backend. Migrates existing installs: if `fileSyncType` was never stored but `webDavEnabled` is true, default to `.webDav`.
+    @CodableUserDefault(key: "fileSyncType", defaultValue: {
+        if UserDefaults.zotero.object(forKey: "fileSyncType") == nil && UserDefaults.zotero.bool(forKey: "webDavEnabled") {
+            return FileSyncType.webDav
+        }
+        return FileSyncType.zotero
+    }(), encoder: Defaults.jsonEncoder, decoder: Defaults.jsonDecoder)
+    var fileSyncType: FileSyncType
+
+    @UserDefault(key: "iCloudVerified", defaultValue: false)
+    var iCloudVerified: Bool
+
     // MARK: - WebDav Session
 
     @UserDefault(key: "webDavEnabled", defaultValue: false)
@@ -242,6 +256,8 @@ final class Defaults {
         shareExtensionIncludeAttachment = true
         selectedLibraryId = .custom(.myLibrary)
         selectedCollectionId = .custom(.all)
+        fileSyncType = .zotero
+        iCloudVerified = false
         webDavUrl = nil
         webDavScheme = .https
         webDavEnabled = false

--- a/Zotero/Models/FileSyncType.swift
+++ b/Zotero/Models/FileSyncType.swift
@@ -1,0 +1,19 @@
+//
+//  FileSyncType.swift
+//  Zotero
+//
+//  Created by Claude on 30.05.2026.
+//  Copyright © 2026 Corporation for Digital Scholarship. All rights reserved.
+//
+
+import Foundation
+
+/// Backend used to sync attachment files. Library data (items/collections/tags) always syncs through the Zotero API regardless of this value.
+/// - `zotero`: Zotero File Storage (ZFS), the default API-backed storage.
+/// - `webDav`: a user-provided WebDAV server.
+/// - `iCloud`: the app's iCloud Drive ubiquitous container.
+enum FileSyncType: String, Codable, Hashable, CaseIterable {
+    case zotero
+    case webDav
+    case iCloud
+}

--- a/Zotero/Scenes/Master/Settings/SettingsCoordinator.swift
+++ b/Zotero/Scenes/Master/Settings/SettingsCoordinator.swift
@@ -143,7 +143,8 @@ final class SettingsCoordinator: NSObject, Coordinator {
     private func createSyncController() -> UIViewController? {
         guard let dbStorage = controllers.userControllers?.dbStorage,
               let syncScheduler = controllers.userControllers?.syncScheduler,
-              let webDavController = controllers.userControllers?.webDavController else {
+              let webDavController = controllers.userControllers?.webDavController,
+              let iCloudController = controllers.userControllers?.iCloudController else {
             DDLogError("SettingsCoordinator: can't show sync, missing userControllers")
             return nil
         }
@@ -153,17 +154,20 @@ final class SettingsCoordinator: NSObject, Coordinator {
             fileStorage: controllers.fileStorage,
             sessionController: controllers.sessionController,
             webDavController: webDavController,
+            iCloudController: iCloudController,
             syncScheduler: syncScheduler,
             coordinatorDelegate: self
         )
         let state = SyncSettingsState(
             account: Defaults.shared.username,
-            fileSyncType: (webDavController.sessionStorage.isEnabled ? .webDav : .zotero),
+            fileSyncType: Defaults.shared.fileSyncType,
             scheme: webDavController.sessionStorage.scheme,
             url: webDavController.sessionStorage.url,
             username: webDavController.sessionStorage.username,
             password: webDavController.sessionStorage.password,
-            isVerified: webDavController.sessionStorage.isVerified
+            isVerified: webDavController.sessionStorage.isVerified,
+            iCloudAvailable: iCloudController.isAvailable,
+            isICloudVerified: iCloudController.isVerified
         )
         let viewModel = ViewModel(initialState: state, handler: handler)
         var view = SyncSettingsView()

--- a/Zotero/Scenes/Master/Settings/Sync/Models/SyncSettingsAction.swift
+++ b/Zotero/Scenes/Master/Settings/Sync/Models/SyncSettingsAction.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum SyncSettingsAction {
     case logout
-    case setFileSyncType(SyncSettingsState.FileSyncType)
+    case setFileSyncType(FileSyncType)
     case setScheme(WebDavScheme)
     case setUrl(String)
     case setUsername(String)

--- a/Zotero/Scenes/Master/Settings/Sync/Models/SyncSettingsState.swift
+++ b/Zotero/Scenes/Master/Settings/Sync/Models/SyncSettingsState.swift
@@ -11,11 +11,6 @@ import Foundation
 import RxSwift
 
 struct SyncSettingsState: ViewModelState {
-    enum FileSyncType: Hashable {
-        case zotero
-        case webDav
-    }
-
     let account: String
 
     var fileSyncType: FileSyncType
@@ -26,9 +21,22 @@ struct SyncSettingsState: ViewModelState {
     var password: String
     var isVerifyingWebDav: Bool
     var webDavVerificationResult: Result<(), Error>?
+    var isVerifyingICloud: Bool
+    var iCloudVerificationResult: Result<(), Error>?
+    var iCloudAvailable: Bool
     var apiDisposeBag: DisposeBag
 
-    init(account: String, fileSyncType: FileSyncType, scheme: WebDavScheme, url: String, username: String, password: String, isVerified: Bool) {
+    init(
+        account: String,
+        fileSyncType: FileSyncType,
+        scheme: WebDavScheme,
+        url: String,
+        username: String,
+        password: String,
+        isVerified: Bool,
+        iCloudAvailable: Bool,
+        isICloudVerified: Bool
+    ) {
         self.account = account
         self.fileSyncType = fileSyncType
         self.markingForReupload = false
@@ -38,6 +46,9 @@ struct SyncSettingsState: ViewModelState {
         self.password = password
         self.isVerifyingWebDav = false
         self.webDavVerificationResult = isVerified ? .success(()) : nil
+        self.isVerifyingICloud = false
+        self.iCloudVerificationResult = isICloudVerified ? .success(()) : nil
+        self.iCloudAvailable = iCloudAvailable
         self.apiDisposeBag = DisposeBag()
     }
 

--- a/Zotero/Scenes/Master/Settings/Sync/ViewModels/SyncSettingsActionHandler.swift
+++ b/Zotero/Scenes/Master/Settings/Sync/ViewModels/SyncSettingsActionHandler.swift
@@ -18,17 +18,19 @@ struct SyncSettingsActionHandler: ViewModelActionHandler {
     private unowned let dbStorage: DbStorage
     private unowned let fileStorage: FileStorage
     private unowned let webDavController: WebDavController
+    private unowned let iCloudController: ICloudController
     private unowned let sessionController: SessionController
     private unowned let syncScheduler: SynchronizationScheduler
     private let backgroundQueue: DispatchQueue
     private weak var coordinatorDelegate: SettingsCoordinatorDelegate?
 
-    init(dbStorage: DbStorage, fileStorage: FileStorage, sessionController: SessionController, webDavController: WebDavController, syncScheduler: SynchronizationScheduler,
-         coordinatorDelegate: SettingsCoordinatorDelegate?) {
+    init(dbStorage: DbStorage, fileStorage: FileStorage, sessionController: SessionController, webDavController: WebDavController, iCloudController: ICloudController,
+         syncScheduler: SynchronizationScheduler, coordinatorDelegate: SettingsCoordinatorDelegate?) {
         self.dbStorage = dbStorage
         self.fileStorage = fileStorage
         self.sessionController = sessionController
         self.webDavController = webDavController
+        self.iCloudController = iCloudController
         self.syncScheduler = syncScheduler
         self.coordinatorDelegate = coordinatorDelegate
         self.backgroundQueue = DispatchQueue(label: "org.zotero.SyncSettingsActionHandler.background", qos: .userInteractive)
@@ -74,8 +76,14 @@ struct SyncSettingsActionHandler: ViewModelActionHandler {
             self.webDavController.resetVerification()
 
         case .verify:
-            trimURLIfNeeded(in: viewModel)
-            self.verify(tryCreatingZoteroDir: false, in: viewModel)
+            switch viewModel.state.fileSyncType {
+            case .iCloud:
+                self.verifyICloud(in: viewModel)
+
+            case .webDav, .zotero:
+                trimURLIfNeeded(in: viewModel)
+                self.verify(tryCreatingZoteroDir: false, in: viewModel)
+            }
 
         case .cancelVerification:
             self.cancelVerification(viewModel: viewModel)
@@ -155,7 +163,7 @@ struct SyncSettingsActionHandler: ViewModelActionHandler {
         }
     }
 
-    private func set(fileSyncType type: SyncSettingsState.FileSyncType, in viewModel: ViewModel<SyncSettingsActionHandler>) {
+    private func set(fileSyncType type: FileSyncType, in viewModel: ViewModel<SyncSettingsActionHandler>) {
         guard viewModel.state.fileSyncType != type else { return }
 
         syncScheduler.cancelSync()
@@ -178,8 +186,11 @@ struct SyncSettingsActionHandler: ViewModelActionHandler {
 
             guard error == nil else { return }
 
+            Defaults.shared.fileSyncType = type
+            // Keep the legacy WebDAV-enabled flag consistent for the download auth-challenge handler.
             webDavController.sessionStorage.isEnabled = type == .webDav
 
+            // ZFS and iCloud (once available) need no server credentials, so syncing can resume immediately. WebDAV waits for verification.
             if type == .zotero {
                 if syncScheduler.inProgress.value {
                     syncScheduler.cancelSync()
@@ -189,7 +200,35 @@ struct SyncSettingsActionHandler: ViewModelActionHandler {
         }
     }
 
-    private func markAttachmentsForReupload(for type: SyncSettingsState.FileSyncType, completion: @escaping (Error?) -> Void) {
+    private func verifyICloud(in viewModel: ViewModel<SyncSettingsActionHandler>) {
+        if !viewModel.state.isVerifyingICloud {
+            update(viewModel: viewModel) { state in
+                state.isVerifyingICloud = true
+            }
+        }
+
+        iCloudController.verify(queue: .main)
+            .subscribe(on: MainScheduler.instance)
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: viewModel, onSuccess: { viewModel, _ in
+                self.update(viewModel: viewModel) { state in
+                    state.isVerifyingICloud = false
+                    state.iCloudVerificationResult = .success(())
+                }
+                if self.syncScheduler.inProgress.value {
+                    self.syncScheduler.cancelSync()
+                }
+                self.syncScheduler.request(sync: .normal, libraries: .all)
+            }, onFailure: { viewModel, error in
+                self.update(viewModel: viewModel) { state in
+                    state.isVerifyingICloud = false
+                    state.iCloudVerificationResult = .failure(error)
+                }
+            })
+            .disposed(by: viewModel.state.apiDisposeBag)
+    }
+
+    private func markAttachmentsForReupload(for type: FileSyncType, completion: @escaping (Error?) -> Void) {
         backgroundQueue.async {
             do {
                 try performMark(for: type)
@@ -204,12 +243,10 @@ struct SyncSettingsActionHandler: ViewModelActionHandler {
             }
         }
 
-        func performMark(for type: SyncSettingsState.FileSyncType) throws {
+        func performMark(for type: FileSyncType) throws {
             let keys = downloadedAttachmentKeys()
-            var requests: [DbRequest] = [MarkAttachmentsNotUploadedDbRequest(keys: keys, libraryId: .custom(.myLibrary))]
-            if type == .zotero {
-                requests.append(DeleteAllWebDavDeletionsDbRequest())
-            }
+            // Re-mark everything for reupload and drop any pending deferred deletions queued for the previous backend.
+            let requests: [DbRequest] = [MarkAttachmentsNotUploadedDbRequest(keys: keys, libraryId: .custom(.myLibrary)), DeleteAllWebDavDeletionsDbRequest()]
             try dbStorage.perform(writeRequests: requests, on: backgroundQueue)
         }
     }

--- a/Zotero/Scenes/Master/Settings/Sync/Views/SyncSettingsView.swift
+++ b/Zotero/Scenes/Master/Settings/Sync/Views/SyncSettingsView.swift
@@ -59,13 +59,18 @@ struct FileSyncingSection: View {
 
     var body: some View {
         Picker(L10n.Settings.Sync.fileSyncingTypeMessage, selection: self.viewModel.binding(get: \.fileSyncType, action: { .setFileSyncType($0) })) {
-            Text("Zotero").tag(SyncSettingsState.FileSyncType.zotero)
-            Text("WebDAV").tag(SyncSettingsState.FileSyncType.webDav)
+            Text("Zotero").tag(FileSyncType.zotero)
+            Text("WebDAV").tag(FileSyncType.webDav)
+            if self.viewModel.state.iCloudAvailable {
+                Text(L10n.Settings.Sync.iCloud).tag(FileSyncType.iCloud)
+            }
         }
         .disabled(self.viewModel.state.markingForReupload)
 
         if self.viewModel.state.fileSyncType == .webDav {
             self.webDavSettings
+        } else if self.viewModel.state.fileSyncType == .iCloud {
+            self.iCloudSettings
         }
     }
 
@@ -73,6 +78,48 @@ struct FileSyncingSection: View {
         var view = WebDavSettings()
         view.coordinatorDelegate = self.coordinatorDelegate
         return view
+    }
+
+    private var iCloudSettings: some View {
+        return ICloudSettings()
+    }
+}
+
+struct ICloudSettings: View {
+    @EnvironmentObject var viewModel: ViewModel<SyncSettingsActionHandler>
+
+    var body: some View {
+        Text(L10n.Settings.Sync.iCloudMessage)
+            .font(.footnote)
+            .foregroundColor(Color(UIColor.secondaryLabel))
+
+        if self.viewModel.state.isVerifyingICloud {
+            HStack {
+                ActivityIndicatorView(style: .medium, isAnimating: .constant(true))
+                Spacer()
+            }
+        } else {
+            HStack {
+                Button(L10n.Settings.Sync.verify) {
+                    self.viewModel.process(action: .verify)
+                }
+                .foregroundColor(Asset.Colors.zoteroBlueWithDarkMode.swiftUiColor)
+
+                if let result = self.viewModel.state.iCloudVerificationResult, case .success = result {
+                    Spacer()
+                    HStack {
+                        Text(L10n.Settings.Sync.verified)
+                        Image(systemName: "checkmark")
+                            .foregroundColor(.green)
+                    }
+                }
+            }
+        }
+
+        if case .failure(let error) = self.viewModel.state.iCloudVerificationResult {
+            Text(ICloudError.message(for: error))
+                .foregroundColor(.red)
+        }
     }
 }
 

--- a/ZoteroTests/SyncActionsSpec.swift
+++ b/ZoteroTests/SyncActionsSpec.swift
@@ -35,6 +35,7 @@ final class SyncActionsSpec: QuickSpec {
                 realm = try! Realm(configuration: config)
                 dbStorage = RealmDbStorage(config: config)
                 Defaults.shared.webDavEnabled = false
+                Defaults.shared.fileSyncType = .zotero
             }
 
             beforeEach {
@@ -484,6 +485,7 @@ final class SyncActionsSpec: QuickSpec {
                             dbStorage: dbStorage,
                             fileStorage: TestControllers.fileStorage,
                             webDavController: webDavController,
+                            iCloudController: ICloudController(dbStorage: dbStorage, fileStorage: TestControllers.fileStorage, transport: ICloudTransportController()),
                             schemaController: TestControllers.schemaController,
                             dateParser: TestControllers.dateParser,
                             queue: DispatchQueue.main,
@@ -539,6 +541,7 @@ final class SyncActionsSpec: QuickSpec {
                             dbStorage: dbStorage,
                             fileStorage: TestControllers.fileStorage,
                             webDavController: webDavController,
+                            iCloudController: ICloudController(dbStorage: dbStorage, fileStorage: TestControllers.fileStorage, transport: ICloudTransportController()),
                             schemaController: TestControllers.schemaController,
                             dateParser: TestControllers.dateParser,
                             queue: DispatchQueue.main,
@@ -625,6 +628,7 @@ final class SyncActionsSpec: QuickSpec {
                             dbStorage: dbStorage,
                             fileStorage: TestControllers.fileStorage,
                             webDavController: webDavController,
+                            iCloudController: ICloudController(dbStorage: dbStorage, fileStorage: TestControllers.fileStorage, transport: ICloudTransportController()),
                             schemaController: TestControllers.schemaController,
                             dateParser: TestControllers.dateParser,
                             queue: DispatchQueue.main,
@@ -718,6 +722,7 @@ final class SyncActionsSpec: QuickSpec {
                             dbStorage: dbStorage,
                             fileStorage: TestControllers.fileStorage,
                             webDavController: webDavController,
+                            iCloudController: ICloudController(dbStorage: dbStorage, fileStorage: TestControllers.fileStorage, transport: ICloudTransportController()),
                             schemaController: TestControllers.schemaController,
                             dateParser: TestControllers.dateParser,
                             queue: DispatchQueue.main,
@@ -841,6 +846,14 @@ private class WebDavTestController: WebDavController {
 
     func resetVerification() {
         self.sessionStorage.isVerified = false
+    }
+
+    var type: FileSyncType { return .webDav }
+
+    var isVerified: Bool { return self.sessionStorage.isVerified }
+
+    func verify(queue: DispatchQueue) -> Single<()> {
+        return Single.error(Error.shouldntBeCalled)
     }
 
     func createZoteroDirectory(queue: DispatchQueue) -> Single<()> {

--- a/ZoteroTests/SyncControllerSpec.swift
+++ b/ZoteroTests/SyncControllerSpec.swift
@@ -29,6 +29,7 @@ final class SyncControllerSpec: QuickSpec {
             var realm: Realm!
             var syncController: SyncController!
             var webDavController: WebDavController!
+            var iCloudController: ICloudController!
             var attachmentDownloader: AttachmentDownloader!
             var backgroundUploaderContext: BackgroundUploaderContext!
             var dbStorage: DbStorage!
@@ -52,12 +53,14 @@ final class SyncControllerSpec: QuickSpec {
                 backgroundUploaderContext = BackgroundUploaderContext()
                 dbStorage = RealmDbStorage(config: realmConfig)
                 webDavController = WebDavControllerImpl(dbStorage: dbStorage, fileStorage: TestControllers.fileStorage, sessionStorage: webDavSession)
+                iCloudController = ICloudController(dbStorage: dbStorage, fileStorage: TestControllers.fileStorage, transport: ICloudTransportController())
                 attachmentDownloader = AttachmentDownloader(
                     userId: userId,
                     apiClient: TestControllers.apiClient,
                     fileStorage: TestControllers.fileStorage,
                     dbStorage: dbStorage,
-                    webDavController: webDavController
+                    webDavController: webDavController,
+                    iCloudController: iCloudController
                 )
                 syncController = SyncController(
                     userId: userId,
@@ -68,6 +71,7 @@ final class SyncControllerSpec: QuickSpec {
                     dateParser: TestControllers.dateParser,
                     backgroundUploaderContext: backgroundUploaderContext,
                     webDavController: webDavController,
+                    iCloudController: iCloudController,
                     attachmentDownloader: attachmentDownloader,
                     syncDelayIntervals: [0, 1, 2, 3],
                     maxRetryCount: 4

--- a/ZoteroTests/WebDavControllerSpec.swift
+++ b/ZoteroTests/WebDavControllerSpec.swift
@@ -35,12 +35,14 @@ final class WebDavControllerSpec: QuickSpec {
 
             func testDownload(attachment: Attachment, successAction: @escaping () -> Void, errorAction: @escaping (Error) -> Void) {
                 webDavController = WebDavControllerImpl(dbStorage: dbStorage, fileStorage: TestControllers.fileStorage, sessionStorage: verifiedCredentials)
+                iCloudController = ICloudController(dbStorage: dbStorage, fileStorage: TestControllers.fileStorage, transport: ICloudTransportController())
                 downloader = AttachmentDownloader(
                     userId: userId,
                     apiClient: TestControllers.apiClient,
                     fileStorage: TestControllers.fileStorage,
                     dbStorage: dbStorage,
-                    webDavController: webDavController
+                    webDavController: webDavController,
+                    iCloudController: iCloudController
                 )
 
                 downloader.observable
@@ -62,13 +64,15 @@ final class WebDavControllerSpec: QuickSpec {
 
             func testSync(syncFinishedAction: @escaping () -> Void) {
                 webDavController = WebDavControllerImpl(dbStorage: dbStorage, fileStorage: TestControllers.fileStorage, sessionStorage: verifiedCredentials)
+                iCloudController = ICloudController(dbStorage: dbStorage, fileStorage: TestControllers.fileStorage, transport: ICloudTransportController())
                 backgroundUploaderContext = BackgroundUploaderContext()
                 let attachmentDownloader = AttachmentDownloader(
                     userId: userId,
                     apiClient: TestControllers.apiClient,
                     fileStorage: TestControllers.fileStorage,
                     dbStorage: dbStorage,
-                    webDavController: webDavController
+                    webDavController: webDavController,
+                    iCloudController: iCloudController
                 )
                 syncController = SyncController(
                     userId: userId,
@@ -79,6 +83,7 @@ final class WebDavControllerSpec: QuickSpec {
                     dateParser: TestControllers.dateParser,
                     backgroundUploaderContext: backgroundUploaderContext,
                     webDavController: webDavController,
+                    iCloudController: iCloudController,
                     attachmentDownloader: attachmentDownloader,
                     syncDelayIntervals: [0, 1, 2, 3],
                     maxRetryCount: 4
@@ -104,6 +109,7 @@ final class WebDavControllerSpec: QuickSpec {
             var realm: Realm!
             var dbStorage: DbStorage!
             var webDavController: WebDavController!
+            var iCloudController: ICloudController!
             var downloader: AttachmentDownloader!
             var syncController: SyncController!
             var backgroundUploaderContext: BackgroundUploaderContext!
@@ -113,10 +119,13 @@ final class WebDavControllerSpec: QuickSpec {
                 dbStorage = RealmDbStorage(config: config)
                 realm = try! Realm(configuration: config)
                 webDavController = nil
+                iCloudController = nil
                 downloader = nil
                 syncController = nil
                 backgroundUploaderContext = nil
                 disposeBag = DisposeBag()
+                // Backend selection now keys off `fileSyncType` instead of the legacy `webDavEnabled` flag.
+                Defaults.shared.fileSyncType = .webDav
                 HTTPStubs.removeAllStubs()
             }
 


### PR DESCRIPTION
Adds **iCloud Drive** as a third attachment-file backend beside Zotero File Storage (ZFS) and WebDAV. Library data (items/collections/tags) still syncs through the Zotero API; iCloud only moves attachment bytes, keeping the desktop/WebDAV `<key>.zip` + `<key>.prop` layout so files are cross-client compatible.

## Design
- Selection keyed on `Defaults.fileSyncType` (`zotero`/`webDav`/`iCloud`), migrated from the old `webDavEnabled` binary.
- Thin `FileSyncBackend` protocol (`type`/`isVerified`/`verify`/`resetVerification`/`delete`) — both controllers conform. Upload/download transport stays **concrete per backend**: WebDAV/ZFS use the background `URLSession`; iCloud uses the OS ubiquity daemon via `NSFileCoordinator`/`NSMetadataQuery`. Unifying those would regress background transfer, so call sites branch on `FileSyncType`.
- `iCloud` backs My Library only; group libraries always use ZFS.

## New files
- `Models/FileSyncType.swift`
- `Controllers/FileStorage/FileSyncBackend.swift` — protocol + provider
- `Controllers/FileStorage/ICloudTransport.swift` — `NSFileCoordinator`/`NSMetadataQuery` helper (container resolve, coordinated read/write, evicted-file materialization w/ progress + timeout, list, delete)
- `Controllers/FileStorage/ICloudController.swift` — backend impl + orphan purge

All four are members of **both** the Zotero app and ZShare extension targets.

## Integration
`UploadAttachmentSyncAction` (new `iCloudResult`), `AttachmentDownloader` (new non-`URLSession` iCloud download path), `ExtensionViewModel` (`uploadToICloud`), `AttachmentCreator`, `SyncController`, `AppDelegate` cleanup, `DeleteWebDavFilesSyncAction` (routes to active backend), DI in `Controllers`/`ShareViewController`, settings picker + Verify UI, ZShare iCloud entitlement, L10n strings. `WebDavDeletionResult` is now a typealias of `FileDeletionResult`.

## Reviewer notes / not yet verified
- **Not compiled** — authored without a local Xcode build. `project.pbxproj` edited by hand (plist-lint passes); confirm the 4 new files appear in both targets.
- **Signing** — the iCloud capability/container `iCloud.org.zotero.ios.Zotero` must be on the **ZShare target** (the app target already had it). Entitlements files are updated but Xcode capability UI / provisioning profiles are not.
- Highest runtime-risk areas: the `AttachmentDownloader` iCloud materialization branch and share-extension iCloud upload.
- `ICloudController.purgeOrphans` exists but is not auto-wired into sync yet (optional Phase 3); eviction-after-download not added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)