### PR TITLE
Fix out of credits timing crash

### DIFF
--- a/Zotero/Scenes/General/Views/ReadAloudViewHandler.swift
+++ b/Zotero/Scenes/General/Views/ReadAloudViewHandler.swift
@@ -134,8 +134,11 @@ final class ReadAloudViewHandler<Delegate: SpeechManagerDelegate> {
                     showOverlayIfNeeded(forType: currentOverlayType(controller: self), state: state)
                 }
                 updateReadAloudButtonMenu(state: state, remainingTime: speechManager.remainingTime.value)
-                if #available(iOS 17.4, *), case .outOfCredits = state {
-                    navbarHeadphonesButtonRef?.performPrimaryAction()
+                if #available(iOS 17.4, *),
+                   case .outOfCredits = state,
+                   let button = navbarHeadphonesButtonRef,
+                   button.window != nil {
+                    button.performPrimaryAction()
                 }
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
Guards against a crash when read aloud runs out of credits while the navigation bar is hidden. The attempt to present the menu from a button that is no longer in the UI hierarchy causes a `BUG_IN_CLIENT_OF_TARGETED_PREVIEW__VIEW_IS_NOT_IN_A_WINDOW` assertion.
To reproduce start read aloud in a reader with a voice with no credits, and immediately tap to go to focus mode. This is a latent timing issue that is made easier to run into with changes in `2.0.8-484`.