### PR TITLE
Improve PDF thumbnail generation

### DIFF
--- a/Zotero/Controllers/PDFThumbnailController.swift
+++ b/Zotero/Controllers/PDFThumbnailController.swift
@@ -244,10 +244,7 @@ extension PDFThumbnailController {
                 $0.key == key && $0.libraryId == libraryId && pageIndices.contains($0.page)
             })
             for requestKey in requestKeys {
-                if case .rendering(let task) = entries[requestKey]?.state {
-                    task.cancel()
-                }
-                entries[requestKey] = nil
+                cancel(requestKey: requestKey)
             }
 
             ioQueue.async { [weak self] in
@@ -280,10 +277,7 @@ extension PDFThumbnailController {
             return
         }
 
-        if case .rendering(let task) = entry.state {
-            task.cancel()
-        }
-        entries[requestKey] = nil
+        cancel(requestKey: requestKey)
     }
 
     private func deleteDiskCache(for documentKey: DocumentKey) {
@@ -293,12 +287,7 @@ extension PDFThumbnailController {
         })
 
         for requestKey in requestKeys {
-            guard let entry = entries[requestKey] else { continue }
-
-            if case .rendering(let task) = entry.state {
-                task.cancel()
-            }
-            entries[requestKey] = nil
+            cancel(requestKey: requestKey)
         }
 
         ioQueue.async { [weak self] in
@@ -340,6 +329,13 @@ extension PDFThumbnailController {
             }
             enqueue(entry: entry)
         }
+    }
+
+    private func cancel(requestKey: RequestKey) {
+        if case .rendering(let task) = entries[requestKey]?.state {
+            task.cancel()
+        }
+        entries[requestKey] = nil
     }
 
     /// Creates and enqueues a render request for PSPDFKit rendering engine.

--- a/Zotero/Controllers/PDFThumbnailController.swift
+++ b/Zotero/Controllers/PDFThumbnailController.swift
@@ -110,17 +110,6 @@ extension PDFThumbnailController {
         }
     }
 
