### PR TITLE
Fix item details end editing crash when autocorrection is triggered

### DIFF
--- a/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailViewController.swift
+++ b/Zotero/Scenes/Detail/ItemDetail/Views/ItemDetailViewController.swift
@@ -345,8 +345,11 @@ final class ItemDetailViewController: UIViewController {
                     indicator.color = .gray
                     saveButton = UIBarButtonItem(customView: indicator)
                 } else {
-                    saveButton = UIBarButtonItem(systemItem: .done, primaryAction: UIAction { [weak viewModel] _ in
-                        viewModel?.process(action: .endEditing)
+                    saveButton = UIBarButtonItem(systemItem: .done, primaryAction: UIAction { [weak self] _ in
+                        self?.view.endEditing(true)
+                        DispatchQueue.main.async { [weak self] in
+                            self?.viewModel.process(action: .endEditing)
+                        }
                     })
                 }
                 navigationItem.rightBarButtonItem = saveButton


### PR DESCRIPTION
Fixes issue when saving item details and autocorrection makes a late change, due to debouncing, that causes an inconsistency exception. 
(not related to the `parentEnvironment` issue)