### PR TITLE
Update reader

### DIFF
--- a/Zotero/Models/Appearance.swift
+++ b/Zotero/Models/Appearance.swift
@@ -40,11 +40,34 @@ enum Appearance {
         case .dark:
             return "dark"
 
+        case .light, .sepia:
+            return "light"
+        }
+    }
+
+    var htmlEpubTheme: String? {
+        switch self {
+        case .sepia:
+            return "sepia"
+
         case .light:
             return "light"
 
+        case .dark:
+            return "dark"
+        }
+    }
+
+    var htmlEpubThemeColor: UIColor {
+        switch self {
+        case .light:
+            return .white
+
+        case .dark:
+            return UIColor(red: 46 / 255, green: 52 / 255, blue: 64 / 255, alpha: 1)
+
         case .sepia:
-            return "sepia"
+            return UIColor(red: 244 / 255, green: 236 / 255, blue: 216 / 255, alpha: 1)
         }
     }
 }

--- a/Zotero/Models/Appearance.swift
+++ b/Zotero/Models/Appearance.swift
@@ -45,7 +45,7 @@ enum Appearance {
         }
     }
 
-    var htmlEpubTheme: String? {
+    var htmlEpubTheme: String {
         switch self {
         case .sepia:
             return "sepia"
@@ -55,6 +55,16 @@ enum Appearance {
 
         case .dark:
             return "dark"
+        }
+    }
+
+    var htmlEpubThemeOption: String {
+        switch self {
+        case .dark:
+            return "darkTheme: '\(htmlEpubTheme)'"
+
+        case .light, .sepia:
+            return "lightTheme: '\(htmlEpubTheme)'"
         }
     }
 

--- a/Zotero/Scenes/Detail/HTML:EPUB/Views/HtmlEpubDocumentViewController.swift
+++ b/Zotero/Scenes/Detail/HTML:EPUB/Views/HtmlEpubDocumentViewController.swift
@@ -75,8 +75,10 @@ class HtmlEpubDocumentViewController: UIViewController {
 
             let configuration = WKWebViewConfiguration()
             configuration.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
+            configuration.userContentController.addUserScript(colorSchemeUserScript(appearanceMode: viewModel.state.settings.appearance, userInterfaceStyle: viewModel.state.interfaceStyle))
             let webView = HtmlEpubWebView(customMenuActions: [highlightAction, underlineAction], configuration: configuration)
             webView.translatesAutoresizingMaskIntoConstraints = false
+            webView.isOpaque = false
             webView.scrollView.contentInsetAdjustmentBehavior = .never
             if #available(iOS 16.4, *) {
                 webView.isInspectable = true
@@ -93,6 +95,86 @@ class HtmlEpubDocumentViewController: UIViewController {
             webViewHandler = WebViewHandler(webView: webView, javascriptHandlers: JSHandlers.allCases.map({ $0.rawValue }))
             webViewHandler.receivedMessageHandler = { [weak self] handler, message in
                 self?.process(handler: handler, message: message)
+            }
+
+            func colorSchemeUserScript(appearanceMode: ReaderSettingsState.Appearance, userInterfaceStyle: UIUserInterfaceStyle) -> WKUserScript {
+                let colorScheme = Appearance.from(appearanceMode: appearanceMode, interfaceStyle: userInterfaceStyle).htmlEpubValue
+                let source = """
+                    (() => {
+                        const nativeMatchMedia = window.matchMedia.bind(window);
+                        const colorSchemeQuery = /^\\(\\s*prefers-color-scheme\\s*:\\s*(dark|light)\\s*\\)$/;
+                        let forcedColorScheme = '\(colorScheme)';
+                        const mediaQueryLists = new Set();
+
+                        function notify(list) {
+                            const event = { type: 'change', media: list.media, matches: list.matches };
+                            if (typeof list.onchange === 'function') {
+                                list.onchange(event);
+                            }
+                            list.__listeners.forEach(listener => {
+                                if (typeof listener === 'function') {
+                                    listener(event);
+                                }
+                                else if (listener && typeof listener.handleEvent === 'function') {
+                                    listener.handleEvent(event);
+                                }
+                            });
+                        }
+
+                        window.__zoteroSetForcedColorScheme = scheme => {
+                            if (forcedColorScheme === scheme) {
+                                return;
+                            }
+                            const previousMatches = new Map(Array.from(mediaQueryLists, list => [list, list.matches]));
+                            forcedColorScheme = scheme;
+                            mediaQueryLists.forEach(list => {
+                                if (previousMatches.get(list) !== list.matches) {
+                                    notify(list);
+                                }
+                            });
+                        };
+
+                        window.matchMedia = query => {
+                            const match = typeof query === 'string' ? query.match(colorSchemeQuery) : null;
+                            if (!match) {
+                                return nativeMatchMedia(query);
+                            }
+
+                            const scheme = match[1];
+                            const list = {
+                                media: query,
+                                onchange: null,
+                                __listeners: new Set(),
+                                get matches() {
+                                    return forcedColorScheme === scheme;
+                                },
+                                addEventListener(type, listener) {
+                                    if (type === 'change') {
+                                        this.__listeners.add(listener);
+                                    }
+                                },
+                                removeEventListener(type, listener) {
+                                    if (type === 'change') {
+                                        this.__listeners.delete(listener);
+                                    }
+                                },
+                                addListener(listener) {
+                                    this.addEventListener('change', listener);
+                                },
+                                removeListener(listener) {
+                                    this.removeEventListener('change', listener);
+                                },
+                                dispatchEvent(event) {
+                                    notify(this);
+                                    return true;
+                                }
+                            };
+                            mediaQueryLists.add(list);
+                            return list;
+                        };
+                    })();
+                    """
+                return WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false)
             }
         }
     }
@@ -117,6 +199,7 @@ class HtmlEpubDocumentViewController: UIViewController {
 
     private func process(state: HtmlEpubReaderState) {
         if state.changes.contains(.readerInitialised) {
+            setWebViewInterfaceStyle(to: state.settings.appearance, userInterfaceStyle: state.interfaceStyle)
             webViewHandler.load(fileUrl: state.readerFile.createUrl()).subscribe().disposed(by: disposeBag)
             return
         }
@@ -186,6 +269,8 @@ class HtmlEpubDocumentViewController: UIViewController {
         func load(documentData data: HtmlEpubReaderState.DocumentData) {
             DDLogInfo("HtmlEpubDocumentViewController: try creating view for \(data.type); page = \(String(describing: data.page))")
             DDLogInfo("URL: \(data.url.absoluteString)")
+            let appearance = Appearance.from(appearanceMode: state.settings.appearance, interfaceStyle: state.interfaceStyle)
+            setWebViewInterfaceStyle(to: state.settings.appearance, userInterfaceStyle: state.interfaceStyle)
             var javascript = "createView({ type: '\(data.type)', url: '\(data.url.absoluteString.replacingOccurrences(of: "'", with: #"\'"#))', annotations: \(data.annotationsJson)"
             if let key = data.selectedAnnotationKey {
                 javascript += ", location: {annotationID: '\(key)'}"
@@ -199,6 +284,7 @@ class HtmlEpubDocumentViewController: UIViewController {
                 }
             }
             javascript += "});"
+            javascript += deferredAppearanceJavascript(for: appearance)
 
             webViewHandler.call(javascript: javascript)
                 .observe(on: MainScheduler.instance)
@@ -206,10 +292,46 @@ class HtmlEpubDocumentViewController: UIViewController {
                     DDLogError("HtmlEpubDocumentViewController: loading document failed - \(error)")
                 })
                 .disposed(by: disposeBag)
+
+            func deferredAppearanceJavascript(for appearance: Appearance) -> String {
+                return """
+                    (() => {
+                        let attempts = 0;
+                        const apply = () => {
+                            attempts += 1;
+                            try {
+                                \(appearanceJavascript(for: appearance))
+                            }
+                            catch (error) {
+                                if (attempts < 100) {
+                                    setTimeout(apply, 20);
+                                }
+                            }
+                        };
+                        apply();
+                    })();
+                    """
+            }
         }
     }
 
     private func updateInterface(to appearanceMode: ReaderSettingsState.Appearance, userInterfaceStyle: UIUserInterfaceStyle) {
+        setWebViewInterfaceStyle(to: appearanceMode, userInterfaceStyle: userInterfaceStyle)
+        let appearance = Appearance.from(appearanceMode: appearanceMode, interfaceStyle: userInterfaceStyle)
+        webView.call(javascript: appearanceJavascript(for: appearance)).subscribe().disposed(by: disposeBag)
+    }
+
+    private func appearanceJavascript(for appearance: Appearance) -> String {
+        let theme = appearance.htmlEpubTheme
+        var javascript = "window._view.setColorScheme('\(appearance.htmlEpubValue)');"
+        if let theme {
+            javascript += "window._view.setTheme('\(theme)');"
+        }
+        return javascript
+    }
+
+    private func setWebViewInterfaceStyle(to appearanceMode: ReaderSettingsState.Appearance, userInterfaceStyle: UIUserInterfaceStyle) {
+        let appearance = Appearance.from(appearanceMode: appearanceMode, interfaceStyle: userInterfaceStyle)
         switch appearanceMode {
         case .automatic:
             webView.overrideUserInterfaceStyle = userInterfaceStyle
@@ -220,8 +342,18 @@ class HtmlEpubDocumentViewController: UIViewController {
         case .dark:
             webView.overrideUserInterfaceStyle = .dark
         }
-        let appearanceString = Appearance.from(appearanceMode: appearanceMode, interfaceStyle: userInterfaceStyle).htmlEpubValue
-        webView.call(javascript: "window._view.setColorScheme('\(appearanceString)');").subscribe().disposed(by: disposeBag)
+        setReaderBackgroundColor(appearance.htmlEpubThemeColor)
+        setForcedColorScheme(to: appearance.htmlEpubValue)
+
+        func setReaderBackgroundColor(_ color: UIColor) {
+            view.backgroundColor = color
+            webView?.backgroundColor = color
+            webView?.scrollView.backgroundColor = color
+        }
+
+        func setForcedColorScheme(to colorScheme: String) {
+            webView?.evaluateJavaScript("window.__zoteroSetForcedColorScheme && window.__zoteroSetForcedColorScheme('\(colorScheme)');", completionHandler: nil)
+        }
     }
 
     private func set(tool data: (AnnotationTool, UIColor)?) {

--- a/Zotero/Scenes/Detail/HTML:EPUB/Views/HtmlEpubDocumentViewController.swift
+++ b/Zotero/Scenes/Detail/HTML:EPUB/Views/HtmlEpubDocumentViewController.swift
@@ -75,7 +75,6 @@ class HtmlEpubDocumentViewController: UIViewController {
 
             let configuration = WKWebViewConfiguration()
             configuration.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
-            configuration.userContentController.addUserScript(colorSchemeUserScript(appearanceMode: viewModel.state.settings.appearance, userInterfaceStyle: viewModel.state.interfaceStyle))
             let webView = HtmlEpubWebView(customMenuActions: [highlightAction, underlineAction], configuration: configuration)
             webView.translatesAutoresizingMaskIntoConstraints = false
             webView.isOpaque = false
@@ -95,86 +94,6 @@ class HtmlEpubDocumentViewController: UIViewController {
             webViewHandler = WebViewHandler(webView: webView, javascriptHandlers: JSHandlers.allCases.map({ $0.rawValue }))
             webViewHandler.receivedMessageHandler = { [weak self] handler, message in
                 self?.process(handler: handler, message: message)
-            }
-
-            func colorSchemeUserScript(appearanceMode: ReaderSettingsState.Appearance, userInterfaceStyle: UIUserInterfaceStyle) -> WKUserScript {
-                let colorScheme = Appearance.from(appearanceMode: appearanceMode, interfaceStyle: userInterfaceStyle).htmlEpubValue
-                let source = """
-                    (() => {
-                        const nativeMatchMedia = window.matchMedia.bind(window);
-                        const colorSchemeQuery = /^\\(\\s*prefers-color-scheme\\s*:\\s*(dark|light)\\s*\\)$/;
-                        let forcedColorScheme = '\(colorScheme)';
-                        const mediaQueryLists = new Set();
-
-                        function notify(list) {
-                            const event = { type: 'change', media: list.media, matches: list.matches };
-                            if (typeof list.onchange === 'function') {
-                                list.onchange(event);
-                            }
-                            list.__listeners.forEach(listener => {
-                                if (typeof listener === 'function') {
-                                    listener(event);
-                                }
-                                else if (listener && typeof listener.handleEvent === 'function') {
-                                    listener.handleEvent(event);
-                                }
-                            });
-                        }
-
-                        window.__zoteroSetForcedColorScheme = scheme => {
-                            if (forcedColorScheme === scheme) {
-                                return;
-                            }
-                            const previousMatches = new Map(Array.from(mediaQueryLists, list => [list, list.matches]));
-                            forcedColorScheme = scheme;
-                            mediaQueryLists.forEach(list => {
-                                if (previousMatches.get(list) !== list.matches) {
-                                    notify(list);
-                                }
-                            });
-                        };
-
-                        window.matchMedia = query => {
-                            const match = typeof query === 'string' ? query.match(colorSchemeQuery) : null;
-                            if (!match) {
-                                return nativeMatchMedia(query);
-                            }
-
-                            const scheme = match[1];
-                            const list = {
-                                media: query,
-                                onchange: null,
-                                __listeners: new Set(),
-                                get matches() {
-                                    return forcedColorScheme === scheme;
-                                },
-                                addEventListener(type, listener) {
-                                    if (type === 'change') {
-                                        this.__listeners.add(listener);
-                                    }
-                                },
-                                removeEventListener(type, listener) {
-                                    if (type === 'change') {
-                                        this.__listeners.delete(listener);
-                                    }
-                                },
-                                addListener(listener) {
-                                    this.addEventListener('change', listener);
-                                },
-                                removeListener(listener) {
-                                    this.removeEventListener('change', listener);
-                                },
-                                dispatchEvent(event) {
-                                    notify(this);
-                                    return true;
-                                }
-                            };
-                            mediaQueryLists.add(list);
-                            return list;
-                        };
-                    })();
-                    """
-                return WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false)
             }
         }
     }
@@ -271,7 +190,7 @@ class HtmlEpubDocumentViewController: UIViewController {
             DDLogInfo("URL: \(data.url.absoluteString)")
             let appearance = Appearance.from(appearanceMode: state.settings.appearance, interfaceStyle: state.interfaceStyle)
             setWebViewInterfaceStyle(to: state.settings.appearance, userInterfaceStyle: state.interfaceStyle)
-            var javascript = "createView({ type: '\(data.type)', url: '\(data.url.absoluteString.replacingOccurrences(of: "'", with: #"\'"#))', annotations: \(data.annotationsJson)"
+            var javascript = "createView({ type: '\(data.type)', url: '\(data.url.absoluteString.replacingOccurrences(of: "'", with: #"\'"#))', annotations: \(data.annotationsJson), colorScheme: '\(appearance.htmlEpubValue)', \(appearance.htmlEpubThemeOption)"
             if let key = data.selectedAnnotationKey {
                 javascript += ", location: {annotationID: '\(key)'}"
             } else if let page = data.page {
@@ -284,7 +203,6 @@ class HtmlEpubDocumentViewController: UIViewController {
                 }
             }
             javascript += "});"
-            javascript += deferredAppearanceJavascript(for: appearance)
 
             webViewHandler.call(javascript: javascript)
                 .observe(on: MainScheduler.instance)
@@ -292,26 +210,6 @@ class HtmlEpubDocumentViewController: UIViewController {
                     DDLogError("HtmlEpubDocumentViewController: loading document failed - \(error)")
                 })
                 .disposed(by: disposeBag)
-
-            func deferredAppearanceJavascript(for appearance: Appearance) -> String {
-                return """
-                    (() => {
-                        let attempts = 0;
-                        const apply = () => {
-                            attempts += 1;
-                            try {
-                                \(appearanceJavascript(for: appearance))
-                            }
-                            catch (error) {
-                                if (attempts < 100) {
-                                    setTimeout(apply, 20);
-                                }
-                            }
-                        };
-                        apply();
-                    })();
-                    """
-            }
         }
     }
 
@@ -319,15 +217,10 @@ class HtmlEpubDocumentViewController: UIViewController {
         setWebViewInterfaceStyle(to: appearanceMode, userInterfaceStyle: userInterfaceStyle)
         let appearance = Appearance.from(appearanceMode: appearanceMode, interfaceStyle: userInterfaceStyle)
         webView.call(javascript: appearanceJavascript(for: appearance)).subscribe().disposed(by: disposeBag)
-    }
 
-    private func appearanceJavascript(for appearance: Appearance) -> String {
-        let theme = appearance.htmlEpubTheme
-        var javascript = "window._view.setColorScheme('\(appearance.htmlEpubValue)');"
-        if let theme {
-            javascript += "window._view.setTheme('\(theme)');"
+        func appearanceJavascript(for appearance: Appearance) -> String {
+            return "window._view.setColorScheme('\(appearance.htmlEpubValue)');window._view.setTheme('\(appearance.htmlEpubTheme)');"
         }
-        return javascript
     }
 
     private func setWebViewInterfaceStyle(to appearanceMode: ReaderSettingsState.Appearance, userInterfaceStyle: UIUserInterfaceStyle) {
@@ -343,16 +236,11 @@ class HtmlEpubDocumentViewController: UIViewController {
             webView.overrideUserInterfaceStyle = .dark
         }
         setReaderBackgroundColor(appearance.htmlEpubThemeColor)
-        setForcedColorScheme(to: appearance.htmlEpubValue)
 
         func setReaderBackgroundColor(_ color: UIColor) {
             view.backgroundColor = color
             webView?.backgroundColor = color
             webView?.scrollView.backgroundColor = color
-        }
-
-        func setForcedColorScheme(to colorScheme: String) {
-            webView?.evaluateJavaScript("window.__zoteroSetForcedColorScheme && window.__zoteroSetForcedColorScheme('\(colorScheme)');", completionHandler: nil)
         }
     }
 

--- a/Zotero/Scenes/Detail/HTML:EPUB/Views/HtmlEpubDocumentViewController.swift
+++ b/Zotero/Scenes/Detail/HTML:EPUB/Views/HtmlEpubDocumentViewController.swift
@@ -23,11 +23,18 @@ class HtmlEpubDocumentViewController: UIViewController {
 
     private weak var webView: WKWebView!
     private var webViewHandler: WebViewHandler!
+    var containerInsets: NSDirectionalEdgeInsets? {
+        didSet {
+            applyContainerInsetsIfInitialized()
+        }
+    }
+    private var isReaderInitialized: Bool
     weak var parentDelegate: HtmlEpubReaderContainerDelegate?
 
     init(viewModel: ViewModel<HtmlEpubReaderActionHandler>) {
         self.viewModel = viewModel
         disposeBag = DisposeBag()
+        isReaderInitialized = false
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -70,13 +77,14 @@ class HtmlEpubDocumentViewController: UIViewController {
             configuration.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
             let webView = HtmlEpubWebView(customMenuActions: [highlightAction, underlineAction], configuration: configuration)
             webView.translatesAutoresizingMaskIntoConstraints = false
+            webView.scrollView.contentInsetAdjustmentBehavior = .never
             if #available(iOS 16.4, *) {
                 webView.isInspectable = true
             }
             view.addSubview(webView)
 
             NSLayoutConstraint.activate([
-                view.safeAreaLayoutGuide.topAnchor.constraint(equalTo: webView.topAnchor),
+                view.topAnchor.constraint(equalTo: webView.topAnchor),
                 view.bottomAnchor.constraint(equalTo: webView.bottomAnchor),
                 view.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: webView.leadingAnchor),
                 view.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: webView.trailingAnchor)
@@ -239,6 +247,17 @@ class HtmlEpubDocumentViewController: UIViewController {
         webViewHandler.call(javascript: "setTool({ type: '\(toolName)', color: '\(color.hexString)' });").subscribe().disposed(by: disposeBag)
     }
 
+    private func applyContainerInsetsIfInitialized() {
+        guard let containerInsets, isReaderInitialized else { return }
+        let javascript = "setContainerInsets({ top: \(containerInsets.top), right: \(containerInsets.trailing), bottom: \(containerInsets.bottom), left: \(containerInsets.leading) });"
+        webViewHandler.call(javascript: javascript)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onFailure: { error in
+                DDLogError("HtmlEpubDocumentViewController: setting container insets failed - \(error)")
+            })
+            .disposed(by: disposeBag)
+    }
+
     private func process(handler: String, message: Any) {
         switch handler {
         case JSHandlers.log.rawValue:
@@ -254,6 +273,8 @@ class HtmlEpubDocumentViewController: UIViewController {
 
             switch event {
             case "onInitialized":
+                isReaderInitialized = true
+                applyContainerInsetsIfInitialized()
                 viewModel.process(action: .loadDocument)
 
             case "onSaveAnnotations":
@@ -279,8 +300,8 @@ class HtmlEpubDocumentViewController: UIViewController {
                     return
                 }
 
-                let navigationBarInset = (parentDelegate?.statusBarHeight ?? 0) + (parentDelegate?.navigationBarHeight ?? 0)
-                let rect = CGRect(x: rectArray[0], y: rectArray[1] + navigationBarInset, width: rectArray[2] - rectArray[0], height: rectArray[3] - rectArray[1])
+                let topInset = parentDelegate?.containerTopInset ?? 0
+                let rect = CGRect(x: rectArray[0], y: rectArray[1] + topInset, width: rectArray[2] - rectArray[0], height: rectArray[3] - rectArray[1])
                 viewModel.process(action: .showAnnotationPopover(key: key, rect: rect))
 
             case "onSelectAnnotations":

--- a/Zotero/Scenes/Detail/HTML:EPUB/Views/HtmlEpubReaderViewController.swift
+++ b/Zotero/Scenes/Detail/HTML:EPUB/Views/HtmlEpubReaderViewController.swift
@@ -12,8 +12,7 @@ import CocoaLumberjackSwift
 import RxSwift
 
 protocol HtmlEpubReaderContainerDelegate: AnyObject {
-    var statusBarHeight: CGFloat { get }
-    var navigationBarHeight: CGFloat { get }
+    var containerTopInset: CGFloat { get }
     var isSidebarVisible: Bool { get }
 
     func show(url: URL)
@@ -47,6 +46,12 @@ class HtmlEpubReaderViewController: UIViewController, ReaderViewController, Pare
     }
     private(set) var isCompactWidth: Bool
     var statusBarHeight: CGFloat
+    private var lastLayoutSize: CGSize?
+    private var lastContainerInsets: NSDirectionalEdgeInsets?
+    private var isChangingInterfaceVisibility: Bool
+    var containerTopInset: CGFloat {
+        return lastContainerInsets?.top ?? currentContainerInsets().top
+    }
     var key: String { return viewModel.state.key }
     
     weak var coordinatorDelegate: HtmlEpubReaderCoordinatorDelegate?
@@ -100,6 +105,7 @@ class HtmlEpubReaderViewController: UIViewController, ReaderViewController, Pare
         self.viewModel = viewModel
         isCompactWidth = compactSize
         disposeBag = DisposeBag()
+        isChangingInterfaceVisibility = false
         statusBarHeight = UIApplication
             .shared
             .connectedScenes
@@ -260,6 +266,7 @@ class HtmlEpubReaderViewController: UIViewController, ReaderViewController, Pare
     override func viewIsAppearing(_ animated: Bool) {
         super.viewIsAppearing(animated)
         annotationToolbarHandler?.viewIsAppearing(editingEnabled: viewModel.state.library.metadataEditable)
+        updateContainerInsets(force: true)
     }
 
     deinit {
@@ -270,6 +277,14 @@ class HtmlEpubReaderViewController: UIViewController, ReaderViewController, Pare
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+
+        let layoutSize = view.bounds.size
+        let isSizeChange = lastLayoutSize != layoutSize
+        lastLayoutSize = layoutSize
+        updateStatusBarHeight(allowZero: isSizeChange)
+        if isSizeChange || !isChangingInterfaceVisibility || isTopToolbarVisible(forToolbarState: toolbarState) {
+            updateContainerInsets()
+        }
 
         guard let documentController else { return }
 
@@ -287,9 +302,14 @@ class HtmlEpubReaderViewController: UIViewController, ReaderViewController, Pare
 
         coordinator.animate(alongsideTransition: { [weak self] _ in
             guard let self else { return }
-            statusBarHeight = view.safeAreaInsets.top - (navigationController?.isNavigationBarHidden == true ? 0 : navigationBarHeight)
+            updateStatusBarHeight(allowZero: true)
             annotationToolbarHandler?.viewWillTransitionToNewSize()
-        }, completion: nil)
+            updateContainerInsets(force: true)
+        }, completion: { [weak self] _ in
+            guard let self else { return }
+            updateStatusBarHeight(allowZero: true)
+            updateContainerInsets(force: true)
+        })
     }
 
     override var prefersStatusBarHidden: Bool {
@@ -472,6 +492,33 @@ class HtmlEpubReaderViewController: UIViewController, ReaderViewController, Pare
         navigationController?.presentingViewController?.dismiss(animated: true)
     }
 
+    private func updateStatusBarHeight(allowZero: Bool = false) {
+        guard let newStatusBarHeight = (view.scene as? UIWindowScene)?.statusBarManager?.statusBarFrame.height else { return }
+        let shouldUpdate = newStatusBarHeight > 0 || allowZero
+        guard shouldUpdate else { return }
+        statusBarHeight = newStatusBarHeight
+    }
+
+    private func currentContainerInsets(forToolbarState state: AnnotationToolbarHandler.State? = nil) -> NSDirectionalEdgeInsets {
+        let state = state ?? toolbarState
+        let toolbarHeight = isTopToolbarVisible(forToolbarState: state) ? (annotationToolbarController?.size ?? 0) : 0
+        let top = statusBarHeight + navigationBarHeight + toolbarHeight
+
+        return NSDirectionalEdgeInsets(top: top, leading: 0, bottom: 0, trailing: 0)
+    }
+
+    private func isTopToolbarVisible(forToolbarState state: AnnotationToolbarHandler.State) -> Bool {
+        return state.visible && viewModel.state.library.metadataEditable && state.position == .top
+    }
+
+    private func updateContainerInsets(forToolbarState state: AnnotationToolbarHandler.State? = nil, force: Bool = false) {
+        let insets = currentContainerInsets(forToolbarState: state)
+        guard force || (insets != lastContainerInsets) else { return }
+
+        lastContainerInsets = insets
+        documentController?.containerInsets = insets
+    }
+
     private func createRightBarButtonItems() -> [UIBarButtonItem] {
         var buttons = [settingsButton, searchButton]
         if viewModel.state.library.metadataEditable {
@@ -521,27 +568,15 @@ extension HtmlEpubReaderViewController: AnnotationToolbarHandlerDelegate {
     }
     
     func annotationToolbarWillChange(state: AnnotationToolbarHandler.State, statusBarVisible: Bool) {
+        updateContainerInsets(forToolbarState: state)
     }
 
     func topDidChange(forToolbarState state: AnnotationToolbarHandler.State) {
-        guard let annotationToolbarHandler, let annotationToolbarController else { return }
-        let (statusBarOffset, _, totalOffset) = annotationToolbarHandler.topOffsets(statusBarVisible: statusBarVisible)
-
-        if !state.visible {
-            documentControllerTop.constant = totalOffset
+        documentControllerTop.constant = 0
+        if isChangingInterfaceVisibility && !isTopToolbarVisible(forToolbarState: state) {
             return
         }
-
-        switch state.position {
-        case .pinned:
-            documentControllerTop.constant = statusBarOffset + annotationToolbarController.size
-
-        case .top:
-            documentControllerTop.constant = totalOffset + annotationToolbarController.size
-
-        case .trailing, .leading:
-            documentControllerTop.constant = totalOffset
-        }
+        updateContainerInsets(forToolbarState: state)
     }
 
     func updateStatusBar() {
@@ -613,8 +648,12 @@ extension HtmlEpubReaderViewController: HtmlEpubReaderContainerDelegate {
             navigationController?.navigationBar.alpha = 0
         }
 
+        isChangingInterfaceVisibility = true
         statusBarVisible = !isHidden
         annotationToolbarHandler?.interfaceVisibilityDidChange()
+        if isTopToolbarVisible(forToolbarState: toolbarState) {
+            updateContainerInsets(force: true)
+        }
 
         UIView.animate(withDuration: 0.15, animations: { [weak self] in
             guard let self else { return }
@@ -627,6 +666,15 @@ extension HtmlEpubReaderViewController: HtmlEpubReaderContainerDelegate {
             applyPageIndicator(navBarHidden: isHidden)
             view.layoutIfNeeded()
             annotationToolbarHandler?.interfaceVisibilityDidChange()
+            if isTopToolbarVisible(forToolbarState: toolbarState) {
+                updateContainerInsets(force: true)
+            }
+        }, completion: { [weak self] _ in
+            guard let self else { return }
+            isChangingInterfaceVisibility = false
+            if isTopToolbarVisible(forToolbarState: toolbarState) {
+                updateContainerInsets(force: true)
+            }
         })
 
         if isHidden && isSidebarVisible {

--- a/Zotero/Scenes/Detail/HTML:EPUB/Views/HtmlEpubReaderViewController.swift
+++ b/Zotero/Scenes/Detail/HTML:EPUB/Views/HtmlEpubReaderViewController.swift
@@ -93,7 +93,13 @@ class HtmlEpubReaderViewController: UIViewController, ReaderViewController, Pare
         search.rx.tap
             .subscribe(onNext: { [weak self] _ in
                 guard let self, let documentController else { return }
-                coordinatorDelegate?.showSearch(viewModel: viewModel, documentController: documentController, text: nil, sender: searchButton, userInterfaceStyle: viewModel.state.interfaceStyle)
+                coordinatorDelegate?.showSearch(
+                    viewModel: viewModel,
+                    documentController: documentController,
+                    text: nil,
+                    sender: searchButton,
+                    userInterfaceStyle: presentedUserInterfaceStyle(for: viewModel.state.settings.appearance)
+                )
             })
             .disposed(by: disposeBag)
         return search
@@ -293,6 +299,12 @@ class HtmlEpubReaderViewController: UIViewController, ReaderViewController, Pare
         }
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) else { return }
+        viewModel.process(action: .userInterfaceStyleChanged(currentSystemUserInterfaceStyle))
+    }
+
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
@@ -461,16 +473,44 @@ class HtmlEpubReaderViewController: UIViewController, ReaderViewController, Pare
     // MARK: - Actions
 
     private func updateInterface(to settings: HtmlEpubSettings) {
-        switch settings.appearance {
+        navigationController?.overrideUserInterfaceStyle = readerUserInterfaceStyle(for: settings.appearance)
+        updatePresentedReaderInterface(to: settings)
+
+        func readerUserInterfaceStyle(for appearance: ReaderSettingsState.Appearance) -> UIUserInterfaceStyle {
+            switch appearance {
+            case .automatic:
+                return .unspecified
+
+            case .light, .sepia:
+                return .light
+
+            case .dark:
+                return .dark
+            }
+        }
+    }
+
+    private func presentedUserInterfaceStyle(for appearance: ReaderSettingsState.Appearance) -> UIUserInterfaceStyle {
+        switch appearance {
         case .automatic:
-            navigationController?.overrideUserInterfaceStyle = .unspecified
+            return currentSystemUserInterfaceStyle
 
         case .light, .sepia:
-            navigationController?.overrideUserInterfaceStyle = .light
+            return .light
 
         case .dark:
-            navigationController?.overrideUserInterfaceStyle = .dark
+            return .dark
         }
+    }
+
+    private func updatePresentedReaderInterface(to settings: HtmlEpubSettings) {
+        navigationController?.presentedViewController?.overrideUserInterfaceStyle = presentedUserInterfaceStyle(for: settings.appearance)
+    }
+
+    private var currentSystemUserInterfaceStyle: UIUserInterfaceStyle {
+        let windowSceneStyle = view.window?.windowScene?.traitCollection.userInterfaceStyle
+        let traitStyle = traitCollection.userInterfaceStyle
+        return windowSceneStyle ?? traitStyle
     }
 
     private func toggleSidebar(animated: Bool) {
@@ -478,12 +518,17 @@ class HtmlEpubReaderViewController: UIViewController, ReaderViewController, Pare
     }
 
     private func showSettings(sender: UIBarButtonItem) {
-        guard let viewModel = coordinatorDelegate?.showSettings(with: viewModel.state.settings, sender: sender) else { return }
-        viewModel.stateObservable
+        guard let settingsViewModel = coordinatorDelegate?.showSettings(with: viewModel.state.settings, sender: sender) else { return }
+        updatePresentedReaderInterface(to: viewModel.state.settings)
+        settingsViewModel.stateObservable
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] state in
+                guard let self else { return }
                 let settings = HtmlEpubSettings(appearance: state.appearance)
-                self?.viewModel.process(action: .setSettings(settings))
+                if settings.appearance == .automatic {
+                    self.viewModel.process(action: .userInterfaceStyleChanged(currentSystemUserInterfaceStyle))
+                }
+                self.viewModel.process(action: .setSettings(settings))
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
* Updates HTMl/Epub reader document top position, so contets are not re-rendered when transitioning reader to and from full screen. Also, only moving annotation toolbar from or to top position, will cause a re-render.
* Fixes sepia appearance mode and improves appearance transitions and use in pop up view controllers.
