### PR TITLE
Show indent buttons on note editor for phone user interface idiom

### DIFF
--- a/Zotero/Scenes/General/Views/NoteEditorViewController.swift
+++ b/Zotero/Scenes/General/Views/NoteEditorViewController.swift
@@ -210,7 +210,11 @@ final class NoteEditorViewController: UIViewController {
     private func perform(action: String, data: [String: Any]) {
         switch action {
         case "initialized":
-            let data = WebViewEncoder.encodeAsJSONForJavascript(["value": viewModel.state.text, "readOnly": viewModel.state.kind.readOnly])
+            let data = WebViewEncoder.encodeAsJSONForJavascript([
+                "value": viewModel.state.text,
+                "readOnly": viewModel.state.kind.readOnly,
+                "showIndentButtons": UIDevice.current.userInterfaceIdiom == .phone
+            ])
             webView.call(javascript: "start(\(data));").subscribe().disposed(by: disposeBag)
 
         case "readerInitialized":


### PR DESCRIPTION
FIxes issue reported in https://forums.zotero.org/discussion/133227/note-editor-on-mobile-indenting-paragraphs-and-list-items