-    /// Start rendering process of multiple thumbnails per document.
-    /// - parameter pages: Page indices which should be rendered.
-    func cache(pages: [UInt], key: String, libraryId: LibraryIdentifier, document: Document, imageSize: CGSize, appearance: Appearance) -> Observable<()> {
-        let observables = pages.map({
-            thumbnail(page: $0, key: key, libraryId: libraryId, document: document, imageSize: imageSize, appearance: appearance)
-                .map({ _ in () })
-                .asObservable()
-        })
-        return Observable.merge(observables)
-    }
-
     /// Loads a thumbnail from disk or renders and caches it if needed. Concurrent requests for the same thumbnail share one operation.
     func thumbnail(page: UInt, key: String, libraryId: LibraryIdentifier, document: Document, imageSize: CGSize, appearance: Appearance) -> Single<UIImage> {
         return Single.create { [weak self] subscriber -> Disposable in

--- a/Zotero/Controllers/PDFThumbnailController.swift
+++ b/Zotero/Controllers/PDFThumbnailController.swift
@@ -15,9 +15,15 @@ import RxSwift
 final class PDFThumbnailController: NSObject {
     enum Error: Swift.Error {
         case imageNotAvailable
+        case invalidImageData
     }
 
-    struct SubscriberKey: Hashable {
+    private struct DocumentKey: Hashable {
+        let key: String
+        let libraryId: LibraryIdentifier
+    }
+
+    private struct RequestKey: Hashable {
         let key: String
         let libraryId: LibraryIdentifier
         let page: UInt
@@ -25,18 +31,48 @@ final class PDFThumbnailController: NSObject {
         let appearance: Appearance
     }
 
-    private let queue: DispatchQueue
-    private let scheduler: SerialDispatchQueueScheduler
-    private unowned let fileStorage: FileStorage
+    private struct Request {
+        let key: RequestKey
+        let document: Document
+    }
 
-    private var subscribers: [SubscriberKey: (SingleEvent<UIImage>) -> Void]
+    private enum DiskLoadResult {
+        case image(UIImage)
+        case notFound
+        case unreadable(Swift.Error)
+    }
+
+    private struct Entry {
+        enum State {
+            case loadingFromDisk
+            case rendering(RenderTask)
+            case savingToDisk(UIImage)
+        }
+
+        let id: UUID
+        let request: Request
+        var state: State
+        var subscribers: [UUID: (SingleEvent<UIImage>) -> Void]
+    }
+
+    private let accessQueue: DispatchQueue
+    private let accessQueueKey: DispatchSpecificKey<Void>
+    private let ioQueue: DispatchQueue
+    private let scheduler: SerialDispatchQueueScheduler
+    private let fileStorage: FileStorage
+
+    private var entries: [RequestKey: Entry]
+    private var activeSessionCounts: [DocumentKey: Int]
 
     init(fileStorage: FileStorage) {
-        let queue = DispatchQueue(label: "org.zotero.PdfThumbnailController.queue", qos: .default)
+        accessQueue = DispatchQueue(label: "org.zotero.PDFThumbnailController.accessQueue", qos: .default)
+        accessQueueKey = DispatchSpecificKey<Void>()
+        accessQueue.setSpecific(key: accessQueueKey, value: ())
+        ioQueue = DispatchQueue(label: "org.zotero.PDFThumbnailController.ioQueue", qos: .default)
+        scheduler = SerialDispatchQueueScheduler(queue: accessQueue, internalSerialQueueName: "org.zotero.PDFThumbnailController.scheduler")
         self.fileStorage = fileStorage
-        subscribers = [:]
-        self.queue = queue
-        scheduler = SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: "org.zotero.PdfThumbnailController.scheduler")
+        entries = [:]
+        activeSessionCounts = [:]
         super.init()
     }
 }
@@ -44,70 +80,261 @@ final class PDFThumbnailController: NSObject {
 // MARK: - PSPDFKit
 
 extension PDFThumbnailController {
-    /// Start rendering process of multiple thumbnails per document.
-    /// - parameter pages: Page indices which should be rendered.
-    /// - parameter 
-    func cache(pages: [UInt], key: String, libraryId: LibraryIdentifier, document: Document, imageSize: CGSize, appearance: Appearance) -> Observable<()> {
-        let observables = pages.map({
-            cache(page: $0, key: key, libraryId: libraryId, document: document, imageSize: imageSize, appearance: appearance).flatMap({ _ in return Single.just(()) }).asObservable()
-        })
-        return Observable.merge(observables).subscribe(on: scheduler)
+    private func performOnAccessQueue<Result>(_ work: () -> Result) -> Result {
+        if DispatchQueue.getSpecific(key: accessQueueKey) != nil {
+            return work()
+        }
+        return accessQueue.sync(execute: work)
     }
 
-    func cache(page: UInt, key: String, libraryId: LibraryIdentifier, document: Document, imageSize: CGSize, appearance: Appearance) -> Single<UIImage> {
+    func start(forKey key: String, libraryId: LibraryIdentifier) {
+        performOnAccessQueue {
+            let documentKey = DocumentKey(key: key, libraryId: libraryId)
+            activeSessionCounts[documentKey, default: 0] += 1
+        }
+    }
+
+    func stop(forKey key: String, libraryId: LibraryIdentifier) {
+        accessQueue.async { [weak self] in
+            guard let self else { return }
+
+            let documentKey = DocumentKey(key: key, libraryId: libraryId)
+            guard activeSessionCounts[documentKey, default: 0] > 0 else {
+                DDLogWarn("PDFThumbnailController: ignored stop without active session; key=\(key); library=\(libraryId)")
+                return
+            }
+            activeSessionCounts[documentKey, default: 0] -= 1
+
+            guard activeSessionCounts[documentKey, default: 0] == 0 else { return }
+            deleteDiskCache(for: documentKey)
+        }
+    }
+
+    /// Start rendering process of multiple thumbnails per document.
+    /// - parameter pages: Page indices which should be rendered.
+    func cache(pages: [UInt], key: String, libraryId: LibraryIdentifier, document: Document, imageSize: CGSize, appearance: Appearance) -> Observable<()> {
+        let observables = pages.map({
+            thumbnail(page: $0, key: key, libraryId: libraryId, document: document, imageSize: imageSize, appearance: appearance)
+                .map({ _ in () })
+                .asObservable()
+        })
+        return Observable.merge(observables)
+    }
+
+    /// Loads a thumbnail from disk or renders and caches it if needed. Concurrent requests for the same thumbnail share one operation.
+    func thumbnail(page: UInt, key: String, libraryId: LibraryIdentifier, document: Document, imageSize: CGSize, appearance: Appearance) -> Single<UIImage> {
         return Single.create { [weak self] subscriber -> Disposable in
             guard let self else { return Disposables.create() }
-            dispatchPrecondition(condition: .onQueue(queue))
-            let subscriberKey = SubscriberKey(key: key, libraryId: libraryId, page: page, size: imageSize, appearance: appearance)
-            subscribers[subscriberKey] = subscriber
-            enqueue(subscriberKey: subscriberKey, document: document, imageSize: imageSize)
-            return Disposables.create()
+
+            let requestKey = RequestKey(key: key, libraryId: libraryId, page: page, size: imageSize, appearance: appearance)
+            let subscriberId = UUID()
+            performOnAccessQueue {
+                add(subscriber: subscriber, id: subscriberId, request: Request(key: requestKey, document: document))
+            }
+
+            return Disposables.create { [weak self] in
+                self?.accessQueue.async { [weak self] in
+                    self?.removeSubscriber(with: subscriberId, requestKey: requestKey)
+                }
+            }
         }
         .subscribe(on: scheduler)
+
+        func add(subscriber: @escaping (SingleEvent<UIImage>) -> Void, id subscriberId: UUID, request: Request) {
+            let documentKey = DocumentKey(key: request.key.key, libraryId: request.key.libraryId)
+            guard (activeSessionCounts[documentKey, default: 0]) > 0 else {
+                DDLogWarn("PDFThumbnailController: ignored request without active session; key=\(request.key.key); library=\(request.key.libraryId); page=\(request.key.page)")
+                return
+            }
+
+            if var entry = entries[request.key] {
+                switch entry.state {
+                case .loadingFromDisk:
+                    entry.subscribers[subscriberId] = subscriber
+                    entries[request.key] = entry
+
+                case .rendering:
+                    entry.subscribers[subscriberId] = subscriber
+                    entries[request.key] = entry
+
+                case .savingToDisk(let image):
+                    subscriber(.success(image))
+                }
+                return
+            }
+
+            let entry = Entry(
+                id: UUID(),
+                request: request,
+                state: .loadingFromDisk,
+                subscribers: [subscriberId: subscriber]
+            )
+            entries[request.key] = entry
+            loadFromDisk(requestKey: request.key, entryId: entry.id)
+
+            func loadFromDisk(requestKey: RequestKey, entryId: UUID) {
+                ioQueue.async { [weak self] in
+                    guard let self else { return }
+
+                    let file = Files.pageThumbnail(
+                        pageIndex: requestKey.page,
+                        key: requestKey.key,
+                        libraryId: requestKey.libraryId,
+                        appearance: requestKey.appearance
+                    )
+                    let result: DiskLoadResult
+                    if fileStorage.has(file) {
+                        do {
+                            let data = try fileStorage.read(file)
+                            if let image = UIImage(data: data) {
+                                result = .image(image)
+                            } else {
+                                result = .unreadable(Error.invalidImageData)
+                            }
+                        } catch let error {
+                            result = .unreadable(error)
+                        }
+                    } else {
+                        result = .notFound
+                    }
+                    accessQueue.async { [weak self] in
+                        self?.completeDiskLoad(with: result, requestKey: requestKey, entryId: entryId)
+                    }
+                }
+            }
+        }
     }
 
     /// Deletes cached thumbnails for given PDF document.
     /// - parameter key: Attachment item key.
     /// - parameter libraryId: Library identifier of item.
     func deleteAll(forKey key: String, libraryId: LibraryIdentifier) {
-        queue.async { [weak self] in
-            try? self?.fileStorage.remove(Files.pageThumbnails(for: key, libraryId: libraryId))
+        accessQueue.async { [weak self] in
+            guard let self else { return }
+
+            let documentKey = DocumentKey(key: key, libraryId: libraryId)
+            deleteDiskCache(for: documentKey)
         }
     }
 
-    /// Checks whether thumbnail is available for given page in document.
-    /// - parameter page: Page index..
-    /// - parameter key: Key of PDF item.
+    /// Deletes cached thumbnails for specific pages of a PDF document.
+    /// - parameter pages: Page indices to delete.
+    /// - parameter key: Attachment item key.
     /// - parameter libraryId: Library identifier of item.
-    /// - parameter isDark: `true` if dark mode is on, `false` otherwise.
-    /// - returns: `true` if thumbnail is available, `false` otherwise.
-    func hasThumbnail(page: UInt, key: String, libraryId: LibraryIdentifier, appearance: Appearance) -> Bool {
-        return fileStorage.has(Files.pageThumbnail(pageIndex: page, key: key, libraryId: libraryId, appearance: appearance))
+    func delete(pages: Set<Int>, forKey key: String, libraryId: LibraryIdentifier) {
+        let pageIndices = Set(pages.compactMap({ UInt(exactly: $0) }))
+        guard !pageIndices.isEmpty else { return }
+
+        accessQueue.async { [weak self] in
+            guard let self else { return }
+
+            let requestKeys = entries.keys.filter({
+                $0.key == key && $0.libraryId == libraryId && pageIndices.contains($0.page)
+            })
+            for requestKey in requestKeys {
+                if case .rendering(let task) = entries[requestKey]?.state {
+                    task.cancel()
+                }
+                entries[requestKey] = nil
+            }
+
+            ioQueue.async { [weak self] in
+                guard let self else { return }
+
+                for page in pageIndices {
+                    for appearance in [Appearance.light, .dark, .sepia] {
+                        do {
+                            try fileStorage.remove(
+                                Files.pageThumbnail(
+                                    pageIndex: page,
+                                    key: key,
+                                    libraryId: libraryId,
+                                    appearance: appearance
+                                )
+                            )
+                        } catch {
+                            DDLogError("PDFThumbnailController: can't delete cached page thumbnail; key=\(key); library=\(libraryId); page=\(page); appearance=\(appearance); error=\(error)")
+                        }
+                    }
+                }
+            }
+        }
     }
 
-    /// Loads thumbnail from cached file
-    /// - parameter page: Page index.
-    /// - parameter key: Key of PDF item.
-    /// - parameter libraryId: Library identifier of item.
-    /// - parameter isDark: `true` if dark mode is on, `false` otherwise.
-    /// - returns: UIImage of given page thumbnail.
-    func thumbnail(page: UInt, key: String, libraryId: LibraryIdentifier, appearance: Appearance) -> UIImage? {
-        do {
-            let data = try fileStorage.read(Files.pageThumbnail(pageIndex: page, key: key, libraryId: libraryId, appearance: appearance))
-            return try UIImage(imageData: data)
-        } catch let error {
-            DDLogError("PdfThumbnailController: can't load thumbnail - \(error)")
-            return nil
+    private func removeSubscriber(with subscriberId: UUID, requestKey: RequestKey) {
+        guard var entry = entries[requestKey], entry.subscribers.removeValue(forKey: subscriberId) != nil else { return }
+        guard entry.subscribers.isEmpty else {
+            entries[requestKey] = entry
+            return
+        }
+
+        if case .rendering(let task) = entry.state {
+            task.cancel()
+        }
+        entries[requestKey] = nil
+    }
+
+    private func deleteDiskCache(for documentKey: DocumentKey) {
+        // First invalidate any pending entries.
+        let requestKeys = entries.keys.filter({
+            $0.key == documentKey.key && $0.libraryId == documentKey.libraryId
+        })
+
+        for requestKey in requestKeys {
+            guard let entry = entries[requestKey] else { continue }
+
+            if case .rendering(let task) = entry.state {
+                task.cancel()
+            }
+            entries[requestKey] = nil
+        }
+
+        ioQueue.async { [weak self] in
+            guard let self else { return }
+
+            let thumbnails = Files.pageThumbnails(for: documentKey.key, libraryId: documentKey.libraryId)
+            guard fileStorage.has(thumbnails) else { return }
+            do {
+                try fileStorage.remove(thumbnails)
+            } catch {
+                DDLogError("PDFThumbnailController: can't delete disk cache; key=\(documentKey.key); library=\(documentKey.libraryId); error=\(error)")
+            }
+        }
+    }
+
+    private func completeDiskLoad(with result: DiskLoadResult, requestKey: RequestKey, entryId: UUID) {
+        guard let entry = entries[requestKey], entry.id == entryId else { return }
+
+        switch result {
+        case .image(let image):
+            entries[requestKey] = nil
+            perform(event: .success(image), subscribers: entry.subscribers)
+
+        case .notFound:
+            enqueue(entry: entry)
+
+        case .unreadable(let error):
+            DDLogWarn("PDFThumbnailController: can't load cached thumbnail; key=\(requestKey.key); library=\(requestKey.libraryId); page=\(requestKey.page); error=\(error)")
+            ioQueue.async { [weak self] in
+                guard let self else { return }
+                try? fileStorage.remove(
+                    Files.pageThumbnail(
+                        pageIndex: requestKey.page,
+                        key: requestKey.key,
+                        libraryId: requestKey.libraryId,
+                        appearance: requestKey.appearance
+                    )
+                )
+            }
+            enqueue(entry: entry)
         }
     }
 
     /// Creates and enqueues a render request for PSPDFKit rendering engine.
-    /// - parameter subscriberKey: Subscriber key identifying this request.
-    /// - parameter document: Document to render.
-    /// - parameter imageSize: Size of rendered image.
-    private func enqueue(subscriberKey: SubscriberKey, document: Document, imageSize: CGSize) {
+    /// - parameter entry: Entry identifying this request and its subscribers.
+    private func enqueue(entry: Entry) {
         let options = RenderOptions()
-        switch subscriberKey.appearance {
+        switch entry.request.key.appearance {
         case .dark:
             options.invertRenderColor = true
             options.filters = [.colorCorrectInverted]
@@ -119,9 +346,9 @@ extension PDFThumbnailController {
             break
         }
 
-        let request = MutableRenderRequest(document: document)
-        request.pageIndex = subscriberKey.page
-        request.imageSize = imageSize
+        let request = MutableRenderRequest(document: entry.request.document)
+        request.pageIndex = entry.request.key.page
+        request.imageSize = entry.request.key.size
         request.options = options
 
         do {
@@ -129,43 +356,74 @@ extension PDFThumbnailController {
             task.priority = .userInitiated
             task.completionHandler = { [weak self] image, error in
                 let result: Result<UIImage, Swift.Error> = image.flatMap({ .success($0) }) ?? .failure(error ?? Error.imageNotAvailable)
-                self?.queue.async(flags: .barrier) {
-                    self?.completeRequest(with: result, subscriberKey: subscriberKey)
+                self?.accessQueue.async {
+                    self?.completeRender(with: result, requestKey: entry.request.key, entryId: entry.id)
                 }
             }
+            var updatedEntry = entry
+            updatedEntry.state = .rendering(task)
+            entries[entry.request.key] = updatedEntry
             PSPDFKit.SDK.shared.renderManager.renderQueue.schedule(task)
         } catch let error {
-            DDLogError("PdfThumbnailController: can't create task - \(error)")
+            DDLogError("PDFThumbnailController: can't create render task; key=\(entry.request.key.key); library=\(entry.request.key.libraryId); page=\(entry.request.key.page); error=\(error)")
+            entries[entry.request.key] = nil
+            perform(event: .failure(error), subscribers: entry.subscribers)
         }
     }
 
-    private func completeRequest(with result: Result<UIImage, Swift.Error>, subscriberKey: SubscriberKey) {
+    private func completeRender(with result: Result<UIImage, Swift.Error>, requestKey: RequestKey, entryId: UUID) {
+        guard var entry = entries[requestKey], entry.id == entryId else { return }
+
         switch result {
         case .success(let image):
-            perform(event: .success(image), subscriberKey: subscriberKey)
-            cache(image: image, page: subscriberKey.page, key: subscriberKey.key, libraryId: subscriberKey.libraryId, appearance: subscriberKey.appearance)
+            let subscribers = entry.subscribers
+            entry.state = .savingToDisk(image)
+            entry.subscribers.removeAll()
+            entries[requestKey] = entry
+            perform(event: .success(image), subscribers: subscribers)
+            cache(image: image, requestKey: requestKey, entryId: entryId)
 
         case .failure(let error):
-            DDLogError("PdfThumbnailController: could not generate image - \(error)")
-            perform(event: .failure(error), subscriberKey: subscriberKey)
+            DDLogError("PDFThumbnailController: could not generate image; key=\(requestKey.key); library=\(requestKey.libraryId); page=\(requestKey.page); error=\(error)")
+            entries[requestKey] = nil
+            perform(event: .failure(error), subscribers: entry.subscribers)
         }
+    }
 
-        func perform(event: SingleEvent<UIImage>, subscriberKey: SubscriberKey) {
-            subscribers[subscriberKey]?(event)
-            subscribers[subscriberKey] = nil
-        }
+    private func perform(event: SingleEvent<UIImage>, subscribers: [UUID: (SingleEvent<UIImage>) -> Void]) {
+        subscribers.values.forEach { $0(event) }
+    }
 
-        func cache(image: UIImage, page: UInt, key: String, libraryId: LibraryIdentifier, appearance: Appearance) {
-            autoreleasepool {
+    private func cache(image: UIImage, requestKey: RequestKey, entryId: UUID) {
+        ioQueue.async { [weak self] in
+            guard let self else { return }
+            guard performOnAccessQueue({ [weak self] in self?.entries[requestKey]?.id == entryId }) else {
+                return
+            }
+            autoreleasepool { [weak self] in
+                guard let self else { return }
                 guard let data = image.pngData() else {
-                    DDLogError("PdfThumbnailController: can't create data from image")
+                    DDLogError("PDFThumbnailController: can't create image data; key=\(requestKey.key); library=\(requestKey.libraryId); page=\(requestKey.page)")
                     return
                 }
                 do {
-                    try fileStorage.write(data, to: Files.pageThumbnail(pageIndex: page, key: key, libraryId: libraryId, appearance: appearance), options: .atomicWrite)
+                    try fileStorage.write(
+                        data,
+                        to: Files.pageThumbnail(
+                            pageIndex: requestKey.page,
+                            key: requestKey.key,
+                            libraryId: requestKey.libraryId,
+                            appearance: requestKey.appearance
+                        ),
+                        options: .atomicWrite
+                    )
                 } catch let error {
-                    DDLogError("PdfThumbnailController: can't store preview - \(error)")
+                    DDLogError("PDFThumbnailController: can't store thumbnail; key=\(requestKey.key); library=\(requestKey.libraryId); page=\(requestKey.page); error=\(error)")
                 }
+            }
+            accessQueue.async { [weak self] in
+                guard let self, let entry = entries[requestKey], entry.id == entryId else { return }
+                entries[requestKey] = nil
             }
         }
     }

--- a/Zotero/Controllers/PDFThumbnailController.swift
+++ b/Zotero/Controllers/PDFThumbnailController.swift
@@ -23,7 +23,7 @@ final class PDFThumbnailController: NSObject {
         let libraryId: LibraryIdentifier
     }
 
-    private struct RequestKey: Hashable {
+    fileprivate struct RequestKey: Hashable {
         let key: String
         let libraryId: LibraryIdentifier
         let page: UInt
@@ -31,9 +31,15 @@ final class PDFThumbnailController: NSObject {
         let appearance: Appearance
     }
 
-    private struct Request {
-        let key: RequestKey
-        let document: Document
+    struct Request {
+        enum Priority: Int {
+            case prefetch
+            case visible
+        }
+
+        fileprivate let key: RequestKey
+        fileprivate let document: Document
+        fileprivate var priority: Priority
     }
 
     private enum DiskLoadResult {
@@ -50,7 +56,7 @@ final class PDFThumbnailController: NSObject {
         }
 
         let id: UUID
-        let request: Request
+        var request: Request
         var state: State
         var subscribers: [UUID: (SingleEvent<UIImage>) -> Void]
     }
@@ -111,14 +117,26 @@ extension PDFThumbnailController {
     }
 
     /// Loads a thumbnail from disk or renders and caches it if needed. Concurrent requests for the same thumbnail share one operation.
-    func thumbnail(page: UInt, key: String, libraryId: LibraryIdentifier, document: Document, imageSize: CGSize, appearance: Appearance) -> Single<UIImage> {
+    func thumbnail(
+        page: UInt,
+        key: String,
+        libraryId: LibraryIdentifier,
+        document: Document,
+        imageSize: CGSize,
+        appearance: Appearance,
+        priority: Request.Priority
+    ) -> Single<UIImage> {
         return Single.create { [weak self] subscriber -> Disposable in
             guard let self else { return Disposables.create() }
 
             let requestKey = RequestKey(key: key, libraryId: libraryId, page: page, size: imageSize, appearance: appearance)
             let subscriberId = UUID()
             performOnAccessQueue {
-                add(subscriber: subscriber, id: subscriberId, request: Request(key: requestKey, document: document))
+                add(
+                    subscriber: subscriber,
+                    id: subscriberId,
+                    request: Request(key: requestKey, document: document, priority: priority)
+                )
             }
 
             return Disposables.create { [weak self] in
@@ -139,10 +157,12 @@ extension PDFThumbnailController {
             if var entry = entries[request.key] {
                 switch entry.state {
                 case .loadingFromDisk:
+                    promote(&entry, to: request.priority)
                     entry.subscribers[subscriberId] = subscriber
                     entries[request.key] = entry
 
                 case .rendering:
+                    promote(&entry, to: request.priority)
                     entry.subscribers[subscriberId] = subscriber
                     entries[request.key] = entry
 
@@ -160,6 +180,14 @@ extension PDFThumbnailController {
             )
             entries[request.key] = entry
             loadFromDisk(requestKey: request.key, entryId: entry.id)
+
+            func promote(_ entry: inout Entry, to priority: Request.Priority) {
+                guard priority.rawValue > entry.request.priority.rawValue else { return }
+                entry.request.priority = priority
+                if case .rendering(let task) = entry.state {
+                    task.priority = .userInitiated
+                }
+            }
 
             func loadFromDisk(requestKey: RequestKey, entryId: UUID) {
                 ioQueue.async { [weak self] in
@@ -342,7 +370,7 @@ extension PDFThumbnailController {
 
         do {
             let task = try RenderTask(request: request)
-            task.priority = .userInitiated
+            task.priority = entry.request.priority == .visible ? .userInitiated : .utility
             task.completionHandler = { [weak self] image, error in
                 let result: Result<UIImage, Swift.Error> = image.flatMap({ .success($0) }) ?? .failure(error ?? Error.imageNotAvailable)
                 self?.accessQueue.async {

--- a/Zotero/Controllers/PDFThumbnailController.swift
+++ b/Zotero/Controllers/PDFThumbnailController.swift
@@ -156,12 +156,7 @@ extension PDFThumbnailController {
 
             if var entry = entries[request.key] {
                 switch entry.state {
-                case .loadingFromDisk:
-                    promote(&entry, to: request.priority)
-                    entry.subscribers[subscriberId] = subscriber
-                    entries[request.key] = entry
-
-                case .rendering:
+                case .loadingFromDisk, .rendering:
                     promote(&entry, to: request.priority)
                     entry.subscribers[subscriberId] = subscriber
                     entries[request.key] = entry

--- a/Zotero/Models/DeletableObject.swift
+++ b/Zotero/Models/DeletableObject.swift
@@ -155,6 +155,7 @@ extension RItem: Deletable {
             if contentType == "application/pdf" {
                 // This is a PDF file, remove all annotations and thumbnails.
                 NotificationCenter.default.post(name: .attachmentDeleted, object: Files.annotationPreviews(for: self.key, libraryId: libraryId))
+                NotificationCenter.default.post(name: .attachmentDeleted, object: Files.pageThumbnails(for: key, libraryId: libraryId))
             }
             #endif
         }

--- a/Zotero/Scenes/Detail/PDF/Models/PDFReaderAction.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/PDFReaderAction.swift
@@ -49,7 +49,6 @@ enum PDFReaderAction {
     case setVisiblePage(page: Int, userActionFromDocument: Bool, fromThumbnailList: Bool)
     case setFontSize(key: String, size: CGFloat)
     case export(includeAnnotations: Bool)
-    case clearTmpData
     case setSidebarEditingEnabled(Bool)
     case setSettings(settings: PDFSettings)
     case changeIdleTimerDisabled(Bool)

--- a/Zotero/Scenes/Detail/PDF/Models/PDFReaderState.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/PDFReaderState.swift
@@ -141,6 +141,8 @@ struct PDFReaderState: ViewModelState {
     var selectionFromDocument: Bool
     /// Annotation keys changed by the latest annotation update.
     var changedAnnotationKeys: [PDFReaderAnnotationKey]?
+    /// Page indices whose rendered thumbnails changed in the latest annotation update.
+    var changedAnnotationPages: Set<Int>?
     /// Page that should be shown initially, instead of stored page
     var initialPage: Int?
     /// Rects that should be highlighted initially, used by note editor to highlight original annotation position
@@ -201,6 +203,7 @@ struct PDFReaderState: ViewModelState {
         self.activeEraserSize = CGFloat(Defaults.shared.activeEraserSize)
         self.activeFontSize = CGFloat(Defaults.shared.activeFontSize)
         self.selectionFromDocument = false
+        self.changedAnnotationPages = nil
 
         switch libraryId {
         case .custom:
@@ -227,6 +230,7 @@ struct PDFReaderState: ViewModelState {
         self.focusDocumentLocation = nil
         selectionFromDocument = false
         self.changedAnnotationKeys = nil
+        self.changedAnnotationPages = nil
         self.error = nil
         self.pdfNotification = nil
         self.changedColorForTool = nil

--- a/Zotero/Scenes/Detail/PDF/Models/PDFThumbnailsAction.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/PDFThumbnailsAction.swift
@@ -14,5 +14,5 @@ enum PDFThumbnailsAction {
     case setAppearance(Appearance)
     case loadPages
     case setSelectedPage(pageIndex: Int, type: PDFThumbnailsState.SelectionType)
-    case reloadThumbnails
+    case reloadThumbnails(Set<Int>)
 }

--- a/Zotero/Scenes/Detail/PDF/Models/PDFThumbnailsAction.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/PDFThumbnailsAction.swift
@@ -10,6 +10,7 @@ import Foundation
 
 enum PDFThumbnailsAction {
     case prefetch([UInt])
+    case cancelPrefetch([UInt])
     case load(UInt)
     case setAppearance(Appearance)
     case loadPages

--- a/Zotero/Scenes/Detail/PDF/Models/PDFThumbnailsState.swift
+++ b/Zotero/Scenes/Detail/PDF/Models/PDFThumbnailsState.swift
@@ -47,6 +47,7 @@ struct PDFThumbnailsState: ViewModelState {
     var pages: [Page]
     var appearance: Appearance
     var loadedThumbnail: Int?
+    var reloadedPageIndices: Set<Int>?
     var selectedPageIndex: Int
     var changes: Changes
 
@@ -62,10 +63,12 @@ struct PDFThumbnailsState: ViewModelState {
         self.appearance = appearance
         self.changes = []
         self.pages = []
+        self.reloadedPageIndices = nil
     }
 
     mutating func cleanup() {
         changes = []
         loadedThumbnail = nil
+        reloadedPageIndices = nil
     }
 }

--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFReaderActionHandler.swift
@@ -236,10 +236,6 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
         case .export(let includeAnnotations):
             export(includeAnnotations: includeAnnotations, viewModel: viewModel)
 
-        case .clearTmpData:
-            // Clear page thumbnails
-            pdfThumbnailController.deleteAll(forKey: viewModel.state.key, libraryId: viewModel.state.library.identifier)
-
         case .setSettings(let settings):
             update(settings: settings, in: viewModel)
 
@@ -253,6 +249,7 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
             filterAnnotations(with: searchTerm, filter: filter, in: viewModel)
 
         case .deinitialiseReader:
+            pdfThumbnailController.stop(forKey: viewModel.state.key, libraryId: viewModel.state.library.identifier)
             lastReadWatcher.submit(key: viewModel.state.key, libraryId: viewModel.state.library.identifier, date: Date())
 
         case .unlock(let password):
@@ -1505,6 +1502,7 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
 
             let endTime = CFAbsoluteTimeGetCurrent()
 
+            pdfThumbnailController.start(forKey: key, libraryId: library.identifier)
             lastReadWatcher.submit(key: key, libraryId: library.identifier, date: Date())
 
             update(viewModel: viewModel) { state in
@@ -1658,6 +1656,7 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
         }
         deleteDocumentAnnotationsCache(for: viewModel.state.key, libraryId: viewModel.state.library.identifier)
         annotationPreviewController.deleteAll(parentKey: viewModel.state.key, libraryId: viewModel.state.library.identifier)
+        pdfThumbnailController.deleteAll(forKey: viewModel.state.key, libraryId: viewModel.state.library.identifier)
         update(viewModel: viewModel) { state in
             state.documentMD5Changed = true
             state.changes = .md5
@@ -1818,6 +1817,7 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
         var deletedPdfAnnotations: [PSPDFKit.Annotation] = []
         var insertedPdfAnnotations: [PSPDFKit.Annotation] = []
         var shouldRecomputeDefaultAnnotationPageLabel = false
+        var affectedThumbnailPages: Set<Int> = []
 
         // Check which annotations changed and update `Document`
         // Modifications are indexed by the previously observed items
@@ -1830,6 +1830,9 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
             let oldItem = databaseAnnotations[index]
             let key = PDFReaderAnnotationKey(key: oldItem.key, type: .database)
             guard let item = objects.filter(.key(key.key)).first else { continue }
+            if let oldAnnotation = PDFDatabaseAnnotation(item: oldItem) {
+                affectedThumbnailPages.insert(oldAnnotation.page)
+            }
 
             let newPageLabel = item.fields.filter(.key(FieldKeys.Item.Annotation.pageLabel)).first?.value
             let oldPageLabel = oldItem.fields.filter(.key(FieldKeys.Item.Annotation.pageLabel)).first?.value
@@ -1838,6 +1841,7 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
             }
 
             guard item.changeType != .syncResponse, let annotation = PDFDatabaseAnnotation(item: item) else { continue }
+            affectedThumbnailPages.insert(annotation.page)
 
             if canUpdate(key: key, item: item, at: index, viewModel: viewModel) {
                 DDLogInfo("PDFReaderActionHandler: update key \(key)")
@@ -1897,10 +1901,11 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
             }
 
             shouldRecomputeDefaultAnnotationPageLabel = true
-            
-            guard let oldAnnotation = PDFDatabaseAnnotation(item: databaseAnnotations[index]),
-                  let pdfAnnotation = annotationProvider?.annotation(at: PageIndex(oldAnnotation.page), with: oldAnnotation.key)
-            else { continue }
+
+            guard let oldAnnotation = PDFDatabaseAnnotation(item: databaseAnnotations[index]) else { continue }
+            affectedThumbnailPages.insert(oldAnnotation.page)
+
+            guard let pdfAnnotation = annotationProvider?.annotation(at: PageIndex(oldAnnotation.page), with: oldAnnotation.key) else { continue }
             DDLogInfo("PDFReaderActionHandler: delete PDF annotation")
             deletedPdfAnnotations.append(pdfAnnotation)
         }
@@ -1926,6 +1931,7 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
                 shouldCancelUpdate = true
                 break
             }
+            affectedThumbnailPages.insert(annotation.page)
             guard annotation.page < viewModel.state.document.pageCount else {
                 DDLogWarn("PDFReaderActionHandler: tried inserting page (\(annotation.page)) outside of document page count (\(viewModel.state.document.pageCount)); \(annotation.key); \(viewModel.state.key)")
                 continue
@@ -2018,6 +2024,9 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
             viewModel.state.document.add(annotations: insertedPdfAnnotations, options: nil)
             annotationPreviewController.store(annotations: insertedPdfAnnotations, parentKey: viewModel.state.key, libraryId: viewModel.state.library.identifier, appearance: appearance, notify: false)
         }
+        if !affectedThumbnailPages.isEmpty {
+            pdfThumbnailController.delete(pages: affectedThumbnailPages, forKey: viewModel.state.key, libraryId: viewModel.state.library.identifier)
+        }
         observeDocument(in: viewModel)
 
         // Update state
@@ -2034,6 +2043,7 @@ final class PDFReaderActionHandler: ViewModelActionHandler, BackgroundDbProcessi
             state.annotationPages = annotationPages
 
             state.changedAnnotationKeys = updatedKeys
+            state.changedAnnotationPages = affectedThumbnailPages
 
             // Update selection
             if let key = selectKey {

--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFThumbnailsActionHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFThumbnailsActionHandler.swift
@@ -86,6 +86,11 @@ final class PDFThumbnailsActionHandler: ViewModelActionHandler {
         }
     }
 
+    private func cache(image: UIImage, pageIndex: UInt, viewModel: ViewModel<PDFThumbnailsActionHandler>) {
+        let cost = image.cgImage.map({ $0.bytesPerRow * $0.height }) ?? 0
+        viewModel.state.cache.setObject(image, forKey: NSNumber(value: pageIndex), cost: cost)
+    }
+
     private func prefetch(pageIndices: [UInt], in viewModel: ViewModel<PDFThumbnailsActionHandler>) {
         for pageIndex in Set(pageIndices) {
             guard prefetchDisposables[pageIndex] == nil else { continue }
@@ -100,9 +105,10 @@ final class PDFThumbnailsActionHandler: ViewModelActionHandler {
                 priority: .prefetch
             )
             .observe(on: MainScheduler.instance)
-            .subscribe(onSuccess: { [weak self] _ in
-                self?.prefetchDisposables[pageIndex] = nil
-            }, onFailure: { [weak self] _ in
+            .subscribe(onSuccess: { [weak self, weak viewModel] image in
+                guard let self, let viewModel else { return }
+                cache(image: image, pageIndex: pageIndex, viewModel: viewModel)
+            }, onDisposed: { [weak self] in
                 self?.prefetchDisposables[pageIndex] = nil
             })
             prefetchDisposables[pageIndex] = disposable
@@ -133,18 +139,14 @@ final class PDFThumbnailsActionHandler: ViewModelActionHandler {
             priority: .visible
         )
         .observe(on: MainScheduler.instance)
-        .subscribe(with: viewModel) { viewModel, image in
-            cache(image: image, viewModel: viewModel)
-        }
-        .disposed(by: disposeBag)
-
-        func cache(image: UIImage, viewModel: ViewModel<PDFThumbnailsActionHandler>) {
-            let cost = image.cgImage.map({ $0.bytesPerRow * $0.height }) ?? 0
-            viewModel.state.cache.setObject(image, forKey: NSNumber(value: pageIndex), cost: cost)
+        .subscribe(onSuccess: { [weak self, weak viewModel] image in
+            guard let self, let viewModel else { return }
+            cache(image: image, pageIndex: pageIndex, viewModel: viewModel)
             update(viewModel: viewModel) { state in
                 state.loadedThumbnail = Int(pageIndex)
             }
-        }
+        })
+        .disposed(by: disposeBag)
     }
 
     private func setAppearance(appearance: Appearance, in viewModel: ViewModel<PDFThumbnailsActionHandler>) {

--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFThumbnailsActionHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFThumbnailsActionHandler.swift
@@ -96,7 +96,8 @@ final class PDFThumbnailsActionHandler: ViewModelActionHandler {
                 libraryId: viewModel.state.libraryId,
                 document: viewModel.state.document,
                 imageSize: viewModel.state.thumbnailSize,
-                appearance: viewModel.state.appearance
+                appearance: viewModel.state.appearance,
+                priority: .prefetch
             )
             .observe(on: MainScheduler.instance)
             .subscribe(onSuccess: { [weak self] _ in
@@ -128,7 +129,8 @@ final class PDFThumbnailsActionHandler: ViewModelActionHandler {
             libraryId: viewModel.state.libraryId,
             document: viewModel.state.document,
             imageSize: viewModel.state.thumbnailSize,
-            appearance: viewModel.state.appearance
+            appearance: viewModel.state.appearance,
+            priority: .visible
         )
         .observe(on: MainScheduler.instance)
         .subscribe(with: viewModel) { viewModel, image in

--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFThumbnailsActionHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFThumbnailsActionHandler.swift
@@ -16,12 +16,10 @@ struct PDFThumbnailsActionHandler: ViewModelActionHandler {
     typealias State = PDFThumbnailsState
 
     private unowned let thumbnailController: PDFThumbnailController
-    private let queue: DispatchQueue
     private let disposeBag: DisposeBag
 
     init(thumbnailController: PDFThumbnailController) {
         self.thumbnailController = thumbnailController
-        self.queue = DispatchQueue(label: "org.zotero.PDFThumbnailsActionHandler.background", qos: .userInitiated, attributes: .concurrent)
         self.disposeBag = DisposeBag()
     }
 
@@ -42,16 +40,16 @@ struct PDFThumbnailsActionHandler: ViewModelActionHandler {
         case .setSelectedPage(let pageIndex, let type):
             set(selectedPage: pageIndex, type: type, viewModel: viewModel)
 
-        case .reloadThumbnails:
-            reloadThumbnails(viewModel: viewModel)
+        case .reloadThumbnails(let pageIndices):
+            reloadThumbnails(pageIndices: pageIndices, viewModel: viewModel)
         }
     }
 
-    private func reloadThumbnails(viewModel: ViewModel<PDFThumbnailsActionHandler>) {
-        guard !viewModel.state.pages.isEmpty else { return }
-        viewModel.state.cache.removeAllObjects()
-        thumbnailController.deleteAll(forKey: viewModel.state.key, libraryId: viewModel.state.libraryId)
+    private func reloadThumbnails(pageIndices: Set<Int>, viewModel: ViewModel<PDFThumbnailsActionHandler>) {
+        guard !viewModel.state.pages.isEmpty, !pageIndices.isEmpty else { return }
+        pageIndices.forEach({ viewModel.state.cache.removeObject(forKey: NSNumber(value: $0)) })
         update(viewModel: viewModel) { state in
+            state.reloadedPageIndices = pageIndices
             state.changes = .reload
         }
     }
@@ -83,12 +81,8 @@ struct PDFThumbnailsActionHandler: ViewModelActionHandler {
     }
 
     private func prefetch(pageIndices: [UInt], in viewModel: ViewModel<PDFThumbnailsActionHandler>) {
-        let toFetch = pageIndices.compactMap { pageIndex in
-            let hasImage = thumbnailController.hasThumbnail(page: pageIndex, key: viewModel.state.key, libraryId: viewModel.state.libraryId, appearance: viewModel.state.appearance)
-            return hasImage ? nil : pageIndex
-        }
         thumbnailController.cache(
-            pages: toFetch,
+            pages: pageIndices,
             key: viewModel.state.key,
             libraryId: viewModel.state.libraryId,
             document: viewModel.state.document,
@@ -100,40 +94,19 @@ struct PDFThumbnailsActionHandler: ViewModelActionHandler {
     }
 
     private func load(pageIndex: UInt, in viewModel: ViewModel<PDFThumbnailsActionHandler>) {
-        if thumbnailController.hasThumbnail(page: pageIndex, key: viewModel.state.key, libraryId: viewModel.state.libraryId, appearance: viewModel.state.appearance) {
-            loadCachedThumbnailAsync()
-        } else {
-            loadAndCacheThumbnailAsync()
+        thumbnailController.thumbnail(
+            page: pageIndex,
+            key: viewModel.state.key,
+            libraryId: viewModel.state.libraryId,
+            document: viewModel.state.document,
+            imageSize: viewModel.state.thumbnailSize,
+            appearance: viewModel.state.appearance
+        )
+        .observe(on: MainScheduler.instance)
+        .subscribe(with: viewModel) { viewModel, image in
+            cache(image: image, viewModel: viewModel)
         }
-
-        func loadCachedThumbnailAsync() {
-            queue.async { [weak thumbnailController, weak viewModel] in
-                guard let thumbnailController,
-                      let viewModel,
-                      let image = thumbnailController.thumbnail(page: pageIndex, key: viewModel.state.key, libraryId: viewModel.state.libraryId, appearance: viewModel.state.appearance)
-                else { return }
-                DispatchQueue.main.async { [weak viewModel] in
-                    guard let viewModel else { return }
-                    cache(image: image, viewModel: viewModel)
-                }
-            }
-        }
-
-        func loadAndCacheThumbnailAsync() {
-            thumbnailController.cache(
-                page: pageIndex,
-                key: viewModel.state.key,
-                libraryId: viewModel.state.libraryId,
-                document: viewModel.state.document,
-                imageSize: viewModel.state.thumbnailSize,
-                appearance: viewModel.state.appearance
-            )
-            .observe(on: MainScheduler.instance)
-            .subscribe(with: viewModel) { viewModel, image in
-                cache(image: image, viewModel: viewModel)
-            }
-            .disposed(by: disposeBag)
-        }
+        .disposed(by: disposeBag)
 
         func cache(image: UIImage, viewModel: ViewModel<PDFThumbnailsActionHandler>) {
             viewModel.state.cache.setObject(image, forKey: NSNumber(value: pageIndex))

--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFThumbnailsActionHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFThumbnailsActionHandler.swift
@@ -137,7 +137,8 @@ final class PDFThumbnailsActionHandler: ViewModelActionHandler {
         .disposed(by: disposeBag)
 
         func cache(image: UIImage, viewModel: ViewModel<PDFThumbnailsActionHandler>) {
-            viewModel.state.cache.setObject(image, forKey: NSNumber(value: pageIndex))
+            let cost = image.cgImage.map({ $0.bytesPerRow * $0.height }) ?? 0
+            viewModel.state.cache.setObject(image, forKey: NSNumber(value: pageIndex), cost: cost)
             update(viewModel: viewModel) { state in
                 state.loadedThumbnail = Int(pageIndex)
             }

--- a/Zotero/Scenes/Detail/PDF/ViewModels/PDFThumbnailsActionHandler.swift
+++ b/Zotero/Scenes/Detail/PDF/ViewModels/PDFThumbnailsActionHandler.swift
@@ -11,16 +11,18 @@ import UIKit
 import PSPDFKit
 import RxSwift
 
-struct PDFThumbnailsActionHandler: ViewModelActionHandler {
+final class PDFThumbnailsActionHandler: ViewModelActionHandler {
     typealias Action = PDFThumbnailsAction
     typealias State = PDFThumbnailsState
 
     private unowned let thumbnailController: PDFThumbnailController
     private let disposeBag: DisposeBag
+    private var prefetchDisposables: [UInt: Disposable]
 
     init(thumbnailController: PDFThumbnailController) {
         self.thumbnailController = thumbnailController
         self.disposeBag = DisposeBag()
+        self.prefetchDisposables = [:]
     }
 
     func process(action: PDFThumbnailsAction, in viewModel: ViewModel<PDFThumbnailsActionHandler>) {
@@ -30,6 +32,9 @@ struct PDFThumbnailsActionHandler: ViewModelActionHandler {
 
         case .prefetch(let pageIndices):
             prefetch(pageIndices: pageIndices, in: viewModel)
+
+        case .cancelPrefetch(let pageIndices):
+            cancelPrefetch(pageIndices: pageIndices)
 
         case .setAppearance(let appearance):
             setAppearance(appearance: appearance, in: viewModel)
@@ -47,6 +52,7 @@ struct PDFThumbnailsActionHandler: ViewModelActionHandler {
 
     private func reloadThumbnails(pageIndices: Set<Int>, viewModel: ViewModel<PDFThumbnailsActionHandler>) {
         guard !viewModel.state.pages.isEmpty, !pageIndices.isEmpty else { return }
+        cancelPrefetch(pageIndices: pageIndices.compactMap({ UInt(exactly: $0) }))
         pageIndices.forEach({ viewModel.state.cache.removeObject(forKey: NSNumber(value: $0)) })
         update(viewModel: viewModel) { state in
             state.reloadedPageIndices = pageIndices
@@ -81,16 +87,38 @@ struct PDFThumbnailsActionHandler: ViewModelActionHandler {
     }
 
     private func prefetch(pageIndices: [UInt], in viewModel: ViewModel<PDFThumbnailsActionHandler>) {
-        thumbnailController.cache(
-            pages: pageIndices,
-            key: viewModel.state.key,
-            libraryId: viewModel.state.libraryId,
-            document: viewModel.state.document,
-            imageSize: viewModel.state.thumbnailSize,
-            appearance: viewModel.state.appearance
-        )
-        .subscribe()
-        .disposed(by: disposeBag)
+        for pageIndex in Set(pageIndices) {
+            guard prefetchDisposables[pageIndex] == nil else { continue }
+
+            let disposable = thumbnailController.thumbnail(
+                page: pageIndex,
+                key: viewModel.state.key,
+                libraryId: viewModel.state.libraryId,
+                document: viewModel.state.document,
+                imageSize: viewModel.state.thumbnailSize,
+                appearance: viewModel.state.appearance
+            )
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] _ in
+                self?.prefetchDisposables[pageIndex] = nil
+            }, onFailure: { [weak self] _ in
+                self?.prefetchDisposables[pageIndex] = nil
+            })
+            prefetchDisposables[pageIndex] = disposable
+            disposable.disposed(by: disposeBag)
+        }
+    }
+
+    private func cancelPrefetch(pageIndices: [UInt]) {
+        for pageIndex in Set(pageIndices) {
+            prefetchDisposables.removeValue(forKey: pageIndex)?.dispose()
+        }
+    }
+
+    private func cancelAllPrefetches() {
+        let disposables = Array(prefetchDisposables.values)
+        prefetchDisposables.removeAll()
+        disposables.forEach({ $0.dispose() })
     }
 
     private func load(pageIndex: UInt, in viewModel: ViewModel<PDFThumbnailsActionHandler>) {
@@ -117,6 +145,7 @@ struct PDFThumbnailsActionHandler: ViewModelActionHandler {
     }
 
     private func setAppearance(appearance: Appearance, in viewModel: ViewModel<PDFThumbnailsActionHandler>) {
+        cancelAllPrefetches()
         viewModel.state.cache.removeAllObjects()
         update(viewModel: viewModel) { state in
             state.appearance = appearance

--- a/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFReaderViewController.swift
@@ -625,7 +625,6 @@ class PDFReaderViewController: UIViewController, ReaderViewController {
         if let page = documentController?.pdfController?.pageIndex {
             viewModel.process(action: .submitPendingPage(Int(page)))
         }
-        viewModel.process(action: .clearTmpData)
         navigationController?.presentingViewController?.dismiss(animated: true, completion: nil)
     }
 

--- a/Zotero/Scenes/Detail/PDF/Views/PDFSidebarViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFSidebarViewController.swift
@@ -291,7 +291,7 @@ class PDFSidebarViewController: UIViewController {
                         thumbnailsViewModel.process(action: .setSelectedPage(pageIndex: state.visiblePage, type: .fromDocument))
                     }
                     if state.changes.contains(.annotations) {
-                        thumbnailsViewModel.process(action: .reloadThumbnails)
+                        thumbnailsViewModel.process(action: .reloadThumbnails(state.changedAnnotationPages ?? []))
                     }
                     if state.changes.contains(.appearance) {
                         thumbnailsViewModel.process(action: .setAppearance(.from(appearanceMode: state.settings.appearanceMode, interfaceStyle: state.interfaceStyle)))

--- a/Zotero/Scenes/Detail/PDF/Views/PDFThumbnailsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFThumbnailsViewController.swift
@@ -154,6 +154,11 @@ extension PDFThumbnailsViewController: UICollectionViewDataSourcePrefetching {
         let toFetch = indexPaths.map({ $0.row }).map(UInt.init)
         viewModel.process(action: .prefetch(toFetch))
     }
+
+    func collectionView(_ collectionView: UICollectionView, cancelPrefetchingForItemsAt indexPaths: [IndexPath]) {
+        let toCancel = indexPaths.map({ $0.row }).map(UInt.init)
+        viewModel.process(action: .cancelPrefetch(toCancel))
+    }
 }
 
 extension PDFThumbnailsViewController {

--- a/Zotero/Scenes/Detail/PDF/Views/PDFThumbnailsViewController.swift
+++ b/Zotero/Scenes/Detail/PDF/Views/PDFThumbnailsViewController.swift
@@ -116,11 +116,27 @@ class PDFThumbnailsViewController: UICollectionViewController {
         // The following updates should be ignored if the collection hasn't loaded yet for the first time.
         guard dataSource.snapshot().numberOfSections > 0 else { return }
 
-        if state.changes.contains(.appearance) || state.changes.contains(.reload) {
+        if state.changes.contains(.appearance) {
             updateQueue.async { [weak self] in
                 guard let self else { return }
                 var snapshot = dataSource.snapshot()
                 snapshot.reconfigureItems(snapshot.itemIdentifiers)
+                dataSource.apply(snapshot, animatingDifferences: false, completion: nil)
+            }
+            return
+        }
+
+        if state.changes.contains(.reload), let pageIndices = state.reloadedPageIndices {
+            updateQueue.async { [weak self] in
+                guard let self else { return }
+                var snapshot = dataSource.snapshot()
+                let items = snapshot.itemIdentifiers
+                let updatedItems = pageIndices.compactMap({ pageIndex -> PDFThumbnailsState.Page? in
+                    guard items.indices.contains(pageIndex) else { return nil }
+                    return items[pageIndex]
+                })
+                guard !updatedItems.isEmpty else { return }
+                snapshot.reconfigureItems(updatedItems)
                 dataSource.apply(snapshot, animatingDifferences: false, completion: nil)
             }
             return


### PR DESCRIPTION
* Improves memory use for PDF thumbnails cache.
* Deduplicates thumbnail render tasks for the same page.
* Cancels pending render tasks if not needed anymore.
* Lowers render task priority for prefetched non-visible pages.
* Supplies cost for thumbnails in-memory cache.