### PR TITLE
Fix items toolbar filter button image in iOS 18

### DIFF
--- a/Zotero/Scenes/Detail/HTML:EPUB/Views/HtmlEpubAnnotationsViewController.swift
+++ b/Zotero/Scenes/Detail/HTML:EPUB/Views/HtmlEpubAnnotationsViewController.swift
@@ -351,8 +351,7 @@ class HtmlEpubAnnotationsViewController: UIViewController {
     private func setupToolbar(filterEnabled: Bool, filterOn: Bool, editingEnabled: Bool, deletionEnabled: Bool) {
         guard !toolbarContainer.isHidden else { return }
 
-        var items: [UIBarButtonItem] = []
-        items.append(UIBarButtonItem(systemItem: .flexibleSpace, primaryAction: nil, menu: nil))
+        var items: [UIBarButtonItem] = [.flexibleSpace()]
 
         if editingEnabled {
             let delete = UIBarButtonItem(title: L10n.delete, style: .plain, target: nil, action: nil)

--- a/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailViewController.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailViewController.swift
@@ -383,9 +383,7 @@ final class ItemDetailViewController: UIViewController {
                 func attachmentButtonItems(for state: MainAttachmentButtonState?) -> [UIBarButtonItem] {
                     guard let state else { return [] }
 
-                    let spacer = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
-                    spacer.width = 16
-                    var items: [UIBarButtonItem] = [spacer]
+                    var items: [UIBarButtonItem] = [.fixedSpace(16)]
 
                     switch state {
                     case .ready(let key), .error(let key, _):

--- a/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
+++ b/Zotero/Scenes/Detail/Items/ViewModels/ItemsToolbarController.swift
@@ -158,27 +158,27 @@ final class ItemsToolbarController {
                 .disposed(by: disposeBag)
                 return item
             })
-            let innerFlexibleSpace = UIBarButtonItem.flexibleSpace()
-            if #available(iOS 26.0, *) {
-                innerFlexibleSpace.hidesSharedBackground = false
-            }
             return [.flexibleSpace()] + items.enumerated().flatMap({ index, item in
-                [item, index < items.count - 1 ? innerFlexibleSpace : .flexibleSpace()]
+                [item, index < items.count - 1 ? createInnerFlexibleSpace() : .flexibleSpace()]
             })
+
+            func createInnerFlexibleSpace() -> UIBarButtonItem {
+                let flexibleSpace: UIBarButtonItem = .flexibleSpace()
+                if #available(iOS 26.0, *) {
+                    flexibleSpace.hidesSharedBackground = false
+                }
+                return flexibleSpace
+            }
         }
 
         func createNormalToolbarItems(for filters: [ItemsFilter]) -> [UIBarButtonItem] {
-            let fixedSpacer = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
-            fixedSpacer.width = 16
-            let flexibleSpacer = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+            let fixedSpaceWidth: CGFloat = 16
 
             let filterImageName = filters.isEmpty ? "line.horizontal.3.decrease.circle" : "line.horizontal.3.decrease.circle.fill"
-            let filterButton = UIBarButtonItem(image: UIImage(systemName: filterImageName), style: .plain, target: nil, action: nil)
+            let filterImage = UIImage(systemName: filterImageName)
+            let filterButton = UIBarButtonItem(image: filterImage, style: .plain, target: nil, action: nil)
             if isCompact {
-                filterButton.primaryAction = UIAction { [weak self, weak filterButton] _ in
-                    guard let filterButton else { return }
-                    self?.delegate?.showFilters(button: filterButton)
-                }
+                filterButton.primaryAction = createFilterPrimaryAction(image: filterImage)
             } else {
                 let downloadsFilterEnabled = data.filters.contains(where: { $0.isDownloadedFilesFilter })
                 filterButton.menu = createFilterMenu(downloadsFilterEnabled: downloadsFilterEnabled)
@@ -189,13 +189,14 @@ final class ItemsToolbarController {
             let titleButton = UIBarButtonItem(customView: createTitleView())
             titleButton.tag = ToolbarItem.title.tag
 
-            var items: [UIBarButtonItem] = [fixedSpacer, filterButton, flexibleSpacer, titleButton]
+            var items: [UIBarButtonItem] = [.fixedSpace(fixedSpaceWidth), filterButton, .flexibleSpace(), titleButton]
 
             if data.showsDocumentWorkerRecorder {
-                let documentWorkerButton = UIBarButtonItem(image: UIImage(systemName: "ladybug"), style: .plain, target: nil, action: nil)
-                documentWorkerButton.primaryAction = UIAction { [weak self, weak documentWorkerButton] _ in
-                    guard let documentWorkerButton else { return }
-                    self?.delegate?.showDocumentWorkerRecorder(button: documentWorkerButton)
+                let documentWorkerImage = UIImage(systemName: "ladybug")
+                let documentWorkerButton = UIBarButtonItem(image: documentWorkerImage, style: .plain, target: nil, action: nil)
+                documentWorkerButton.primaryAction = UIAction(image: documentWorkerImage) { [weak self] action in
+                    guard let button = action.sender as? UIBarButtonItem else { return }
+                    self?.delegate?.showDocumentWorkerRecorder(button: button)
                 }
                 documentWorkerButton.tag = ToolbarItem.documentWorkerRecorder.tag
                 documentWorkerButton.accessibilityLabel = "Document Worker"
@@ -207,9 +208,9 @@ final class ItemsToolbarController {
                 let sortButton = UIBarButtonItem(image: action.image, menu: createSortMenu(for: data.sortType))
                 sortButton.tag = ToolbarItem.sort.tag
                 sortButton.accessibilityLabel = L10n.Accessibility.Items.sortItems
-                items.append(contentsOf: [flexibleSpacer, sortButton, fixedSpacer])
+                items.append(contentsOf: [.flexibleSpace(), sortButton, .fixedSpace(fixedSpaceWidth)])
             } else {
-                items.append(contentsOf: [flexibleSpacer, fixedSpacer])
+                items.append(contentsOf: [.flexibleSpace(), .fixedSpace(fixedSpaceWidth)])
             }
 
             return items
@@ -283,6 +284,13 @@ final class ItemsToolbarController {
         return UIMenu(title: L10n.Items.Filters.title, children: [downloadsAction])
     }
 
+    private func createFilterPrimaryAction(image: UIImage?) -> UIAction {
+        return UIAction(image: image) { [weak self] action in
+            guard let button = action.sender as? UIBarButtonItem else { return }
+            self?.delegate?.showFilters(button: button)
+        }
+    }
+
     private func createSortMenu(for sortType: ItemsSortType) -> UIMenu {
         let ascendingAction = UIAction(title: L10n.Items.ascending, state: sortType.ascending ? .on : .off) { [weak self] _ in
             var newSortType = sortType
@@ -338,13 +346,11 @@ final class ItemsToolbarController {
 
         if let item = viewController.toolbarItems?.first(where: { $0.tag == ToolbarItem.filter.tag }) {
             let filterImageName = filters.isEmpty ? "line.horizontal.3.decrease.circle" : "line.horizontal.3.decrease.circle.fill"
-            item.image = UIImage(systemName: filterImageName)
+            let filterImage = UIImage(systemName: filterImageName)
+            item.image = filterImage
             if isCompact {
                 item.menu = nil
-                item.primaryAction = UIAction { [weak self, weak item] _ in
-                    guard let item else { return }
-                    self?.delegate?.showFilters(button: item)
-                }
+                item.primaryAction = createFilterPrimaryAction(image: filterImage)
             } else {
                 item.primaryAction = nil
                 let downloadsFilterEnabled = filters.contains(where: { $0.isDownloadedFilesFilter })

--- a/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
+++ b/Zotero/Scenes/Detail/Lookup/Views/ManualLookupViewController.swift
@@ -139,9 +139,6 @@ class ManualLookupViewController: UIViewController {
     private func setupCloseCancelAllBarButtons() {
         navigationItem.rightBarButtonItem = nil
 
-        let fixedSpacer = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
-        fixedSpacer.width = 16
-
         let closeItem = UIBarButtonItem(title: L10n.close, style: .plain, target: nil, action: nil)
         closeItem.rx.tap.subscribe(onNext: { [weak self] in
             guard let self else { return }
@@ -155,7 +152,7 @@ class ManualLookupViewController: UIViewController {
             self?.close()
         }).disposed(by: self.disposeBag)
 
-        navigationItem.leftBarButtonItems = [closeItem, fixedSpacer, cancelAllItem]
+        navigationItem.leftBarButtonItems = [closeItem, .fixedSpace(16), cancelAllItem]
     }
 
     private func setupCancelDoneBarButtons() {

--- a/Zotero/Scenes/Detail/PDF/Views/PDFAnnotationsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFAnnotationsViewController.swift
@@ -541,8 +541,7 @@ final class PDFAnnotationsViewController: UIViewController {
     private func setupToolbar(filterEnabled: Bool, filterOn: Bool, editingEnabled: Bool, deletionEnabled: Bool, mergingEnabled: Bool) {
         guard !toolbarContainer.isHidden else { return }
 
-        var items: [UIBarButtonItem] = []
-        items.append(UIBarButtonItem(systemItem: .flexibleSpace, primaryAction: nil, menu: nil))
+        var items: [UIBarButtonItem] = [.flexibleSpace()]
 
         if editingEnabled {
             let merge = UIBarButtonItem(title: L10n.Pdf.AnnotationsSidebar.merge, style: .plain, target: nil, action: nil)


### PR DESCRIPTION
Fixes issue reported in https://forums.zotero.org/discussion/132436/%D0%98schezli-na-ayfone-tegi-tags

* Fixes regression that made filter button not have an image in iOS 18.
* Modernizes all bar button item flexible and fixed space uses.

